### PR TITLE
feat: ScopePill icons, UserMenu polish, and design token migration (C-144)

### DIFF
--- a/app/components/Pills/ScopePill.tsx
+++ b/app/components/Pills/ScopePill.tsx
@@ -4,6 +4,7 @@ import {
   type PillColor,
   pillColorFromName,
 } from "@cytario/design";
+import { Shield, Users } from "lucide-react";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -23,9 +24,19 @@ export function ScopePill({ scope, visibleCount }: ScopePillProps) {
   if (!scope || UUID_RE.test(scope)) {
     return <Pill color="slate">Personal</Pill>;
   }
+
+  const isAdmin = scope.endsWith("/admins");
+
   return (
-    <PathPill visibleCount={visibleCount} colorFn={scopeColor}>
-      {scope}
-    </PathPill>
+    <div className="inline-flex items-center gap-1">
+      {isAdmin ? (
+        <Shield size={16} aria-hidden="true" className="shrink-0 text-(--color-text-secondary)" />
+      ) : (
+        <Users size={16} aria-hidden="true" className="shrink-0 text-(--color-text-secondary)" />
+      )}
+      <PathPill visibleCount={visibleCount} colorFn={scopeColor}>
+        {scope}
+      </PathPill>
+    </div>
   );
 }

--- a/app/components/Pills/ScopePill.tsx
+++ b/app/components/Pills/ScopePill.tsx
@@ -34,7 +34,11 @@ export function ScopePill({ scope, visibleCount }: ScopePillProps) {
           size={20}
           fill="white"
           aria-hidden="true"
-          className="shrink-0 text-(--color-text-secondary) bg-slate-300 border p-0.5 rounded-2xl "
+          className={`
+            shrink-0 
+            border p-0.5 rounded-2xl
+            bg-(--color-surface-muted) text-(--color-text-secondary)
+          `}
         />
       ) : null}
       <PathPill visibleCount={visibleCount} colorFn={scopeColor}>

--- a/app/components/Pills/ScopePill.tsx
+++ b/app/components/Pills/ScopePill.tsx
@@ -4,7 +4,7 @@ import {
   type PillColor,
   pillColorFromName,
 } from "@cytario/design";
-import { Shield, Users } from "lucide-react";
+import { Shield } from "lucide-react";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -31,17 +31,12 @@ export function ScopePill({ scope, visibleCount }: ScopePillProps) {
     <div className="inline-flex items-center gap-1">
       {isAdmin ? (
         <Shield
-          size={16}
+          size={20}
+          fill="white"
           aria-hidden="true"
-          className="shrink-0 text-(--color-text-secondary)"
+          className="shrink-0 text-(--color-text-secondary) bg-slate-300 border p-0.5 rounded-2xl "
         />
-      ) : (
-        <Users
-          size={16}
-          aria-hidden="true"
-          className="shrink-0 text-(--color-text-secondary)"
-        />
-      )}
+      ) : null}
       <PathPill visibleCount={visibleCount} colorFn={scopeColor}>
         {scope}
       </PathPill>

--- a/app/components/Pills/ScopePill.tsx
+++ b/app/components/Pills/ScopePill.tsx
@@ -26,6 +26,7 @@ export function ScopePill({ scope, visibleCount }: ScopePillProps) {
   }
 
   const isAdmin = scope.endsWith("/admins");
+  const displayPath = isAdmin ? scope.replace(/\/admins$/, "") : scope;
 
   return (
     <div className="inline-flex items-center gap-1">
@@ -35,7 +36,7 @@ export function ScopePill({ scope, visibleCount }: ScopePillProps) {
         <Users size={16} aria-hidden="true" className="shrink-0 text-(--color-text-secondary)" />
       )}
       <PathPill visibleCount={visibleCount} colorFn={scopeColor}>
-        {scope}
+        {displayPath}
       </PathPill>
     </div>
   );

--- a/app/components/Pills/ScopePill.tsx
+++ b/app/components/Pills/ScopePill.tsx
@@ -26,17 +26,24 @@ export function ScopePill({ scope, visibleCount }: ScopePillProps) {
   }
 
   const isAdmin = scope.endsWith("/admins");
-  const displayPath = isAdmin ? scope.replace(/\/admins$/, "") : scope;
 
   return (
     <div className="inline-flex items-center gap-1">
       {isAdmin ? (
-        <Shield size={16} aria-hidden="true" className="shrink-0 text-(--color-text-secondary)" />
+        <Shield
+          size={16}
+          aria-hidden="true"
+          className="shrink-0 text-(--color-text-secondary)"
+        />
       ) : (
-        <Users size={16} aria-hidden="true" className="shrink-0 text-(--color-text-secondary)" />
+        <Users
+          size={16}
+          aria-hidden="true"
+          className="shrink-0 text-(--color-text-secondary)"
+        />
       )}
       <PathPill visibleCount={visibleCount} colorFn={scopeColor}>
-        {displayPath}
+        {scope}
       </PathPill>
     </div>
   );

--- a/app/components/Pills/__tests__/ScopePill.test.tsx
+++ b/app/components/Pills/__tests__/ScopePill.test.tsx
@@ -52,14 +52,14 @@ describe("ScopePill", () => {
     expect(container.querySelector(".lucide-users")).not.toBeInTheDocument();
   });
 
-  test("strips /admins segment from display but keeps path", () => {
+  test("shows all segments including admins for admin scope", () => {
     render(<ScopePill scope="cytario/Lab Services/admins" />);
     expect(
-      screen.getByLabelText("Path: cytario / Lab Services"),
+      screen.getByLabelText("Path: cytario / Lab Services / admins"),
     ).toBeInTheDocument();
     expect(screen.getByText("cytario")).toBeInTheDocument();
     expect(screen.getByText("Lab Services")).toBeInTheDocument();
-    expect(screen.queryByText("admins")).not.toBeInTheDocument();
+    expect(screen.getByText("admins")).toBeInTheDocument();
   });
 
   test("renders Users icon for non-admin scope", () => {

--- a/app/components/Pills/__tests__/ScopePill.test.tsx
+++ b/app/components/Pills/__tests__/ScopePill.test.tsx
@@ -52,6 +52,16 @@ describe("ScopePill", () => {
     expect(container.querySelector(".lucide-users")).not.toBeInTheDocument();
   });
 
+  test("strips /admins segment from display but keeps path", () => {
+    render(<ScopePill scope="cytario/Lab Services/admins" />);
+    expect(
+      screen.getByLabelText("Path: cytario / Lab Services"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("cytario")).toBeInTheDocument();
+    expect(screen.getByText("Lab Services")).toBeInTheDocument();
+    expect(screen.queryByText("admins")).not.toBeInTheDocument();
+  });
+
   test("renders Users icon for non-admin scope", () => {
     const { container } = render(<ScopePill scope="cytario/Lab Services" />);
     expect(container.querySelector(".lucide-users")).toBeInTheDocument();

--- a/app/components/Pills/__tests__/ScopePill.test.tsx
+++ b/app/components/Pills/__tests__/ScopePill.test.tsx
@@ -19,7 +19,6 @@ describe("ScopePill", () => {
     expect(
       screen.getByLabelText("Path: cytario / Lab Services"),
     ).toBeInTheDocument();
-    expect(screen.getByText("cytario")).toBeInTheDocument();
     expect(screen.getByText("Lab Services")).toBeInTheDocument();
   });
 
@@ -28,13 +27,11 @@ describe("ScopePill", () => {
     expect(screen.getByText("cytario")).toBeInTheDocument();
   });
 
-  test("renders deep scope path with all segments", () => {
+  test("renders deep scope path with all segments in aria-label", () => {
     render(<ScopePill scope="cytario/Lab Services/team-x" />);
     expect(
       screen.getByLabelText("Path: cytario / Lab Services / team-x"),
     ).toBeInTheDocument();
-    expect(screen.getByText("cytario")).toBeInTheDocument();
-    expect(screen.getByText("Lab Services")).toBeInTheDocument();
     expect(screen.getByText("team-x")).toBeInTheDocument();
   });
 
@@ -52,13 +49,11 @@ describe("ScopePill", () => {
     expect(container.querySelector(".lucide-users")).not.toBeInTheDocument();
   });
 
-  test("shows all segments including admins for admin scope", () => {
+  test("shows last segment and full path in aria-label for admin scope", () => {
     render(<ScopePill scope="cytario/Lab Services/admins" />);
     expect(
       screen.getByLabelText("Path: cytario / Lab Services / admins"),
     ).toBeInTheDocument();
-    expect(screen.getByText("cytario")).toBeInTheDocument();
-    expect(screen.getByText("Lab Services")).toBeInTheDocument();
     expect(screen.getByText("admins")).toBeInTheDocument();
   });
 

--- a/app/components/Pills/__tests__/ScopePill.test.tsx
+++ b/app/components/Pills/__tests__/ScopePill.test.tsx
@@ -62,9 +62,9 @@ describe("ScopePill", () => {
     expect(screen.getByText("admins")).toBeInTheDocument();
   });
 
-  test("renders Users icon for non-admin scope", () => {
+  test("renders no icon for non-admin scope", () => {
     const { container } = render(<ScopePill scope="cytario/Lab Services" />);
-    expect(container.querySelector(".lucide-users")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-users")).not.toBeInTheDocument();
     expect(container.querySelector(".lucide-shield")).not.toBeInTheDocument();
   });
 

--- a/app/components/Pills/__tests__/ScopePill.test.tsx
+++ b/app/components/Pills/__tests__/ScopePill.test.tsx
@@ -43,4 +43,24 @@ describe("ScopePill", () => {
     expect(screen.getByText("team-x")).toBeInTheDocument();
     expect(screen.queryByText("cytario")).toBeNull();
   });
+
+  test("renders Shield icon for admin scope", () => {
+    const { container } = render(
+      <ScopePill scope="cytario/Lab Services/admins" />,
+    );
+    expect(container.querySelector(".lucide-shield")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-users")).not.toBeInTheDocument();
+  });
+
+  test("renders Users icon for non-admin scope", () => {
+    const { container } = render(<ScopePill scope="cytario/Lab Services" />);
+    expect(container.querySelector(".lucide-users")).toBeInTheDocument();
+    expect(container.querySelector(".lucide-shield")).not.toBeInTheDocument();
+  });
+
+  test("renders no icon for Personal scope", () => {
+    const { container } = render(<ScopePill scope="" />);
+    expect(container.querySelector(".lucide-shield")).not.toBeInTheDocument();
+    expect(container.querySelector(".lucide-users")).not.toBeInTheDocument();
+  });
 });

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -6,7 +6,7 @@ import {
   MenuSection,
   MenuSeparator,
 } from "@cytario/design";
-import { LogOut, Settings, Shield, User, Users } from "lucide-react";
+import { LogOut, Settings, User } from "lucide-react";
 
 import { UserProfile } from "~/.server/auth/getUserInfo";
 import { ScopePill } from "~/components/Pills/ScopePill";
@@ -41,7 +41,6 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
                   <MenuItem
                     key={scope}
                     id={`admin-${scope}`}
-                    icon={Shield}
                     href={`/admin/users?scope=${encodeURIComponent(scope)}`}
                   >
                     <ScopePill scope={scope} />
@@ -56,7 +55,7 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
             <>
               <MenuSection header="Groups">
                 {user.groups.map((group) => (
-                  <MenuItem key={group} id={`group-${group}`} icon={Users}>
+                  <MenuItem key={group} id={`group-${group}`}>
                     <ScopePill scope={group} />
                   </MenuItem>
                 ))}

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -55,9 +55,9 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
             <>
               <MenuSection header="Groups">
                 {user.groups.map((group) => (
-                  <MenuItem key={group} id={`group-${group}`}>
+                  <div key={group} className="px-3 py-2 text-sm">
                     <ScopePill scope={group} />
-                  </MenuItem>
+                  </div>
                 ))}
               </MenuSection>
               <MenuSeparator />

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -43,7 +43,7 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
                     id={`admin-${scope}`}
                     href={`/admin/users?scope=${encodeURIComponent(scope)}`}
                   >
-                    <ScopePill scope={scope} />
+                    <ScopePill scope={`${scope}/admins`} />
                   </MenuItem>
                 ))}
               </MenuSection>

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -55,9 +55,13 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
             <>
               <MenuSection header="Groups">
                 {user.groups.map((group) => (
-                  <div key={group} className="px-3 py-2 text-sm">
+                  <MenuItem
+                    key={group}
+                    id={`group-${group}`}
+                    className="hover:bg-transparent focus:bg-transparent cursor-default"
+                  >
                     <ScopePill scope={group} />
-                  </div>
+                  </MenuItem>
                 ))}
               </MenuSection>
               <MenuSeparator />

--- a/app/routes/admin/users/__tests__/AdminUsersRoute.test.tsx
+++ b/app/routes/admin/users/__tests__/AdminUsersRoute.test.tsx
@@ -98,7 +98,6 @@ describe("AdminUsersRoute", () => {
     expect(await screen.findByText("Name")).toBeInTheDocument();
     expect(screen.getByText("Email")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
-    expect(screen.getByText("Admin Groups")).toBeInTheDocument();
     expect(screen.getByText("Groups")).toBeInTheDocument();
 
     // ID is hidden by default

--- a/app/routes/admin/users/users.route.tsx
+++ b/app/routes/admin/users/users.route.tsx
@@ -59,7 +59,6 @@ interface UserRow {
   userId: string;
   email: string;
   enabled: string;
-  adminGroups: string;
   groups: string;
   _scope: string;
   [key: string]: unknown;
@@ -116,12 +115,8 @@ function buildGroupColumn(
 function buildColumns(
   groups: GroupInfo[],
   groupCounts: Map<string, number>,
-  adminGroupCounts: Map<string, number>,
   totalCount: number,
 ): ColumnConfig[] {
-  const nonAdminGroups = groups.filter((g) => !g.isAdmin);
-  const adminGroups = groups.filter((g) => g.isAdmin);
-
   return [
     {
       id: "name",
@@ -182,17 +177,9 @@ function buildColumns(
       },
     },
     buildGroupColumn(
-      "adminGroups",
-      "Admin Groups",
-      adminGroups,
-      adminGroupCounts,
-      totalCount,
-      { pillVisibleCount: 2 },
-    ),
-    buildGroupColumn(
       "groups",
       "Groups",
-      nonAdminGroups,
+      groups,
       groupCounts,
       totalCount,
     ),
@@ -214,16 +201,6 @@ const cellRenderers: CellRenderers<UserRow> = {
       <Pill color={row.enabled === "true" ? "green" : "slate"}>{label}</Pill>
     );
   },
-  adminGroups: (row) => (
-    <div className="flex flex-wrap gap-1">
-      {row.adminGroups
-        .split(", ")
-        .filter(Boolean)
-        .map((path) => (
-          <ScopePill key={path} scope={path} />
-        ))}
-    </div>
-  ),
   groups: (row) => (
     <div className="flex flex-wrap gap-1">
       {row.groups
@@ -256,12 +233,7 @@ export default function AdminUsersRoute() {
         userId: user.id,
         email: user.email ?? "",
         enabled: String(user.enabled),
-        adminGroups: [...groupPaths]
-          .filter((p) => p.endsWith("/admins"))
-          .join(", "),
-        groups: [...groupPaths]
-          .filter((p) => !p.endsWith("/admins"))
-          .join(", "),
+        groups: [...groupPaths].join(", "),
         _scope: scope,
       })),
     [users, scope],
@@ -277,19 +249,9 @@ export default function AdminUsersRoute() {
     return counts;
   }, [data]);
 
-  const adminGroupCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const row of data) {
-      for (const path of row.adminGroups.split(", ").filter(Boolean)) {
-        counts.set(path, (counts.get(path) ?? 0) + 1);
-      }
-    }
-    return counts;
-  }, [data]);
-
   const columns = useMemo(
-    () => buildColumns(groups, groupCounts, adminGroupCounts, data.length),
-    [groups, groupCounts, adminGroupCounts, data.length],
+    () => buildColumns(groups, groupCounts, data.length),
+    [groups, groupCounts, data.length],
   );
 
   return (


### PR DESCRIPTION
<img width="1352" height="699" alt="c144-admin-usermenu" src="https://github.com/user-attachments/assets/737524c7-baf3-4fd3-91d3-b398799c17e8" />


## Summary
- Merge Admin Groups and Groups into a single column with leading Shield icon for admin scopes
- Remove hover state from non-interactive group items in UserMenu
- Migrate ScopePill from native Tailwind colors (`bg-slate-300`) to design tokens (`bg-(--color-surface-muted)`)

## Screenshot
<!-- drag c144-admin-usermenu.png here -->

## Test plan
- [x] Verify Shield icon appears only for admin scope pills, not for regular scopes
- [x] Verify UserMenu group items no longer show hover state
- [x] Verify ScopePill styling adapts correctly under dark mode (token-based)
- [x] Unit tests pass (ScopePill, AdminUsersRoute)