### PR TITLE
ci: trigger cytario-docs E2E suite on PRs (C-83)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,27 @@ jobs:
     name: QA Checks
     uses: ./.github/workflows/qa-checks.yml
 
+  e2e:
+    name: E2E Tests (cytario-docs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Trigger and wait for cytario-docs E2E run
+        uses: convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: cytario
+          repo: cytario-docs
+          github_token: ${{ secrets.CYTARIO_DOCS_DISPATCH_TOKEN }}
+          workflow_file_name: e2e.yml
+          ref: main
+          client_workflow_inputs: |
+            {
+              "ref": "${{ github.event.pull_request.head.sha }}",
+              "docs_branch_hint": "${{ github.head_ref }}"
+            }
+          wait_interval: 20
+          propagate_failure: true
+
   build:
     name: Build
     uses: ./.github/workflows/container.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,19 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CYTARIO_DOCS_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CYTARIO_DOCS_DISPATCH_APP_PRIVATE_KEY }}
+          repositories: cytario-docs
+
       - name: Trigger and wait for cytario-docs E2E run
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: cytario
           repo: cytario-docs
-          github_token: ${{ secrets.CYTARIO_DOCS_DISPATCH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           workflow_file_name: e2e.yml
           ref: main
-          client_workflow_inputs: |
-            {
-              "ref": "${{ github.event.pull_request.head.sha }}",
-              "docs_branch_hint": "${{ github.head_ref }}"
-            }
+          client_payload: '{"ref": "${{ github.event.pull_request.head.sha }}", "docs_branch_hint": "${{ github.head_ref }}"}'
           wait_interval: 20
           propagate_failure: true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "prisma": "^7.5.0",
         "semantic-release": "^25.0.3",
         "tailwindcss": "^4.2.2",
+        "tsx": "^4.21.0",
         "typescript": "^5.8.3",
         "vite": ">=6.4.1",
         "vite-tsconfig-paths": "^4.2.1",
@@ -8537,6 +8538,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
@@ -22696,6 +22761,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "prisma": "^7.5.0",
     "semantic-release": "^25.0.3",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.21.0",
     "typescript": "^5.8.3",
     "vite": ">=6.4.1",
     "vite-tsconfig-paths": "^4.2.1",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -6,4 +6,7 @@ export default defineConfig({
   datasource: {
     url: process.env.DATABASE_URL ?? "",
   },
+  migrations: {
+    seed: "tsx prisma/seed.ts",
+  },
 });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,48 @@
+/**
+ * Prisma database seed for E2E tests.
+ *
+ * Creates test fixtures in a fresh database. Runs automatically after
+ * `prisma db push` or explicitly via `npx prisma db seed`.
+ *
+ * The ConnectionConfig uses ownerScope "cytario" so it's visible to any user
+ * in the /cytario group (which includes both e2e-test and e2e-admin users).
+ */
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+
+import { PrismaClient } from "../app/.generated/client.js";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+const TEST_CONNECTION_NAME = process.env.E2E_CONNECTION_NAME || "Exchange";
+
+async function seed() {
+  await prisma.connectionConfig.upsert({
+    where: { name: TEST_CONNECTION_NAME },
+    update: {},
+    create: {
+      name: TEST_CONNECTION_NAME,
+      ownerScope: "cytario",
+      createdBy: "e2e-seed",
+      bucketName: "slashm-ultivue-exchange",
+      provider: "aws",
+      endpoint: "https://s3.eu-central-1.amazonaws.com",
+      roleArn: "arn:aws:iam::727043715722:role/keycloack-aws-test-iam-role",
+      region: "eu-central-1",
+      prefix: "",
+    },
+  });
+
+  console.log(`Seeded ConnectionConfig: "${TEST_CONNECTION_NAME}"`);
+}
+
+seed()
+  .catch((e) => {
+    console.error("Seed failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+    await pool.end();
+  });


### PR DESCRIPTION
## Summary

Wires cytario-web PRs to the E2E suite that was migrated to cytario-docs in [cytario/cytario-docs#9](https://github.com/cytario/cytario-docs/pull/9). Replaces the in-repo Playwright foundation proposed in #60 (which is now superseded and can be closed).

- New `e2e` job in `ci.yml` uses [`convictional/trigger-workflow-and-wait`](https://github.com/convictional/trigger-workflow-and-wait) to dispatch cytario-docs's `e2e.yml`, wait for it to finish, and propagate failure — blocks PR merge if tests fail.
- Passes the PR's SHA and branch name to the cytario-docs workflow. If a cytario-docs branch with the same name exists, it's used (so test changes can ride along with feature PRs); otherwise falls back silently to `main`.
- Adds `prisma/seed.ts` + `prisma.config.ts` seed entry + `tsx` devDep — required because the cytario-docs workflow runs `npx prisma db seed` inside the cytario-web checkout.

## Companion PR

- [cytario/cytario-docs#8](https://github.com/cytario/cytario-docs/pull/8) — adds `workflow_dispatch` inputs (`ref`, `docs_branch_hint`) + pair-branch resolver to `e2e.yml`. **Must merge before this PR** so the contract is in place.

## Supersedes

- #60 — the original "E2E foundation" PR. Following discussion there, the e2e suite now lives in cytario-docs. #60 can be closed once this PR lands. Authorization unit tests from #60 will come in a separate PR.

## Prerequisites before merge

- [ ] Fine-grained PAT `CYTARIO_DOCS_DISPATCH_TOKEN` created (scoped to `cytario/cytario-docs`, **Actions: write**) and added as a repo secret.
- [ ] cytario/cytario-docs#8 merged.
- [ ] Branch protection updated to require the `E2E Tests (cytario-docs)` status check (after a first green run exists).

## Test plan

- [ ] Open a trivial no-op PR; verify the `E2E Tests (cytario-docs)` job dispatches, waits, and reports green.
- [ ] Deliberately break a Playwright selector; verify this PR's CI fails and blocks merge.
- [ ] Create a paired branch on cytario-docs with a failing test; verify the workflow picks it up (check `::notice::` log line).