### PR TITLE
feat: add create group support (C-49)

### DIFF
--- a/app/.server/auth/__tests__/createGroup.test.ts
+++ b/app/.server/auth/__tests__/createGroup.test.ts
@@ -75,6 +75,7 @@ describe("createGroup", () => {
     expect(result).toEqual({
       id: "new-group-id",
       path: "cytario/lab/Ultivue",
+      adminsGroupId: "admins-group-id",
     });
 
     // Created group under parent

--- a/app/.server/auth/__tests__/createGroup.test.ts
+++ b/app/.server/auth/__tests__/createGroup.test.ts
@@ -1,0 +1,193 @@
+import { createGroup } from "../keycloakAdmin";
+
+vi.mock("~/config", () => ({
+  cytarioConfig: {
+    auth: {
+      baseUrl: "http://localhost:8080/realms/master",
+    },
+  },
+}));
+
+vi.mock("../keycloakAdmin/serviceAccountToken", () => ({
+  getAdminToken: vi.fn().mockResolvedValue("mock-admin-token"),
+}));
+
+const BASE = "http://localhost:8080/admin/realms/master";
+
+const mockParentGroup = {
+  id: "parent-123",
+  name: "lab",
+  path: "/cytario/lab",
+  subGroups: [],
+};
+
+function mockFetchSequence(responses: Array<Partial<Response>>) {
+  const fn = vi.fn();
+  for (const res of responses) {
+    fn.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(null),
+      headers: new Headers(),
+      ...res,
+    });
+  }
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("createGroup", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("creates group and admins subgroup under parent", async () => {
+    const fetchMock = mockFetchSequence([
+      // findGroupByPath → fetchGroups
+      {
+        json: () =>
+          Promise.resolve([
+            {
+              id: "root",
+              name: "cytario",
+              path: "/cytario",
+              subGroups: [mockParentGroup],
+            },
+          ]),
+      },
+      // POST /groups/{parentId}/children → new group
+      {
+        status: 201,
+        headers: new Headers({
+          location: `${BASE}/groups/new-group-id`,
+        }),
+      },
+      // POST /groups/{newGroupId}/children → admins subgroup
+      {
+        status: 201,
+        headers: new Headers({
+          location: `${BASE}/groups/admins-group-id`,
+        }),
+      },
+    ]);
+
+    const result = await createGroup("cytario/lab", "Ultivue");
+
+    expect(result).toEqual({
+      id: "new-group-id",
+      path: "cytario/lab/Ultivue",
+    });
+
+    // Created group under parent
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/groups/parent-123/children`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "Ultivue" }),
+      }),
+    );
+
+    // Created admins subgroup
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/groups/new-group-id/children`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ name: "admins" }),
+      }),
+    );
+  });
+
+  test("throws 404 when parent scope does not exist", async () => {
+    mockFetchSequence([
+      // findGroupByPath → empty result
+      { json: () => Promise.resolve([]) },
+    ]);
+
+    await expect(createGroup("nonexistent", "foo")).rejects.toThrow(
+      "Parent group not found: nonexistent",
+    );
+  });
+
+  test("propagates 409 from Keycloak for duplicate name", async () => {
+    mockFetchSequence([
+      // findGroupByPath
+      {
+        json: () =>
+          Promise.resolve([
+            {
+              id: "root",
+              name: "cytario",
+              path: "/cytario",
+              subGroups: [mockParentGroup],
+            },
+          ]),
+      },
+      // POST /groups/{parentId}/children → 409
+      { ok: false, status: 409, statusText: "Conflict" },
+    ]);
+
+    await expect(
+      createGroup("cytario/lab", "existing"),
+    ).rejects.toThrow("409 Conflict");
+  });
+
+  test("rolls back parent group when admins subgroup creation fails", async () => {
+    const fetchMock = mockFetchSequence([
+      // findGroupByPath
+      {
+        json: () =>
+          Promise.resolve([
+            {
+              id: "root",
+              name: "cytario",
+              path: "/cytario",
+              subGroups: [mockParentGroup],
+            },
+          ]),
+      },
+      // POST /groups/{parentId}/children → success
+      {
+        status: 201,
+        headers: new Headers({
+          location: `${BASE}/groups/new-group-id`,
+        }),
+      },
+      // POST /groups/{newGroupId}/children (admins) → 500
+      { ok: false, status: 500, statusText: "Internal Server Error" },
+      // DELETE /groups/{newGroupId} → rollback
+      { ok: true, status: 204 },
+    ]);
+
+    await expect(
+      createGroup("cytario/lab", "broken"),
+    ).rejects.toThrow("500 Internal Server Error");
+
+    // Verify rollback DELETE was called
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/groups/new-group-id`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  test("throws when Location header is missing", async () => {
+    mockFetchSequence([
+      // findGroupByPath
+      {
+        json: () =>
+          Promise.resolve([
+            {
+              id: "root",
+              name: "cytario",
+              path: "/cytario",
+              subGroups: [mockParentGroup],
+            },
+          ]),
+      },
+      // POST /groups/{parentId}/children → 201 but no Location
+      { status: 201, headers: new Headers() },
+    ]);
+
+    await expect(
+      createGroup("cytario/lab", "noheader"),
+    ).rejects.toThrow("Missing Location header");
+  });
+});

--- a/app/.server/auth/keycloakAdmin/groups.ts
+++ b/app/.server/auth/keycloakAdmin/groups.ts
@@ -1,5 +1,11 @@
 import type { UserProfile } from "../getUserInfo";
-import { adminFetch, type KeycloakGroup, type KeycloakUser } from "./client";
+import {
+  adminFetch,
+  adminMutate,
+  KeycloakAdminError,
+  type KeycloakGroup,
+  type KeycloakUser,
+} from "./client";
 
 export interface GroupWithMembers {
   id: string;
@@ -161,6 +167,53 @@ export function collectAllUsers(group: GroupWithMembers): UserWithGroups[] {
 
   traverse(group);
   return Array.from(userMap.values());
+}
+
+/**
+ * Creates a subgroup under the given parent scope, and auto-creates an
+ * "admins" subgroup inside the new group for admin delegation.
+ *
+ * If the admins subgroup creation fails, the parent group is rolled back
+ * (deleted) to avoid leaving the hierarchy in an inconsistent state.
+ */
+export async function createGroup(
+  parentScope: string,
+  name: string,
+): Promise<{ id: string; path: string }> {
+  const parent = await findGroupByPath(parentScope);
+  if (!parent) {
+    throw new KeycloakAdminError(404, `Parent group not found: ${parentScope}`);
+  }
+
+  const response = await adminMutate(
+    "POST",
+    `/groups/${parent.id}/children`,
+    { name },
+  );
+
+  const location = response.headers.get("location");
+  if (!location) {
+    throw new Error("Missing Location header from group creation response");
+  }
+  const newGroupId = location.split("/").pop();
+  if (!newGroupId) {
+    throw new Error("Could not extract group ID from Location header");
+  }
+
+  try {
+    await adminMutate("POST", `/groups/${newGroupId}/children`, {
+      name: "admins",
+    });
+  } catch (e) {
+    console.error("Failed to create admins subgroup, rolling back:", e);
+    await adminMutate("DELETE", `/groups/${newGroupId}`);
+    throw e;
+  }
+
+  return {
+    id: newGroupId,
+    path: `${parentScope}/${name}`,
+  };
 }
 
 /**

--- a/app/.server/auth/keycloakAdmin/groups.ts
+++ b/app/.server/auth/keycloakAdmin/groups.ts
@@ -179,7 +179,7 @@ export function collectAllUsers(group: GroupWithMembers): UserWithGroups[] {
 export async function createGroup(
   parentScope: string,
   name: string,
-): Promise<{ id: string; path: string }> {
+): Promise<{ id: string; path: string; adminsGroupId: string }> {
   const parent = await findGroupByPath(parentScope);
   if (!parent) {
     throw new KeycloakAdminError(404, `Parent group not found: ${parentScope}`);
@@ -200,10 +200,18 @@ export async function createGroup(
     throw new Error("Could not extract group ID from Location header");
   }
 
+  let adminsGroupId: string;
   try {
-    await adminMutate("POST", `/groups/${newGroupId}/children`, {
-      name: "admins",
-    });
+    const adminsResponse = await adminMutate(
+      "POST",
+      `/groups/${newGroupId}/children`,
+      { name: "admins" },
+    );
+    const adminsLocation = adminsResponse.headers.get("location");
+    adminsGroupId = adminsLocation?.split("/").pop() ?? "";
+    if (!adminsGroupId) {
+      throw new Error("Missing Location header from admins subgroup creation");
+    }
   } catch (e) {
     console.error("Failed to create admins subgroup, rolling back:", e);
     try {
@@ -217,6 +225,7 @@ export async function createGroup(
   return {
     id: newGroupId,
     path: `${parentScope}/${name}`,
+    adminsGroupId,
   };
 }
 

--- a/app/.server/auth/keycloakAdmin/groups.ts
+++ b/app/.server/auth/keycloakAdmin/groups.ts
@@ -206,7 +206,11 @@ export async function createGroup(
     });
   } catch (e) {
     console.error("Failed to create admins subgroup, rolling back:", e);
-    await adminMutate("DELETE", `/groups/${newGroupId}`);
+    try {
+      await adminMutate("DELETE", `/groups/${newGroupId}`);
+    } catch (rollbackErr) {
+      console.error("Rollback also failed, orphaned group:", rollbackErr);
+    }
     throw e;
   }
 

--- a/app/.server/auth/keycloakAdmin/index.ts
+++ b/app/.server/auth/keycloakAdmin/index.ts
@@ -1,6 +1,7 @@
 export { type KeycloakGroup, type KeycloakUser } from "./client";
 
 export {
+  createGroup,
   findGroupByPath,
   getManageableScopes,
   getGroupWithMembers,

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -56,6 +56,10 @@ const protectedRoutes = [
             file: "routes/admin/bulkInvite/bulkInvite.modal.tsx",
           },
           {
+            path: "create-group",
+            file: "routes/admin/createGroup/createGroup.modal.tsx",
+          },
+          {
             path: ":userId",
             file: "routes/admin/updateUser/updateUser.modal.tsx",
           },

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,6 +1,7 @@
 import { type RouteConfig, layout } from "@react-router/dev/routes";
 
-const publicRoutes = [
+/** OIDC authentication flow — server-side redirects, no rendered UI, no layout needed. */
+const authRoutes = [
   {
     path: "/login",
     file: "routes/auth/login.route.tsx",
@@ -15,60 +16,61 @@ const publicRoutes = [
   },
 ];
 
-const protectedRoutes = [
-  // wrap in scroll view route layout
-  layout("routes/layouts/scrollview.layout.tsx", [
-    {
-      path: "/",
-      file: "routes/home/home.route.tsx",
-    },
-    {
-      path: "/recent",
-      file: "routes/recent.route.tsx",
-    },
-    {
-      path: "/search",
-      file: "routes/search.route.tsx",
-    },
-    {
-      path: "/config",
-      file: "routes/config.route.tsx",
-    },
-    {
-      path: "/connections",
-      file: "routes/connections/connections.route.tsx",
-    },
-    {
-      path: "/connections/:name/*",
-      file: "routes/objects.route.tsx",
-    },
-    layout("routes/admin/admin.layout.tsx", [
-      {
-        path: "/admin/users",
-        file: "routes/admin/users/users.route.tsx",
-        children: [
-          {
-            path: "invite",
-            file: "routes/admin/inviteUser/inviteUser.modal.tsx",
-          },
-          {
-            path: "bulk-invite",
-            file: "routes/admin/bulkInvite/bulkInvite.modal.tsx",
-          },
-          {
-            path: "create-group",
-            file: "routes/admin/createGroup/createGroup.modal.tsx",
-          },
-          {
-            path: ":userId",
-            file: "routes/admin/updateUser/updateUser.modal.tsx",
-          },
-        ],
-      },
-    ]),
-  ]),
+/** Main application routes — authenticated, wrapped in scrollview layout. */
+const appRoutes = [
+  {
+    path: "/",
+    file: "routes/home/home.route.tsx",
+  },
+  {
+    path: "/recent",
+    file: "routes/recent.route.tsx",
+  },
+  {
+    path: "/search",
+    file: "routes/search.route.tsx",
+  },
+  {
+    path: "/config",
+    file: "routes/config.route.tsx",
+  },
+  {
+    path: "/connections",
+    file: "routes/connections/connections.route.tsx",
+  },
+  {
+    path: "/connections/:name/*",
+    file: "routes/objects.route.tsx",
+  },
 ];
 
+/** Admin routes — scope-gated, wrapped in scrollview layout alongside appRoutes. */
+const adminRoutes = [
+  {
+    path: "/admin/users",
+    file: "routes/admin/users/users.route.tsx",
+    children: [
+      {
+        path: "invite",
+        file: "routes/admin/inviteUser/inviteUser.modal.tsx",
+      },
+      {
+        path: "bulk-invite",
+        file: "routes/admin/bulkInvite/bulkInvite.modal.tsx",
+      },
+      {
+        path: "create-group",
+        file: "routes/admin/createGroup/createGroup.modal.tsx",
+      },
+      {
+        path: ":userId",
+        file: "routes/admin/updateUser/updateUser.modal.tsx",
+      },
+    ],
+  },
+];
+
+/** Data endpoints — authenticated, no layout (JSON responses). */
 const apiRoutes = [
   {
     path: "/api/cyberduck-profile/:name",
@@ -97,8 +99,11 @@ const apiRoutes = [
 ];
 
 export default [
-  ...publicRoutes,
-  ...protectedRoutes,
+  ...authRoutes,
+  layout("routes/layouts/scrollview.layout.tsx", [
+    ...appRoutes,
+    ...adminRoutes,
+  ]),
   ...apiRoutes,
 
   {

--- a/app/routes/admin/admin.layout.tsx
+++ b/app/routes/admin/admin.layout.tsx
@@ -1,5 +1,0 @@
-import { Outlet } from "react-router";
-
-export default function AdminLayout() {
-  return <Outlet />;
-}

--- a/app/routes/admin/createGroup/__tests__/CreateGroupForm.test.tsx
+++ b/app/routes/admin/createGroup/__tests__/CreateGroupForm.test.tsx
@@ -27,12 +27,11 @@ describe("CreateGroupForm", () => {
     expect(screen.getByText("Group name")).toBeInTheDocument();
   });
 
-  test("shows admins subgroup help text", () => {
+  test("shows admin help text", () => {
     renderForm();
 
-    expect(screen.getByText(/admins/)).toBeInTheDocument();
     expect(
-      screen.getByText(/subgroup will be created automatically/),
+      screen.getByText(/added as an admin of this group automatically/),
     ).toBeInTheDocument();
   });
 });

--- a/app/routes/admin/createGroup/__tests__/CreateGroupForm.test.tsx
+++ b/app/routes/admin/createGroup/__tests__/CreateGroupForm.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { createRoutesStub } from "react-router";
+import { describe, expect, test, vi } from "vitest";
+
+import { CreateGroupForm } from "../createGroup.form";
+
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return { ...actual, useSubmit: () => vi.fn() };
+});
+
+function renderForm(scope = "cytario/lab") {
+  const RemixStub = createRoutesStub([
+    {
+      path: "/",
+      Component: () => <CreateGroupForm scope={scope} />,
+    },
+  ]);
+
+  return render(<RemixStub initialEntries={["/"]} />);
+}
+
+describe("CreateGroupForm", () => {
+  test("renders group name field", () => {
+    renderForm();
+
+    expect(screen.getByText("Group name")).toBeInTheDocument();
+  });
+
+  test("shows admins subgroup help text", () => {
+    renderForm();
+
+    expect(screen.getByText(/admins/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/subgroup will be created automatically/),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/routes/admin/createGroup/__tests__/createGroup.action.test.ts
+++ b/app/routes/admin/createGroup/__tests__/createGroup.action.test.ts
@@ -80,7 +80,7 @@ describe("createGroupAction", () => {
 
     expect(mockSession.set).toHaveBeenCalledWith("notification", {
       status: "success",
-      message: 'Created group "Ultivue" under cytario/lab.',
+      message: 'Created group "Ultivue".',
     });
   });
 
@@ -106,7 +106,7 @@ describe("createGroupAction", () => {
     expect(response).toBeInstanceOf(Response);
     expect(mockSession.set).toHaveBeenCalledWith("notification", {
       status: "error",
-      message: 'A group named "existing" already exists under cytario/lab.',
+      message: 'A group named "existing" already exists in this group.',
     });
   });
 

--- a/app/routes/admin/createGroup/__tests__/createGroup.action.test.ts
+++ b/app/routes/admin/createGroup/__tests__/createGroup.action.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+import { createGroupAction } from "../createGroup.action";
+import { authContext } from "~/.server/auth/authMiddleware";
+import { KeycloakAdminError } from "~/.server/auth/keycloakAdmin/client";
+
+vi.mock("~/.server/auth/keycloakAdmin", () => ({
+  createGroup: vi.fn(),
+}));
+
+vi.mock("~/.server/auth/getSession", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("~/.server/auth/sessionStorage", () => ({
+  sessionStorage: {
+    commitSession: vi.fn().mockResolvedValue("mock-cookie"),
+  },
+}));
+
+const { createGroup } = await import("~/.server/auth/keycloakAdmin");
+const { getSession } = await import("~/.server/auth/getSession");
+
+let mockSession: { set: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
+
+function makeRequest(name: string, scope = "cytario/lab") {
+  const form = new FormData();
+  form.append("name", name);
+  return new Request(
+    `http://localhost/admin/users/create-group?scope=${encodeURIComponent(scope)}`,
+    { method: "POST", body: form },
+  );
+}
+
+function makeContext(adminScopes: string[] = ["cytario"]) {
+  const ctx = new Map();
+  ctx.set(authContext, {
+    user: { adminScopes },
+  });
+  return ctx;
+}
+
+function callAction(request: Request, context: Map<unknown, unknown>) {
+  return createGroupAction({
+    request,
+    context,
+    params: {},
+  } as unknown as Parameters<typeof createGroupAction>[0]);
+}
+
+describe("createGroupAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession = { set: vi.fn(), get: vi.fn() };
+    vi.mocked(getSession).mockResolvedValue(mockSession as never);
+  });
+
+  test("redirects with success notification on valid input", async () => {
+    vi.mocked(createGroup).mockResolvedValue({
+      id: "new-id",
+      path: "cytario/lab/Ultivue",
+    });
+
+    const response = await callAction(
+      makeRequest("Ultivue"),
+      makeContext(),
+    );
+
+    expect(createGroup).toHaveBeenCalledWith("cytario/lab", "Ultivue");
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(302);
+
+    expect(mockSession.set).toHaveBeenCalledWith("notification", {
+      status: "success",
+      message: 'Created group "Ultivue" under cytario/lab.',
+    });
+  });
+
+  test("returns field errors for invalid name", async () => {
+    const result = await callAction(makeRequest(""), makeContext());
+
+    expect(createGroup).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      errors: { name: expect.arrayContaining([expect.any(String)]) },
+    });
+  });
+
+  test("returns 409 duplicate-name error message", async () => {
+    vi.mocked(createGroup).mockRejectedValue(
+      new KeycloakAdminError(409, "409 Conflict"),
+    );
+
+    const response = await callAction(
+      makeRequest("existing"),
+      makeContext(),
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect(mockSession.set).toHaveBeenCalledWith("notification", {
+      status: "error",
+      message: 'A group named "existing" already exists under cytario/lab.',
+    });
+  });
+
+  test("returns generic error for non-409 failures", async () => {
+    vi.mocked(createGroup).mockRejectedValue(
+      new KeycloakAdminError(500, "500 Internal Server Error"),
+    );
+
+    const response = await callAction(
+      makeRequest("broken"),
+      makeContext(),
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect(mockSession.set).toHaveBeenCalledWith("notification", {
+      status: "error",
+      message: "Failed to create group. Please try again.",
+    });
+  });
+
+  test("throws 403 when user lacks admin scope", async () => {
+    await expect(
+      callAction(makeRequest("foo"), makeContext(["other/scope"])),
+    ).rejects.toThrow(Response);
+  });
+
+  test("throws 400 when scope query param is missing", async () => {
+    const request = new Request(
+      "http://localhost/admin/users/create-group",
+      {
+        method: "POST",
+        body: (() => {
+          const f = new FormData();
+          f.append("name", "foo");
+          return f;
+        })(),
+      },
+    );
+
+    await expect(
+      callAction(request, makeContext()),
+    ).rejects.toThrow(Response);
+  });
+});

--- a/app/routes/admin/createGroup/__tests__/createGroup.action.test.ts
+++ b/app/routes/admin/createGroup/__tests__/createGroup.action.test.ts
@@ -6,6 +6,7 @@ import { KeycloakAdminError } from "~/.server/auth/keycloakAdmin/client";
 
 vi.mock("~/.server/auth/keycloakAdmin", () => ({
   createGroup: vi.fn(),
+  addUserToGroup: vi.fn(),
 }));
 
 vi.mock("~/.server/auth/getSession", () => ({
@@ -18,7 +19,9 @@ vi.mock("~/.server/auth/sessionStorage", () => ({
   },
 }));
 
-const { createGroup } = await import("~/.server/auth/keycloakAdmin");
+const { createGroup, addUserToGroup } = await import(
+  "~/.server/auth/keycloakAdmin"
+);
 const { getSession } = await import("~/.server/auth/getSession");
 
 let mockSession: { set: ReturnType<typeof vi.fn>; get: ReturnType<typeof vi.fn> };
@@ -35,7 +38,7 @@ function makeRequest(name: string, scope = "cytario/lab") {
 function makeContext(adminScopes: string[] = ["cytario"]) {
   const ctx = new Map();
   ctx.set(authContext, {
-    user: { adminScopes },
+    user: { sub: "user-123", adminScopes },
   });
   return ctx;
 }
@@ -59,6 +62,7 @@ describe("createGroupAction", () => {
     vi.mocked(createGroup).mockResolvedValue({
       id: "new-id",
       path: "cytario/lab/Ultivue",
+      adminsGroupId: "admins-id",
     });
 
     const response = await callAction(
@@ -67,8 +71,12 @@ describe("createGroupAction", () => {
     );
 
     expect(createGroup).toHaveBeenCalledWith("cytario/lab", "Ultivue");
+    expect(addUserToGroup).toHaveBeenCalledWith("user-123", "admins-id");
     expect(response).toBeInstanceOf(Response);
     expect((response as Response).status).toBe(302);
+    expect((response as Response).headers.get("location")).toBe(
+      "/admin/users?scope=cytario%2Flab%2FUltivue",
+    );
 
     expect(mockSession.set).toHaveBeenCalledWith("notification", {
       status: "success",

--- a/app/routes/admin/createGroup/__tests__/createGroup.schema.test.ts
+++ b/app/routes/admin/createGroup/__tests__/createGroup.schema.test.ts
@@ -27,6 +27,17 @@ describe("createGroupSchema", () => {
     expect(result.data!.name).toBe("Ultivue");
   });
 
+  test("parses unicode names", () => {
+    const result = createGroupSchema.safeParse({ name: "Forschung München" });
+    expect(result.success).toBe(true);
+    expect(result.data!.name).toBe("Forschung München");
+  });
+
+  test("fails with whitespace-only name", () => {
+    const result = createGroupSchema.safeParse({ name: "   " });
+    expect(result.success).toBe(false);
+  });
+
   test("fails with empty name", () => {
     const result = createGroupSchema.safeParse({ name: "" });
     expect(result.success).toBe(false);

--- a/app/routes/admin/createGroup/__tests__/createGroup.schema.test.ts
+++ b/app/routes/admin/createGroup/__tests__/createGroup.schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+
+import { createGroupSchema } from "../createGroup.schema";
+
+describe("createGroupSchema", () => {
+  test("parses valid name", () => {
+    const result = createGroupSchema.safeParse({ name: "Ultivue" });
+    expect(result.success).toBe(true);
+    expect(result.data!.name).toBe("Ultivue");
+  });
+
+  test("parses name with spaces", () => {
+    const result = createGroupSchema.safeParse({ name: "Lab Services" });
+    expect(result.success).toBe(true);
+    expect(result.data!.name).toBe("Lab Services");
+  });
+
+  test("parses name with special characters", () => {
+    const result = createGroupSchema.safeParse({ name: "Project #34a-C" });
+    expect(result.success).toBe(true);
+    expect(result.data!.name).toBe("Project #34a-C");
+  });
+
+  test("trims whitespace", () => {
+    const result = createGroupSchema.safeParse({ name: "  Ultivue  " });
+    expect(result.success).toBe(true);
+    expect(result.data!.name).toBe("Ultivue");
+  });
+
+  test("fails with empty name", () => {
+    const result = createGroupSchema.safeParse({ name: "" });
+    expect(result.success).toBe(false);
+  });
+
+  test("fails with slashes", () => {
+    const result = createGroupSchema.safeParse({ name: "team/alpha" });
+    expect(result.success).toBe(false);
+  });
+
+  test("fails when exceeding 255 characters", () => {
+    const result = createGroupSchema.safeParse({ name: "a".repeat(256) });
+    expect(result.success).toBe(false);
+  });
+
+  test("allows exactly 255 characters", () => {
+    const result = createGroupSchema.safeParse({ name: "a".repeat(255) });
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/routes/admin/createGroup/createGroup.action.ts
+++ b/app/routes/admin/createGroup/createGroup.action.ts
@@ -4,7 +4,7 @@ import { createGroupSchema } from "./createGroup.schema";
 import { assertAdminScope } from "../assertAdminScope";
 import { authContext } from "~/.server/auth/authMiddleware";
 import { getSession } from "~/.server/auth/getSession";
-import { createGroup } from "~/.server/auth/keycloakAdmin";
+import { addUserToGroup, createGroup } from "~/.server/auth/keycloakAdmin";
 import { KeycloakAdminError } from "~/.server/auth/keycloakAdmin/client";
 import { sessionStorage } from "~/.server/auth/sessionStorage";
 
@@ -25,11 +25,22 @@ export const createGroupAction: ActionFunction = async ({
   const session = await getSession(request);
 
   try {
-    await createGroup(scope, result.data.name);
+    const { path, adminsGroupId } = await createGroup(
+      scope,
+      result.data.name,
+    );
+
+    await addUserToGroup(user.sub, adminsGroupId);
+
+    const newScopeUrl = `/admin/users?scope=${encodeURIComponent(path)}`;
 
     session.set("notification", {
       status: "success",
       message: `Created group "${result.data.name}" under ${scope}.`,
+    });
+
+    return redirect(newScopeUrl, {
+      headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
     });
   } catch (e) {
     console.error("Create group failed:", e);

--- a/app/routes/admin/createGroup/createGroup.action.ts
+++ b/app/routes/admin/createGroup/createGroup.action.ts
@@ -36,7 +36,7 @@ export const createGroupAction: ActionFunction = async ({
 
     session.set("notification", {
       status: "success",
-      message: `Created group "${result.data.name}" under ${scope}.`,
+      message: `Created group "${result.data.name}".`,
     });
 
     return redirect(newScopeUrl, {
@@ -49,7 +49,7 @@ export const createGroupAction: ActionFunction = async ({
       e instanceof KeycloakAdminError ? e.status : undefined;
     const message =
       status === 409
-        ? `A group named "${result.data.name}" already exists under ${scope}.`
+        ? `A group named "${result.data.name}" already exists in this group.`
         : "Failed to create group. Please try again.";
 
     session.set("notification", {

--- a/app/routes/admin/createGroup/createGroup.action.ts
+++ b/app/routes/admin/createGroup/createGroup.action.ts
@@ -1,0 +1,53 @@
+import { type ActionFunction, redirect } from "react-router";
+
+import { createGroupSchema } from "./createGroup.schema";
+import { assertAdminScope } from "../assertAdminScope";
+import { authContext } from "~/.server/auth/authMiddleware";
+import { getSession } from "~/.server/auth/getSession";
+import { createGroup } from "~/.server/auth/keycloakAdmin";
+import { KeycloakAdminError } from "~/.server/auth/keycloakAdmin/client";
+import { sessionStorage } from "~/.server/auth/sessionStorage";
+
+export const createGroupAction: ActionFunction = async ({
+  request,
+  context,
+}) => {
+  const { user } = context.get(authContext);
+  const { adminUrl, scope } = assertAdminScope(request.url, user.adminScopes);
+
+  const formData = await request.formData();
+  const result = createGroupSchema.safeParse(Object.fromEntries(formData));
+
+  if (!result.success) {
+    return { errors: result.error.flatten().fieldErrors };
+  }
+
+  const session = await getSession(request);
+
+  try {
+    await createGroup(scope, result.data.name);
+
+    session.set("notification", {
+      status: "success",
+      message: `Created group "${result.data.name}" under ${scope}.`,
+    });
+  } catch (e) {
+    console.error("Create group failed:", e);
+
+    const status =
+      e instanceof KeycloakAdminError ? e.status : undefined;
+    const message =
+      status === 409
+        ? `A group named "${result.data.name}" already exists under ${scope}.`
+        : "Failed to create group. Please try again.";
+
+    session.set("notification", {
+      status: "error",
+      message,
+    });
+  }
+
+  return redirect(adminUrl, {
+    headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
+  });
+};

--- a/app/routes/admin/createGroup/createGroup.form.tsx
+++ b/app/routes/admin/createGroup/createGroup.form.tsx
@@ -1,0 +1,74 @@
+import { Field, Fieldset, Input } from "@cytario/design";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { useSubmit } from "react-router";
+
+import {
+  type CreateGroupFormData,
+  createGroupSchema,
+} from "./createGroup.schema";
+
+interface CreateGroupFormProps {
+  scope: string;
+}
+
+export function CreateGroupForm({ scope }: CreateGroupFormProps) {
+  const submit = useSubmit();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<CreateGroupFormData>({
+    resolver: zodResolver(createGroupSchema),
+    defaultValues: { name: "" },
+    mode: "onBlur",
+  });
+
+  const nameValue = useWatch({ control, name: "name" });
+
+  const onSubmit = (data: CreateGroupFormData) => {
+    const formData = new FormData();
+    formData.append("name", data.name);
+    submit(formData, { method: "post" });
+  };
+
+  return (
+    <form
+      id="create-group-form"
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-4"
+    >
+      <Fieldset>
+        <Field label="Group name" error={errors.name}>
+          <Controller
+            control={control}
+            name="name"
+            render={({ field }) => (
+              <Input
+                size="lg"
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+              />
+            )}
+          />
+        </Field>
+      </Fieldset>
+
+      {nameValue.trim() && (
+        <p className="text-sm text-slate-500">
+          Full path:{" "}
+          <span className="font-medium text-slate-700">
+            {scope}/{nameValue.trim()}
+          </span>
+        </p>
+      )}
+
+      <p className="text-sm text-slate-500">
+        An <span className="font-medium">admins</span> subgroup will be created
+        automatically.
+      </p>
+    </form>
+  );
+}

--- a/app/routes/admin/createGroup/createGroup.form.tsx
+++ b/app/routes/admin/createGroup/createGroup.form.tsx
@@ -66,8 +66,7 @@ export function CreateGroupForm({ scope }: CreateGroupFormProps) {
       )}
 
       <p className="text-sm text-slate-500">
-        An <span className="font-medium">admins</span> subgroup will be created
-        automatically.
+        You will be added as an admin of this group automatically.
       </p>
     </form>
   );

--- a/app/routes/admin/createGroup/createGroup.modal.tsx
+++ b/app/routes/admin/createGroup/createGroup.modal.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@cytario/design";
+import { useNavigate, useNavigation, useOutletContext } from "react-router";
+
+import { CreateGroupForm } from "./createGroup.form";
+import { authMiddleware } from "~/.server/auth/authMiddleware";
+import { RouteModal } from "~/components/RouteModal";
+
+export { createGroupAction as action } from "./createGroup.action";
+
+export const middleware = [authMiddleware];
+
+export default function CreateGroupModal() {
+  const navigate = useNavigate();
+  const { state } = useNavigation();
+  const isSubmitting = state === "submitting";
+
+  const { scope } = useOutletContext<{ scope: string }>();
+
+  return (
+    <RouteModal title="Create Group">
+      <CreateGroupForm scope={scope} />
+      <footer className="flex items-center justify-end gap-3 mt-6">
+        <Button onPress={() => navigate(-1)} variant="secondary">
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          form="create-group-form"
+          isDisabled={isSubmitting}
+        >
+          {isSubmitting ? "Creating..." : "Create Group"}
+        </Button>
+      </footer>
+    </RouteModal>
+  );
+}

--- a/app/routes/admin/createGroup/createGroup.schema.ts
+++ b/app/routes/admin/createGroup/createGroup.schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const createGroupSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Required")
+    .max(255, "Maximum 255 characters")
+    .refine((s) => !s.includes("/"), "Slashes are not allowed")
+    .transform((s) => s.trim()),
+});
+
+export type CreateGroupFormData = z.infer<typeof createGroupSchema>;

--- a/app/routes/admin/createGroup/createGroup.schema.ts
+++ b/app/routes/admin/createGroup/createGroup.schema.ts
@@ -3,10 +3,10 @@ import { z } from "zod";
 export const createGroupSchema = z.object({
   name: z
     .string()
+    .trim()
     .min(1, "Required")
     .max(255, "Maximum 255 characters")
-    .refine((s) => !s.includes("/"), "Slashes are not allowed")
-    .transform((s) => s.trim()),
+    .refine((s) => !s.includes("/"), "Slashes are not allowed"),
 });
 
 export type CreateGroupFormData = z.infer<typeof createGroupSchema>;

--- a/app/routes/admin/users/users.route.tsx
+++ b/app/routes/admin/users/users.route.tsx
@@ -1,6 +1,6 @@
 import { ButtonLink, EmptyState, PathPill, Pill } from "@cytario/design";
 import { type RowSelectionState } from "@tanstack/react-table";
-import { UserPlus, Users, UsersRound } from "lucide-react";
+import { FolderPlus, UserPlus, Users, UsersRound } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
   type MetaFunction,
@@ -289,6 +289,13 @@ export default function AdminUsersRoute() {
         <span className="text-sm text-slate-500">
           {data.length} {data.length === 1 ? "user" : "users"}
         </span>
+        <ButtonLink
+          href={`/admin/users/create-group?scope=${encodeURIComponent(scope)}`}
+          variant="secondary"
+          iconLeft={FolderPlus}
+        >
+          Create Group
+        </ButtonLink>
         <ButtonLink
           href={`/admin/users/invite?scope=${encodeURIComponent(scope)}`}
           variant="secondary"


### PR DESCRIPTION
## Summary

- **Backend**: `createGroup` function in Keycloak admin module — creates a subgroup under a parent scope, auto-creates an `admins` subgroup for admin delegation (with rollback on failure), and returns the admins group ID
- **Admin UI**: "Create Group" modal on the admin users page — free-form name input, live path preview, plain-language help text ("You will be added as an admin of this group automatically")
- **Post-creation flow**: creating admin is auto-added to the new `admins` subgroup and redirected to the new group's scope, ready to invite users
- **UX copy**: removed "scope" jargon from all user-visible strings (persona-validated)
- **Routes refactor**: restructured `routes.ts` into `authRoutes`, `appRoutes`, `adminRoutes`, `apiRoutes` with JSDoc comments; removed no-op `admin.layout.tsx`
- **Tests**: 23 new unit tests (5 backend, 6 action, 10 schema, 2 form)

### Companion PRs (merged)

- [cytario-docs#15](https://github.com/cytario/cytario-docs/pull/15) — SRS requirements (SRS-CY-35601–35605), architecture audit table, E2E tests
- [cytario-docs#16](https://github.com/cytario/cytario-docs/pull/16) — KC service account secrets for E2E workflow
- [cytario-docs#17](https://github.com/cytario/cytario-docs/pull/17) — connections-crud reload fallback
- [cytario-docs#18](https://github.com/cytario/cytario-docs/pull/18) — E2E group cleanup and project ordering fix

## Test plan

- [x] Typecheck passes
- [x] All 1075 unit tests pass (23 new for this feature)
- [x] E2E: admin sees Create Group button (SRS-CY-35601)
- [x] E2E: admin creates group, success toast, redirect to new scope (SRS-CY-35602, 35603)
- [x] E2E: duplicate name shows conflict error (SRS-CY-35605)
- [x] E2E: viewer cannot access create-group route (SRS-CY-35604)
- [x] Manual: Create Group → auto-added to admins → redirected to new scope → Invite User visible
- [x] Manual: duplicate name → error message
- [x] Service account `manage-users` role covers group creation (verified in E2E)
- [x] Persona validation (Lab Operator, New Researcher, CIO) — UX copy fixes applied