### PR TITLE
fix: use useSubmit instead of useFetcher so redirects navigate (C-113)

### DIFF
--- a/app/routes/connections/__tests__/connection.form.test.tsx
+++ b/app/routes/connections/__tests__/connection.form.test.tsx
@@ -6,19 +6,15 @@ import { describe, expect, test, vi } from "vitest";
 import { ConnectionForm } from "../connection.form";
 
 const mockSubmit = vi.fn();
-let mockFetcherData: unknown = null;
+let mockActionData: unknown = undefined;
 
 vi.mock("react-router", async () => {
   const actual = await vi.importActual("react-router");
   return {
     ...actual,
-    useFetcher: () => ({
-      submit: mockSubmit,
-      state: "idle",
-      get data() {
-        return mockFetcherData;
-      },
-    }),
+    useSubmit: () => mockSubmit,
+    useActionData: () => mockActionData,
+    useNavigation: () => ({ state: "idle" }),
   };
 });
 
@@ -510,8 +506,8 @@ describe("ConnectionForm", () => {
   });
 
   describe("server errors", () => {
-    test("displays server-side error messages from fetcher data", () => {
-      mockFetcherData = {
+    test("displays server-side error messages from action data", () => {
+      mockActionData = {
         status: "error",
         errors: { name: ["This name is already taken."] },
       };
@@ -522,7 +518,7 @@ describe("ConnectionForm", () => {
         screen.getByText("This name is already taken."),
       ).toBeInTheDocument();
 
-      mockFetcherData = null;
+      mockActionData = null;
     });
   });
 });

--- a/app/routes/connections/connection.form.tsx
+++ b/app/routes/connections/connection.form.tsx
@@ -12,7 +12,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import type { KeyboardEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { Controller, useForm, useWatch } from "react-hook-form";
-import { useFetcher } from "react-router";
+import { useActionData, useNavigation, useSubmit } from "react-router";
 
 import AWS_REGIONS from "./awsRegions.json";
 import {
@@ -73,14 +73,16 @@ export const ConnectionForm = ({
   initialData,
 }: ConnectionFormProps) => {
   const isEditMode = !!initialData;
-  const fetcher = useFetcher<{
+  const submit = useSubmit();
+  const actionData = useActionData<{
     errors?: Record<string, string[]>;
     status?: string;
   }>();
+  const navigation = useNavigation();
 
   const serverErrors =
-    fetcher.data?.status === "error" ? fetcher.data.errors : undefined;
-  const isSubmitting = fetcher.state === "submitting";
+    actionData?.status === "error" ? actionData.errors : undefined;
+  const isSubmitting = navigation.state === "submitting";
 
   // Compute the initial step from server errors so we navigate to the
   // correct page without needing setState inside an effect.
@@ -160,9 +162,9 @@ export const ConnectionForm = ({
     });
     if (isEditMode) {
       formData.append("_originalName", initialData.originalName);
-      fetcher.submit(formData, { method: "PATCH", action: "/connections" });
+      submit(formData, { method: "PATCH", action: "/connections" });
     } else {
-      fetcher.submit(formData, { method: "post", action: "/connections" });
+      submit(formData, { method: "post", action: "/connections" });
     }
   };
 


### PR DESCRIPTION
## Summary
- Replaced `useFetcher` with `useSubmit` + `useActionData` + `useNavigation` in the connection form
- `useFetcher.submit()` swallows redirect responses — it revalidates route data internally but does **not** change the browser URL. Since the modal is URL-driven (`?modal=add-connection`), it stayed open after successful creation
- `useSubmit()` performs a standard navigation-style submission, so the action's `redirect()` is followed natively by the router
- Updated test mocks accordingly

Closes [C-113](https://app.plane.so/cytario/browse/C-113/)

## Test plan
- [x] Typecheck passes
- [x] ESLint passes
- [x] All 1008 tests pass (109 test files)
- [x] Manual Playwright test: created a connection → modal closed, URL navigated to `/connections/<name>`