### PR TITLE
fix(cyberduck): derive unique Vendor field from webapp hostname

### DIFF
--- a/app/routes/api/cyberduck-profile.$bucketName.ts
+++ b/app/routes/api/cyberduck-profile.$bucketName.ts
@@ -28,13 +28,17 @@ export const loader = async ({ params, context }: ActionFunctionArgs) => {
     return new Response("Bucket configuration not found", { status: 404 });
   }
 
-  const { auth } = cytarioConfig;
+  const { auth, endpoints } = cytarioConfig;
 
   const actualRegion = bucketConfig.region ?? "eu-central-1";
   const providerConfig = getS3ProviderConfig(bucketConfig.endpoint, actualRegion);
 
+  // Derive a unique vendor ID from the webapp hostname (e.g. "cytario.com" → "cytario-com")
+  const vendor = new URL(endpoints.webapp).hostname.replace(/\./g, "-");
+
   // Generate Cyberduck profile XML
   const profile = generateCyberduckProfile({
+    vendor,
     bucketName,
     roleArn: bucketConfig.roleArn,
     region: actualRegion,
@@ -60,6 +64,7 @@ export const loader = async ({ params, context }: ActionFunctionArgs) => {
 };
 
 interface CyberduckProfileConfig {
+  vendor: string;
   bucketName: string;
   roleArn: string | null;
   region: string;
@@ -77,6 +82,7 @@ interface CyberduckProfileConfig {
 
 function generateCyberduckProfile(config: CyberduckProfileConfig): string {
   const {
+    vendor,
     bucketName,
     roleArn,
     region,
@@ -119,7 +125,7 @@ function generateCyberduckProfile(config: CyberduckProfileConfig): string {
         <key>Protocol</key>
         <string>s3</string>
         <key>Vendor</key>
-        <string>s3-sts</string>
+        <string>${escapeXml(vendor)}</string>
         <key>Description</key>
         <string>Cytario - ${escapeXml(bucketName)}</string>
         <key>Default Nickname</key>


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

## Related Issue

The Cyberduck profile Vendor field was hardcoded to s3-sts, causing all installations to share the same vendor identifier. This made Cyberduck treat profiles from different deployments as the same connection type, leading to confused/merged connections.
The Vendor is now derived from the WEB_HOST hostname (e.g. https://cytario.com → cytario-com), ensuring each deployment generates profiles with a unique vendor ID.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing tests pass locally
- [ ] I have updated documentation as needed

