### PR TITLE
fix(auth): resolve token refresh race causing ~1h session drops

### DIFF
--- a/app/.server/auth/__tests__/authMiddleware.test.ts
+++ b/app/.server/auth/__tests__/authMiddleware.test.ts
@@ -403,6 +403,9 @@ describe("authMiddleware", () => {
       vi.mocked(refreshAccessTokenWithLock).mockRejectedValue(
         new Error("Failed to acquire refresh lock after maximum retries"),
       );
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       const args = createMiddlewareArgs();
 
@@ -414,6 +417,47 @@ describe("authMiddleware", () => {
       ).rejects.toThrow();
 
       expect(mockNext).not.toHaveBeenCalled();
+      expect(sessionStorage.destroySession).toHaveBeenCalledWith(mockSession);
+      expect(redirect).toHaveBeenCalledWith(
+        expect.stringContaining("/login?redirect="),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Set-Cookie": "destroy-cookie",
+          }),
+        }),
+      );
+      consoleSpy.mockRestore();
+    });
+
+    test("redirects to login when token refresh fails with Keycloak error", async () => {
+      vi.mocked(verifyIdToken).mockResolvedValue(null);
+      vi.mocked(refreshAccessTokenWithLock).mockRejectedValue(
+        new Error("invalid_grant: Token is not active"),
+      );
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const args = createMiddlewareArgs();
+
+      await expect(
+        authMiddleware(
+          args as unknown as Parameters<typeof authMiddleware>[0],
+          mockNext,
+        ),
+      ).rejects.toThrow();
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(sessionStorage.destroySession).toHaveBeenCalledWith(mockSession);
+      expect(redirect).toHaveBeenCalledWith(
+        expect.stringContaining("/login?redirect="),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            "Set-Cookie": "destroy-cookie",
+          }),
+        }),
+      );
+      consoleSpy.mockRestore();
     });
   });
 

--- a/app/.server/auth/__tests__/refreshAuthTokens.test.ts
+++ b/app/.server/auth/__tests__/refreshAuthTokens.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../db/redis", () => ({
   redis: {
     set: vi.fn(),
     eval: vi.fn(),
+    hget: vi.fn(),
   },
 }));
 
@@ -157,6 +158,14 @@ describe("refreshAccessToken", () => {
 });
 
 describe("refreshAccessTokenWithLock", () => {
+  const sessionData = {
+    authTokens: {
+      accessToken: "old-access",
+      idToken: "old-id",
+      refreshToken: "refresh-token",
+    },
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getWellKnownEndpoints).mockResolvedValue({
@@ -172,6 +181,8 @@ describe("refreshAccessTokenWithLock", () => {
       ok: true,
       json: () => Promise.resolve(mock.tokenReponse()),
     });
+    // Default: session has the same refresh token (no prior rotation)
+    vi.mocked(redis.hget).mockResolvedValue(JSON.stringify(sessionData));
   });
 
   test("acquires lock, refreshes token, and releases lock", async () => {
@@ -192,10 +203,14 @@ describe("refreshAccessTokenWithLock", () => {
       "NX",
     );
 
-    // Token refreshed
+    // Session re-read from Redis after acquiring lock
+    expect(redis.hget).toHaveBeenCalledWith("session-123", "data");
+
+    // Token refreshed via Keycloak (since refresh token matches)
     expect(result).toEqual(
       expect.objectContaining({ accessToken: expect.any(String) }),
     );
+    expect(mockFetch).toHaveBeenCalled();
 
     // Lock released via Lua script
     expect(redis.eval).toHaveBeenCalledWith(
@@ -206,13 +221,86 @@ describe("refreshAccessTokenWithLock", () => {
     );
   });
 
+  test("returns already-refreshed tokens when refresh token was rotated", async () => {
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    vi.mocked(redis.eval).mockResolvedValue(1);
+
+    // Session in Redis already has a NEW refresh token (rotated by previous lock holder)
+    const alreadyRefreshed = {
+      authTokens: {
+        accessToken: "new-access",
+        idToken: "new-id",
+        refreshToken: "already-rotated-token",
+      },
+    };
+    vi.mocked(redis.hget).mockResolvedValue(
+      JSON.stringify(alreadyRefreshed),
+    );
+
+    const result = await refreshAccessTokenWithLock(
+      "session-123",
+      "old-refresh-token",
+    );
+
+    // Should return the already-refreshed tokens without calling Keycloak
+    expect(result).toEqual(alreadyRefreshed.authTokens);
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    // Lock should still be released
+    expect(redis.eval).toHaveBeenCalled();
+  });
+
+  test("proceeds with refresh when session has same refresh token", async () => {
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    vi.mocked(redis.eval).mockResolvedValue(1);
+
+    // Session still has the same refresh token — no rotation happened
+    vi.mocked(redis.hget).mockResolvedValue(
+      JSON.stringify({
+        authTokens: {
+          accessToken: "old-access",
+          idToken: "old-id",
+          refreshToken: "same-refresh-token",
+        },
+      }),
+    );
+
+    const result = await refreshAccessTokenWithLock(
+      "session-123",
+      "same-refresh-token",
+    );
+
+    // Should call Keycloak since tokens were not rotated
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({ accessToken: expect.any(String) }),
+    );
+  });
+
+  test("proceeds with refresh when session data is missing", async () => {
+    vi.mocked(redis.set).mockResolvedValue("OK");
+    vi.mocked(redis.eval).mockResolvedValue(1);
+    vi.mocked(redis.hget).mockResolvedValue(null);
+
+    const result = await refreshAccessTokenWithLock(
+      "session-123",
+      "refresh-token",
+    );
+
+    // Should call Keycloak since no session data exists
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({ accessToken: expect.any(String) }),
+    );
+  });
+
   test("releases lock even when refresh fails", async () => {
     vi.mocked(redis.set).mockResolvedValue("OK");
     vi.mocked(redis.eval).mockResolvedValue(1);
     mockFetch.mockResolvedValue({ ok: false, status: 401 });
 
     await expect(
-      refreshAccessTokenWithLock("session-123", "bad-token"),
+      refreshAccessTokenWithLock("session-123", "refresh-token"),
     ).rejects.toThrow("Failed to refresh token");
 
     // Lock should still be released in finally block

--- a/app/.server/auth/__tests__/wellKnownEndpoints.test.ts
+++ b/app/.server/auth/__tests__/wellKnownEndpoints.test.ts
@@ -98,8 +98,8 @@ describe("getWellKnownEndpoints", () => {
       await freshGet();
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
-      // Advance past 1-hour TTL
-      vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+      // Advance past 4-hour TTL
+      vi.advanceTimersByTime(4 * 60 * 60 * 1000 + 1);
 
       await freshGet();
       expect(mockFetch).toHaveBeenCalledTimes(2);

--- a/app/.server/auth/authMiddleware.ts
+++ b/app/.server/auth/authMiddleware.ts
@@ -123,48 +123,52 @@ export const authMiddleware: MiddlewareFunction = async (
     if (isRefreshTokenValid(authTokens.refreshToken)) {
       console.info(`${label} Fetch new tokens and credentials`);
 
-      const newAuthTokens = await refreshAccessTokenWithLock(
-        session.id,
-        authTokens.refreshToken,
-      );
-      session.set("authTokens", newAuthTokens);
-
-      // Fetch new credentials with refreshed tokens
       try {
-        const newCredentials = await getSessionCredentials(
-          { ...updatedSessionData, authTokens: newAuthTokens },
-          provider,
-          bucketName,
-          pathName,
+        const newAuthTokens = await refreshAccessTokenWithLock(
+          session.id,
+          authTokens.refreshToken,
         );
+        session.set("authTokens", newAuthTokens);
 
-        updatedSessionData = {
-          ...updatedSessionData,
-          authTokens: newAuthTokens,
-          credentials: newCredentials,
-        };
-      } catch (error) {
-        console.error(
-          `${label} Failed to fetch credentials after token refresh:`,
-          error,
-        );
-        updatedSessionData = {
-          ...updatedSessionData,
-          authTokens: newAuthTokens,
-        };
-        if (bucketName) {
-          session.set("notification", {
-            status: "error",
-            message: `Unable to access bucket "${bucketName}". Temporary credentials could not be obtained.`,
-          });
+        // Fetch new credentials with refreshed tokens
+        try {
+          const newCredentials = await getSessionCredentials(
+            { ...updatedSessionData, authTokens: newAuthTokens },
+            provider,
+            bucketName,
+            pathName,
+          );
+
+          updatedSessionData = {
+            ...updatedSessionData,
+            authTokens: newAuthTokens,
+            credentials: newCredentials,
+          };
+        } catch (error) {
+          console.error(
+            `${label} Failed to fetch credentials after token refresh:`,
+            error,
+          );
+          updatedSessionData = {
+            ...updatedSessionData,
+            authTokens: newAuthTokens,
+          };
+          if (bucketName) {
+            session.set("notification", {
+              status: "error",
+              message: `Unable to access bucket "${bucketName}". Temporary credentials could not be obtained.`,
+            });
+          }
         }
-      }
 
-      const setCookieHeader = await sessionStorage.commitSession(session);
-      context.set(authContext, updatedSessionData);
-      const response = (await next()) as Response;
-      response.headers.append("Set-Cookie", setCookieHeader);
-      return response;
+        const setCookieHeader = await sessionStorage.commitSession(session);
+        context.set(authContext, updatedSessionData);
+        const response = (await next()) as Response;
+        response.headers.append("Set-Cookie", setCookieHeader);
+        return response;
+      } catch (error) {
+        console.error(`${label} Token refresh failed:`, error);
+      }
     }
   }
 

--- a/app/.server/auth/refreshAuthTokens.ts
+++ b/app/.server/auth/refreshAuthTokens.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 
-import { AuthTokens } from "./sessionStorage";
+import { AuthTokens, SessionData } from "./sessionStorage";
 import { getWellKnownEndpoints } from "./wellKnownEndpoints";
 import { redis } from "../db/redis";
 import { cytarioConfig } from "~/config";
@@ -66,8 +66,27 @@ const RELEASE_LOCK_SCRIPT = `
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
+ * Reads the current session auth tokens directly from Redis,
+ * bypassing the in-memory LRU cache to get the freshest data.
+ */
+async function readSessionTokensFromStore(
+  sessionId: string,
+): Promise<AuthTokens | null> {
+  const data = await redis.hget(sessionId, "data");
+  if (!data) return null;
+
+  const parsed = JSON.parse(data) as Partial<SessionData>;
+  return parsed.authTokens ?? null;
+}
+
+/**
  * Refreshes access tokens with a distributed lock to prevent concurrent refresh
  * races during burst requests. Uses Redis NX + Lua atomic release.
+ *
+ * After acquiring the lock, re-reads the session from Redis to detect if another
+ * request already completed the refresh (Keycloak rotates refresh tokens, so the
+ * old token would be revoked). If the stored refresh token differs from the one
+ * passed in, the already-refreshed tokens are returned without hitting Keycloak.
  */
 export async function refreshAccessTokenWithLock(
   sessionId: string,
@@ -87,6 +106,17 @@ export async function refreshAccessTokenWithLock(
 
     if (acquired === "OK") {
       try {
+        // Re-read session from Redis to check if tokens were already refreshed
+        // by a previous lock holder (handles refresh token rotation)
+        const currentTokens = await readSessionTokensFromStore(sessionId);
+
+        if (
+          currentTokens &&
+          currentTokens.refreshToken !== refreshToken
+        ) {
+          return currentTokens;
+        }
+
         return await refreshAccessToken(refreshToken);
       } finally {
         await redis.eval(RELEASE_LOCK_SCRIPT, 1, lockKey, lockValue);

--- a/app/.server/auth/wellKnownEndpoints.ts
+++ b/app/.server/auth/wellKnownEndpoints.ts
@@ -2,7 +2,7 @@ import { cytarioConfig } from "~/config";
 
 const { baseUrl } = cytarioConfig.auth;
 
-const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000; // 4 hours
 
 interface WellKnownEndpoints {
   authorization_endpoint: string;


### PR DESCRIPTION
## Description

Fixes auth session drops that occur after ~1h of app usage. Root cause: when multiple concurrent requests hit an expired token simultaneously, the distributed refresh lock serializes them correctly but losers re-attempt the refresh with a now-revoked token (Keycloak refresh token rotation), causing an unhandled exception that crashes the request with a 500.

### Bug 1 (Critical) — Refresh lock race with token rotation

`refreshAccessTokenWithLock` correctly uses a Redis NX lock to serialize concurrent refresh attempts. But after the first request refreshes and Keycloak rotates the refresh token, subsequent lock winners still pass the old (revoked) token to Keycloak, which rejects it.

**Fix:** After acquiring the lock, re-read the session from Redis via `readSessionTokensFromStore()`. If the stored refresh token differs from what was passed in (meaning another request already completed the refresh), return the already-refreshed tokens without hitting Keycloak. This handles Keycloak's refresh token rotation correctly.

### Bug 2 (High) — Unhandled exception in refresh path

The `refreshAccessTokenWithLock` call in `authMiddleware.ts` had no try/catch. Any refresh failure (lock exhaustion, Keycloak down, revoked token from Bug 1) threw an unhandled exception, producing a 500 error page instead of a graceful redirect to login.

**Fix:** Wrap in try/catch. On failure, log the error and fall through to `logout()` which destroys the session and redirects to `/login` — users get a clean re-login instead of an error page.

### Bug 3 (Medium) — Cache TTL thundering herd

The OIDC well-known endpoints cache TTL was exactly 1 hour — the same as typical Keycloak access token lifetimes. This caused a thundering herd at the ~1h mark: tokens expire AND the OIDC discovery cache expires simultaneously, amplifying concurrent requests to Keycloak and worsening Bug 1.

**Fix:** Increase `CACHE_TTL_MS` from 1h to 4h. Well-known endpoints rarely change (only on realm reconfiguration). Error paths still clear the cache immediately.

## Related Issue

Follow-up to #27 (security-improvements). Auth failures reported after ~1h of app usage post-deploy.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed

## Files Changed

| File | Change |
|------|--------|
| `app/.server/auth/refreshAuthTokens.ts` | Added `readSessionTokensFromStore()`, session re-read after lock acquisition |
| `app/.server/auth/authMiddleware.ts` | try/catch around refresh, fallthrough to logout on failure |
| `app/.server/auth/wellKnownEndpoints.ts` | Cache TTL 1h → 4h |
| `app/.server/auth/__tests__/refreshAuthTokens.test.ts` | +3 tests: lock loser with rotated token, same token refresh, missing session |
| `app/.server/auth/__tests__/authMiddleware.test.ts` | +2 tests: clean logout on refresh failure, Keycloak error handling |
| `app/.server/auth/__tests__/wellKnownEndpoints.test.ts` | Updated TTL assertion |

## Test Coverage

523 tests across 69 test files. All pass.
