### PR TITLE
fix: prefix tree node IDs with connectionName to prevent duplicate React keys (C-80)

### DIFF
--- a/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
@@ -49,7 +49,6 @@ export function AddOverlay({ callback, query, onOverlayAdd }: AddOverlayProps) {
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);
 
   const handleHover = useCallback((node: DesignTreeNode) => {
-    // The design tree node id is the pathName (or name for buckets)
     setHoveredPath(node.id);
   }, []);
 

--- a/app/components/.client/ImageViewer/components/OverlaysController/__tests__/toDesignTreeNodes.test.ts
+++ b/app/components/.client/ImageViewer/components/OverlaysController/__tests__/toDesignTreeNodes.test.ts
@@ -27,8 +27,8 @@ describe("toDesignTreeNodes", () => {
     const result = toDesignTreeNodes(nodes);
 
     expect(result).toEqual([
-      { id: "data.parquet", name: "data.parquet", icon: File },
-      { id: "other.parquet", name: "other.parquet", icon: File },
+      { id: "aws-test-bucket/data.parquet", name: "data.parquet", icon: File },
+      { id: "aws-test-bucket/other.parquet", name: "other.parquet", icon: File },
     ]);
   });
 
@@ -52,11 +52,11 @@ describe("toDesignTreeNodes", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
-      id: "results/",
+      id: "aws-test-bucket/results/",
       name: "results",
       icon: Folder,
       children: [
-        { id: "results/output.parquet", name: "output.parquet", icon: File },
+        { id: "aws-test-bucket/results/output.parquet", name: "output.parquet", icon: File },
       ],
     });
   });
@@ -78,7 +78,7 @@ describe("toDesignTreeNodes", () => {
 
     const result = toDesignTreeNodes(nodes);
 
-    expect(result[0].id).toBe("unnamed-file");
+    expect(result[0].id).toBe("aws-test-bucket/unnamed-file");
   });
 
   test("omits children property for leaf nodes", () => {
@@ -89,6 +89,27 @@ describe("toDesignTreeNodes", () => {
     const result = toDesignTreeNodes(nodes);
 
     expect(result[0]).not.toHaveProperty("children");
+  });
+
+  test("produces unique ids for same path across different connections", () => {
+    const nodes: TreeNode[] = [
+      makeNode({
+        name: "index.parquet",
+        pathName: ".cytario/index.parquet",
+        connectionName: "bucket-a",
+      }),
+      makeNode({
+        name: "index.parquet",
+        pathName: ".cytario/index.parquet",
+        connectionName: "bucket-b",
+      }),
+    ];
+
+    const result = toDesignTreeNodes(nodes);
+
+    expect(result[0].id).toBe("bucket-a/.cytario/index.parquet");
+    expect(result[1].id).toBe("bucket-b/.cytario/index.parquet");
+    expect(result[0].id).not.toBe(result[1].id);
   });
 
   test("returns empty array for empty input", () => {
@@ -129,23 +150,23 @@ describe("findOriginalNode", () => {
     }),
   ];
 
-  test("finds a root-level node by pathName", () => {
-    const found = findOriginalNode(tree, "root.parquet");
+  test("finds a root-level node by connectionName/pathName", () => {
+    const found = findOriginalNode(tree, "aws-test-bucket/root.parquet");
     expect(found?.name).toBe("root.parquet");
   });
 
-  test("finds a nested node by pathName", () => {
-    const found = findOriginalNode(tree, "analysis/cells.parquet");
+  test("finds a nested node by connectionName/pathName", () => {
+    const found = findOriginalNode(tree, "aws-test-bucket/analysis/cells.parquet");
     expect(found?.name).toBe("cells.parquet");
   });
 
-  test("finds a deeply nested node by pathName", () => {
-    const found = findOriginalNode(tree, "analysis/nested/deep.parquet");
+  test("finds a deeply nested node by connectionName/pathName", () => {
+    const found = findOriginalNode(tree, "aws-test-bucket/analysis/nested/deep.parquet");
     expect(found?.name).toBe("deep.parquet");
   });
 
   test("returns undefined for non-existent id", () => {
-    const found = findOriginalNode(tree, "nonexistent");
+    const found = findOriginalNode(tree, "aws-test-bucket/nonexistent");
     expect(found).toBeUndefined();
   });
 

--- a/app/components/.client/ImageViewer/components/OverlaysController/toDesignTreeNodes.ts
+++ b/app/components/.client/ImageViewer/components/OverlaysController/toDesignTreeNodes.ts
@@ -16,13 +16,13 @@ const nodeTypeIcons = {
  * The design system Tree expects `{ id, name, icon?, children? }` while
  * the app's `buildDirectoryTree` produces nodes with `{ provider, bucketName,
  * name, type, pathName?, children }`. This function bridges the two,
- * assigning a unique `id` from `pathName` (or falling back to `name`)
- * and mapping `type` to a Lucide icon.
+ * assigning a unique `id` from `connectionName/pathName` (or falling back
+ * to `connectionName/name`) and mapping `type` to a Lucide icon.
  */
 export function toDesignTreeNodes(nodes: TreeNode[]): DesignTreeNode[] {
   return nodes.map((node) => {
     const designNode: DesignTreeNode = {
-      id: node.pathName ?? node.name,
+      id: `${node.connectionName}/${node.pathName ?? node.name}`,
       name: node.name,
       icon: nodeTypeIcons[node.type],
     };
@@ -37,7 +37,8 @@ export function toDesignTreeNodes(nodes: TreeNode[]): DesignTreeNode[] {
 
 /**
  * Finds the original `TreeNode` from the directory tree that corresponds
- * to a selected design tree node id (which is `pathName` or `name`).
+ * to a selected design tree node id (which is `connectionName/pathName`
+ * or `connectionName/name`).
  * Performs a depth-first search through the tree.
  */
 export function findOriginalNode(
@@ -45,7 +46,7 @@ export function findOriginalNode(
   id: string,
 ): TreeNode | undefined {
   for (const node of nodes) {
-    const nodeId = node.pathName ?? node.name;
+    const nodeId = `${node.connectionName}/${node.pathName ?? node.name}`;
     if (nodeId === id) return node;
 
     if (node.children.length > 0) {

--- a/app/components/DirectoryView/DirectoryViewGrid.tsx
+++ b/app/components/DirectoryView/DirectoryViewGrid.tsx
@@ -165,7 +165,7 @@ export function DirectoryViewGrid({
   return (
     <div className={gridClass}>
       {nodes.map((node) => {
-        const key = `${node.provider}/${node.bucketName}/${node.pathName ?? node.name}`;
+        const key = `${node.connectionName}/${node.pathName ?? node.name}`;
         if (node.type === "bucket") {
           return <BucketCardGridItem key={key} node={node} />;
         }

--- a/app/components/DirectoryView/DirectoryViewTree.tsx
+++ b/app/components/DirectoryView/DirectoryViewTree.tsx
@@ -18,12 +18,13 @@ type DesignIcon = DesignTreeNode["icon"];
 
 /**
  * Converts app TreeNodes into the design system TreeNode format.
- * Uses pathName as the unique id since it is unique within a bucket.
+ * Uses connectionName/pathName as the unique id to avoid collisions
+ * when the same relative path exists across multiple connections.
  */
 function toDesignTreeNodes(nodes: TreeNode[]): DesignTreeNode[] {
   return nodes.map((node) => {
     const designNode: DesignTreeNode = {
-      id: node.pathName ?? node.name,
+      id: `${node.connectionName}/${node.pathName ?? node.name}`,
       name: node.name,
       icon: getNodeIcon(node) as DesignIcon,
     };
@@ -38,14 +39,15 @@ function toDesignTreeNodes(nodes: TreeNode[]): DesignTreeNode[] {
 
 /**
  * Finds the original TreeNode from the directory tree that corresponds
- * to a design tree node id (which is pathName or name).
+ * to a design tree node id (which is connectionName/pathName or
+ * connectionName/name).
  */
 function findOriginalNode(
   nodes: TreeNode[],
   id: string,
 ): TreeNode | undefined {
   for (const node of nodes) {
-    const nodeId = node.pathName ?? node.name;
+    const nodeId = `${node.connectionName}/${node.pathName ?? node.name}`;
     if (nodeId === id) return node;
 
     if (node.children.length > 0) {


### PR DESCRIPTION
## Summary

- Prefix design tree node `id` with `connectionName/` so IDs are globally unique across connections
- Fixes the React warning: `Encountered two children with the same key` when the same relative path (e.g. `.cytario/index.parquet`) exists in multiple connections
- Updates both `toDesignTreeNodes` implementations and their corresponding `findOriginalNode` lookups

Closes [C-80](https://app.plane.so/cytario/browse/C-80/)

## Test plan

- [x] Existing tests updated to expect `connectionName/` prefix in IDs
- [x] New test case: same `pathName` across different connections produces unique IDs
- [x] `findOriginalNode` lookups updated and verified
- [x] Full test suite passes (1074 tests, 0 failures)
- [x] `tsc --noEmit` clean