### PR TITLE
feat: export components as npm package

### DIFF
--- a/app/components/Controls/Button/IconButtonLink.tsx
+++ b/app/components/Controls/Button/IconButtonLink.tsx
@@ -8,7 +8,7 @@ import {
   buttonThemeStyles,
   iconButtonScaleStyles,
 } from "./styles";
-import { Tooltip } from "~/components/Tooltip/Tooltip";
+import { Tooltip } from "../../Tooltip/Tooltip";
 
 interface IconButtonLinkProps extends IconButtonBaseProps {
   to: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,24 @@
       },
       "engines": {
         "node": ">=24.10.0"
+      },
+      "peerDependencies": {
+        "@headlessui/react": "^2.0.0",
+        "lucide-react": "^0.468.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@headlessui/react": {
+          "optional": false
+        },
+        "lucide-react": {
+          "optional": false
+        },
+        "tailwind-merge": {
+          "optional": false
+        }
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,21 @@
   "name": "cytario-web",
   "version": "1.0.0",
   "description": "Cytario Web",
-  "private": true,
+  "private": false,
   "sideEffects": false,
   "type": "module",
+  "exports": {
+    "./controls": "./app/components/Controls/index.ts",
+    "./components/*": "./app/components/*/index.ts",
+    "./tailwind.css": "./app/tailwind.css"
+  },
+  "main": "./app/components/Controls/index.ts",
+  "types": "./app/components/Controls/index.ts",
+  "files": [
+    "app/components/**",
+    "app/tailwind.css",
+    "README.md"
+  ],
   "scripts": {
     "prepare": "husky || true",
     "build": "react-router build",
@@ -98,5 +110,23 @@
   },
   "engines": {
     "node": ">=24.10.0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "@headlessui/react": "^2.0.0",
+    "lucide-react": "^0.468.0",
+    "tailwind-merge": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@headlessui/react": {
+      "optional": false
+    },
+    "lucide-react": {
+      "optional": false
+    },
+    "tailwind-merge": {
+      "optional": false
+    }
   }
 }


### PR DESCRIPTION
## Description

Export shared components as an npm-consumable package. Adds `exports`, `files`, `peerDependencies` fields to package.json and converts internal `~/` path aliases to relative imports in exported modules.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed
