### PR TITLE
fix: toggle cell overlays per panel

### DIFF
--- a/app/components/.client/ImageViewer/components/Image/Overlays/useOverlaysLayer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/useOverlaysLayer.tsx
@@ -5,7 +5,6 @@ import { OverlaysLayer } from "./OverlaysLayer";
 import { select } from "../../../state/selectors";
 import { useViewerStore } from "../../../state/ViewerStoreContext";
 import { useTilesLoading } from "../../../utils/useTilesLoading";
-import { useFeatureBarStore } from "../../FeatureBar/useFeatureBar";
 import { useNotificationStore } from "~/components/Notification/Notification.store";
 
 type SetTooltip = (
@@ -37,7 +36,8 @@ export const useOverlaysLayers = (
 
   const fillOpacity =
     layersStates[panelLayersStateIndex]?.overlaysFillOpacity ?? 0.8;
-  const showCellOutline = useFeatureBarStore((s) => s.showCellOutline);
+  const showCellOutline =
+    layersStates[panelLayersStateIndex]?.showCellOutline ?? true;
 
   const addNotification = useNotificationStore(
     (state) => state.addNotification

--- a/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.tsx
@@ -3,7 +3,6 @@ import { OverlaysControllerItem } from "./OverlaysController.Item";
 import { select } from "../../state/selectors";
 import { useViewerStore } from "../../state/ViewerStoreContext";
 import { FeatureItem } from "../FeatureBar/FeatureItem";
-import { useFeatureBarStore } from "../FeatureBar/useFeatureBar";
 import { ButtonLink } from "~/components/Controls/Button";
 import { isPointMode } from "~/utils/db/getGeomQuery";
 
@@ -15,8 +14,8 @@ export const OverlaysController = () => {
   const overlaysStates = useViewerStore(select.overlaysStates);
   const fillOpacity = useViewerStore(select.overlaysFillOpacity);
   const setFillOpacity = useViewerStore(select.setOverlaysFillOpacity);
-  const showCellOutline = useFeatureBarStore((s) => s.showCellOutline);
-  const setShowCellOutline = useFeatureBarStore((s) => s.setShowCellOutline);
+  const showCellOutline = useViewerStore(select.showCellOutline);
+  const setShowCellOutline = useViewerStore(select.setShowCellOutline);
   const currentZoom = useViewerStore(select.currentZoom);
 
   // Hide outline toggle when zoomed out (point mode doesn't have outlines)

--- a/app/components/.client/ImageViewer/state/__tests__/createViewerStore.test.ts
+++ b/app/components/.client/ImageViewer/state/__tests__/createViewerStore.test.ts
@@ -41,6 +41,7 @@ const createMockLayersState = () => ({
   overlays: {} as OverlaysState,
   channelsOpacity: 1,
   overlaysFillOpacity: 0.8,
+  showCellOutline: true,
   isChannelsLoading: 0,
   isOverlaysLoading: 0,
 });
@@ -92,6 +93,7 @@ describe("createViewerStore", () => {
       updateOverlaysState: expect.any(Function),
       setOverlaysFillOpacity: expect.any(Function),
       setChannelsOpacity: expect.any(Function),
+      setShowCellOutline: expect.any(Function),
     });
   });
 
@@ -742,6 +744,55 @@ describe("createViewerStore", () => {
 
     store.getState().setChannelsOpacity(0.3);
     expect(store.getState().layersStates[0].channelsOpacity).toBe(0.3);
+  });
+
+  test("setShowCellOutline()", () => {
+    const store = createViewerStore("test-viewer-28b");
+
+    store.setState({
+      imagePanelIndex: 0,
+      imagePanels: [0],
+      layersStates: [createMockLayersState()],
+    });
+
+    expect(store.getState().layersStates[0].showCellOutline).toBe(true);
+
+    store.getState().setShowCellOutline(false);
+    expect(store.getState().layersStates[0].showCellOutline).toBe(false);
+
+    store.getState().setShowCellOutline(true);
+    expect(store.getState().layersStates[0].showCellOutline).toBe(true);
+  });
+
+  test("setShowCellOutline() only affects active panel", () => {
+    const store = createViewerStore("test-viewer-28c");
+
+    store.setState({
+      imagePanelIndex: 0,
+      imagePanels: [0, 1],
+      layersStates: [createMockLayersState(), createMockLayersState()],
+    });
+
+    // Both panels start with showCellOutline = true
+    expect(store.getState().layersStates[0].showCellOutline).toBe(true);
+    expect(store.getState().layersStates[1].showCellOutline).toBe(true);
+
+    // Toggle panel 0's outline off
+    store.getState().setShowCellOutline(false);
+    expect(store.getState().layersStates[0].showCellOutline).toBe(false);
+    expect(store.getState().layersStates[1].showCellOutline).toBe(true);
+
+    // Switch to panel 1 and toggle its outline off
+    store.setState({ imagePanelIndex: 1 });
+    store.getState().setShowCellOutline(false);
+    expect(store.getState().layersStates[0].showCellOutline).toBe(false);
+    expect(store.getState().layersStates[1].showCellOutline).toBe(false);
+
+    // Switch back to panel 0 and toggle it on - panel 1 should stay off
+    store.setState({ imagePanelIndex: 0 });
+    store.getState().setShowCellOutline(true);
+    expect(store.getState().layersStates[0].showCellOutline).toBe(true);
+    expect(store.getState().layersStates[1].showCellOutline).toBe(false);
   });
 
   describe("addChannelsState()", () => {

--- a/app/components/.client/ImageViewer/state/__tests__/selectors.test.ts
+++ b/app/components/.client/ImageViewer/state/__tests__/selectors.test.ts
@@ -57,6 +57,7 @@ describe("selectors", () => {
         overlays: {},
         channelsOpacity: 1,
         overlaysFillOpacity: 0.8,
+        showCellOutline: true,
         isChannelsLoading: 0,
         isOverlaysLoading: 0,
       },
@@ -89,6 +90,7 @@ describe("selectors", () => {
     removeOverlaysState: vi.fn(),
     setOverlaysFillOpacity: vi.fn(),
     setChannelsOpacity: vi.fn(),
+    setShowCellOutline: vi.fn(),
     ...overrides,
   });
 
@@ -134,6 +136,7 @@ describe("selectors", () => {
             overlays: {},
             channelsOpacity: 1,
             overlaysFillOpacity: 0.8,
+            showCellOutline: true,
             isChannelsLoading: 0,
             isOverlaysLoading: 0,
           },
@@ -163,6 +166,7 @@ describe("selectors", () => {
             overlays: {},
             channelsOpacity: 1,
             overlaysFillOpacity: 0.8,
+            showCellOutline: true,
             isChannelsLoading: 0,
             isOverlaysLoading: 0,
           },
@@ -200,6 +204,7 @@ describe("selectors", () => {
             overlays: {},
             channelsOpacity: 1,
             overlaysFillOpacity: 0.8,
+            showCellOutline: true,
             isChannelsLoading: 0,
             isOverlaysLoading: 0,
           },
@@ -251,6 +256,7 @@ describe("selectors", () => {
             overlays: {},
             channelsOpacity: 1,
             overlaysFillOpacity: 0.8,
+            showCellOutline: true,
             isChannelsLoading: 0,
             isOverlaysLoading: 0,
           },
@@ -266,6 +272,53 @@ describe("selectors", () => {
         layersStates: [],
       });
       expect(select.visibleChannelCount(state)).toBe(0);
+    });
+  });
+
+  describe("showCellOutline", () => {
+    test("returns showCellOutline from current layer state", () => {
+      const state = createMockState();
+      expect(select.showCellOutline(state)).toBe(true);
+    });
+
+    test("returns true (default) when no layer state exists", () => {
+      const state = createMockState({
+        imagePanelIndex: -1,
+        imagePanels: [],
+        layersStates: [],
+      });
+      expect(select.showCellOutline(state)).toBe(true);
+    });
+
+    test("returns correct value for specific panel", () => {
+      const state = createMockState({
+        imagePanelIndex: 1,
+        imagePanels: [0, 1],
+        layersStates: [
+          {
+            channels: {},
+            channelIds: [],
+            overlays: {},
+            channelsOpacity: 1,
+            overlaysFillOpacity: 0.8,
+            showCellOutline: true,
+            isChannelsLoading: 0,
+            isOverlaysLoading: 0,
+          },
+          {
+            channels: {},
+            channelIds: [],
+            overlays: {},
+            channelsOpacity: 1,
+            overlaysFillOpacity: 0.8,
+            showCellOutline: false,
+            isChannelsLoading: 0,
+            isOverlaysLoading: 0,
+          },
+        ],
+      });
+      // Panel 1 has showCellOutline = false
+      expect(select.showCellOutline(state)).toBe(false);
     });
   });
 });

--- a/app/components/.client/ImageViewer/state/createViewerStore.ts
+++ b/app/components/.client/ImageViewer/state/createViewerStore.ts
@@ -203,6 +203,7 @@ export const createViewerStore = (id: string) =>
                           overlays: {},
                           channelsOpacity: 1,
                           overlaysFillOpacity: 0.8,
+                          showCellOutline: true,
                           isChannelsLoading: 0,
                           isOverlaysLoading: 0,
                         },
@@ -559,6 +560,21 @@ export const createViewerStore = (id: string) =>
                 },
                 false,
                 "setChannelsOpacity"
+              ),
+
+            setShowCellOutline: (showCellOutline: boolean) =>
+              set(
+                (state) => {
+                  const activeImagePanelIndex =
+                    state.imagePanels[state.imagePanelIndex];
+                  const layerState = state.layersStates[activeImagePanelIndex];
+
+                  if (layerState) {
+                    layerState.showCellOutline = showCellOutline;
+                  }
+                },
+                false,
+                "setShowCellOutline"
               ),
           }),
           {

--- a/app/components/.client/ImageViewer/state/selectors.ts
+++ b/app/components/.client/ImageViewer/state/selectors.ts
@@ -119,5 +119,11 @@ export const select = {
   },
   setChannelsOpacity: (state: ViewerStore) => state.setChannelsOpacity,
 
+  showCellOutline: (state: ViewerStore) => {
+    const layerState = select.layersState(state);
+    return layerState?.showCellOutline ?? true;
+  },
+  setShowCellOutline: (state: ViewerStore) => state.setShowCellOutline,
+
   currentZoom: (state: ViewerStore) => state.viewStateActive?.zoom ?? 0,
 };

--- a/app/components/.client/ImageViewer/state/types.ts
+++ b/app/components/.client/ImageViewer/state/types.ts
@@ -85,6 +85,7 @@ export interface ViewerStoreState {
     overlays: OverlaysState;
     channelsOpacity: number;
     overlaysFillOpacity: number;
+    showCellOutline: boolean;
     isChannelsLoading: number;
     isOverlaysLoading: number;
   }[];
@@ -139,6 +140,7 @@ interface ViewerStoreActions {
 
   setOverlaysFillOpacity: (fillOpacity: number) => void;
   setChannelsOpacity: (opacity: number) => void;
+  setShowCellOutline: (show: boolean) => void;
 }
 
 export type ViewerStore = ViewerStoreState & ViewerStoreActions;


### PR DESCRIPTION
## Description

Fix stroke opacity (cell outline toggle) affecting both split view panels instead of only the active panel.

The `showCellOutline` setting was stored globally in `FeatureBarStore`, causing changes to apply to all panels simultaneously. Now it's stored per-panel in `ViewerStore.layersStates`, matching how `overlaysFillOpacity` works.

Changes:
- Add `showCellOutline` to `layersStates` type
- Add `setShowCellOutline` action to update only the active panel's state
- Add `showCellOutline` selector that reads from the current panel's layer state
- Update `OverlaysController` to use `ViewerStore` instead of `FeatureBarStore`
- Update `useOverlaysLayer` to read `showCellOutline` from per-panel state
- Add unit tests for selector and action

## Related Issue

Fixes #5

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed