### PR TITLE
refactor: migrate resourceId to connectionName/pathName (C-149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,13 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           BRANCH="${{ github.head_ref }}"
-          if gh api "repos/cytario/cytario-docs/branches/$BRANCH" --silent 2>/dev/null; then
+          echo "Looking for branch: $BRANCH"
+          if gh api "repos/cytario/cytario-docs/branches/$BRANCH" --jq '.name'; then
             echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "::notice::Using paired cytario-docs branch: $BRANCH"
           else
+            echo "::warning::Branch not found or access denied, falling back to main"
             echo "ref=main" >> "$GITHUB_OUTPUT"
-            echo "::notice::No paired cytario-docs branch; using main"
           fi
 
       - name: Trigger and wait for cytario-docs E2E

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,40 +27,28 @@ jobs:
           private-key: ${{ secrets.CYTARIO_DOCS_DISPATCH_APP_PRIVATE_KEY }}
           repositories: cytario-docs
 
-      - name: Resolve paired docs branch, dispatch, and wait
+      - name: Dispatch E2E and wait
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          WEB_SHA: ${{ github.event.pull_request.head.sha }}
-          BRANCH: ${{ github.head_ref }}
         run: |
-          # 1. Check if paired branch exists in cytario-docs
-          if git ls-remote --exit-code --heads \
-               "https://x-access-token:${GH_TOKEN}@github.com/cytario/cytario-docs.git" \
-               "$BRANCH" >/dev/null 2>&1; then
-            DOCS_REF="$BRANCH"
-            echo "::notice::Using paired cytario-docs branch: $BRANCH"
-          else
-            DOCS_REF="main"
-            echo "::notice::No paired cytario-docs branch; using main"
-          fi
-
-          # 2. Dispatch E2E workflow
+          # Dispatch to main — the e2e.yml resolve step checks out the
+          # paired branch if it exists (using github.token which has
+          # contents:read on the docs repo). The App token only needs
+          # actions:write to trigger the workflow.
           gh workflow run e2e.yml \
             --repo cytario/cytario-docs \
-            --ref "$DOCS_REF" \
-            -f ref="$WEB_SHA"
+            --ref main \
+            -f ref="${{ github.event.pull_request.head.sha }}" \
+            -f docs_branch_hint="${{ github.head_ref }}"
 
-          # 3. Wait for the run to appear
           sleep 5
           RUN_ID=$(gh run list \
             --repo cytario/cytario-docs \
             --workflow e2e.yml \
-            --branch "$DOCS_REF" \
             --limit 1 \
             --json databaseId --jq '.[0].databaseId')
           echo "::notice::E2E run: https://github.com/cytario/cytario-docs/actions/runs/$RUN_ID"
 
-          # 4. Wait for completion and propagate exit status
           gh run watch "$RUN_ID" --repo cytario/cytario-docs --exit-status
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,39 +27,41 @@ jobs:
           private-key: ${{ secrets.CYTARIO_DOCS_DISPATCH_APP_PRIVATE_KEY }}
           repositories: cytario-docs
 
-      - name: Resolve paired cytario-docs branch
-        id: docs-ref
+      - name: Resolve paired docs branch, dispatch, and wait
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          WEB_SHA: ${{ github.event.pull_request.head.sha }}
+          BRANCH: ${{ github.head_ref }}
         run: |
-          BRANCH="${{ github.head_ref }}"
-          echo "Looking for branch: $BRANCH"
+          # 1. Check if paired branch exists in cytario-docs
           if git ls-remote --exit-code --heads \
                "https://x-access-token:${GH_TOKEN}@github.com/cytario/cytario-docs.git" \
                "$BRANCH" >/dev/null 2>&1; then
-            echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
+            DOCS_REF="$BRANCH"
             echo "::notice::Using paired cytario-docs branch: $BRANCH"
           else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
+            DOCS_REF="main"
             echo "::notice::No paired cytario-docs branch; using main"
           fi
 
-      - name: Trigger and wait for cytario-docs E2E
-        uses: the-actions-org/workflow-dispatch@v4
-        id: e2e-dispatch
-        with:
-          workflow: e2e.yml
-          repo: cytario/cytario-docs
-          ref: ${{ steps.docs-ref.outputs.ref }}
-          token: ${{ steps.app-token.outputs.token }}
-          run-name: "E2E from cytario-web ${{ github.event.pull_request.head.sha }}"
-          inputs: '{"ref": "${{ github.event.pull_request.head.sha }}"}'
-          wait-for-completion: true
-          wait-for-completion-timeout: 10m
+          # 2. Dispatch E2E workflow
+          gh workflow run e2e.yml \
+            --repo cytario/cytario-docs \
+            --ref "$DOCS_REF" \
+            -f ref="$WEB_SHA"
 
-      - name: Link to E2E run
-        if: always()
-        run: echo "::notice::E2E run → ${{ steps.e2e-dispatch.outputs.workflow-url }}"
+          # 3. Wait for the run to appear
+          sleep 5
+          RUN_ID=$(gh run list \
+            --repo cytario/cytario-docs \
+            --workflow e2e.yml \
+            --branch "$DOCS_REF" \
+            --limit 1 \
+            --json databaseId --jq '.[0].databaseId')
+          echo "::notice::E2E run: https://github.com/cytario/cytario-docs/actions/runs/$RUN_ID"
+
+          # 4. Wait for completion and propagate exit status
+          gh run watch "$RUN_ID" --repo cytario/cytario-docs --exit-status
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,13 @@ jobs:
       - name: Trigger and wait for cytario-docs E2E
         uses: the-actions-org/workflow-dispatch@v4
         id: e2e-dispatch
-        env:
-          RUN_NAME: "E2E from cytario-web ${{ github.event.pull_request.head.sha }}"
         with:
           workflow: e2e.yml
           repo: cytario/cytario-docs
           ref: ${{ steps.docs-ref.outputs.ref }}
           token: ${{ steps.app-token.outputs.token }}
-          run-name: ${{ env.RUN_NAME }}
-          inputs: '{"web_sha": "${{ github.event.pull_request.head.sha }}", "run-name": "${{ env.RUN_NAME }}"}'
+          run-name: "E2E from cytario-web ${{ github.event.pull_request.head.sha }}"
+          inputs: '{"ref": "${{ github.event.pull_request.head.sha }}"}'
           wait-for-completion: true
           wait-for-completion-timeout: 10m
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,14 @@ jobs:
         run: |
           BRANCH="${{ github.head_ref }}"
           echo "Looking for branch: $BRANCH"
-          if gh api "repos/cytario/cytario-docs/branches/$BRANCH" --jq '.name'; then
+          if git ls-remote --exit-code --heads \
+               "https://x-access-token:${GH_TOKEN}@github.com/cytario/cytario-docs.git" \
+               "$BRANCH" >/dev/null 2>&1; then
             echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "::notice::Using paired cytario-docs branch: $BRANCH"
           else
-            echo "::warning::Branch not found or access denied, falling back to main"
             echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "::notice::No paired cytario-docs branch; using main"
           fi
 
       - name: Trigger and wait for cytario-docs E2E

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,24 @@ jobs:
             echo "::notice::No paired cytario-docs branch; using main"
           fi
 
-      - name: Trigger and wait for cytario-docs E2E run
-        uses: convictional/trigger-workflow-and-wait@v1.6.5
+      - name: Trigger and wait for cytario-docs E2E
+        uses: the-actions-org/workflow-dispatch@v4
+        id: e2e-dispatch
+        env:
+          RUN_NAME: "E2E from cytario-web ${{ github.event.pull_request.head.sha }}"
         with:
-          owner: cytario
-          repo: cytario-docs
-          github_token: ${{ steps.app-token.outputs.token }}
-          workflow_file_name: e2e.yml
+          workflow: e2e.yml
+          repo: cytario/cytario-docs
           ref: ${{ steps.docs-ref.outputs.ref }}
-          client_payload: '{"ref": "${{ github.event.pull_request.head.sha }}", "docs_branch_hint": "${{ github.head_ref }}"}'
-          wait_interval: 20
-          propagate_failure: true
+          token: ${{ steps.app-token.outputs.token }}
+          run-name: ${{ env.RUN_NAME }}
+          inputs: '{"web_sha": "${{ github.event.pull_request.head.sha }}", "run-name": "${{ env.RUN_NAME }}"}'
+          wait-for-completion: true
+          wait-for-completion-timeout: 10m
+
+      - name: Link to E2E run
+        if: always()
+        run: echo "::notice::E2E run → ${{ steps.e2e-dispatch.outputs.workflow-url }}"
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,20 @@ jobs:
           private-key: ${{ secrets.CYTARIO_DOCS_DISPATCH_APP_PRIVATE_KEY }}
           repositories: cytario-docs
 
+      - name: Resolve paired cytario-docs branch
+        id: docs-ref
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if gh api "repos/cytario/cytario-docs/branches/$BRANCH" --silent 2>/dev/null; then
+            echo "ref=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "::notice::Using paired cytario-docs branch: $BRANCH"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "::notice::No paired cytario-docs branch; using main"
+          fi
+
       - name: Trigger and wait for cytario-docs E2E run
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -34,7 +48,7 @@ jobs:
           repo: cytario-docs
           github_token: ${{ steps.app-token.outputs.token }}
           workflow_file_name: e2e.yml
-          ref: main
+          ref: ${{ steps.docs-ref.outputs.ref }}
           client_payload: '{"ref": "${{ github.event.pull_request.head.sha }}", "docs_branch_hint": "${{ github.head_ref }}"}'
           wait_interval: 20
           propagate_failure: true

--- a/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
@@ -71,19 +71,14 @@ export const OverlaysLayer = ({
     loadTile(id);
 
     try {
-      // Find connection record matching this resourceId's provider/bucketName
-      const { provider, bucketName } = parseResourceId(resourceId);
+      const { connectionName } = parseResourceId(resourceId);
       const { connections } = useConnectionsStore.getState();
-      const conn = Object.values(connections).find(
-        (r) =>
-          r.connectionConfig?.provider === provider &&
-          r.connectionConfig?.bucketName === bucketName,
-      );
+      const conn = connections[connectionName];
       const credentials = conn?.credentials;
       const connectionConfig = conn?.connectionConfig;
 
       if (!credentials) {
-        throw new Error(`No credentials found for bucket: ${bucketName}`);
+        throw new Error(`No credentials found for connection: ${connectionName}`);
       }
 
       // Get ALL marker column names (not just enabled ones)

--- a/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
@@ -12,10 +12,8 @@ import { getPolygon } from "./getPolygon";
 import { MarkerProps } from "./markerUniforms";
 import { CellMarker } from "../../../state/store/types";
 import { toastBridge } from "~/toast-bridge";
-import { useConnectionsStore } from "~/utils/connectionsStore";
 import { isPointMode } from "~/utils/db/getGeomQuery";
 import { getTileDataWasm } from "~/utils/db/getTileDataWasm";
-import { parseResourceId } from "~/utils/resourceId";
 
 type SetTooltip = (
   tooltip: { content: ReactNode; x: number; y: number } | null
@@ -71,25 +69,13 @@ export const OverlaysLayer = ({
     loadTile(id);
 
     try {
-      const { connectionName } = parseResourceId(resourceId);
-      const { connections } = useConnectionsStore.getState();
-      const conn = connections[connectionName];
-      const credentials = conn?.credentials;
-      const connectionConfig = conn?.connectionConfig;
-
-      if (!credentials) {
-        throw new Error(`No credentials found for connection: ${connectionName}`);
-      }
-
       // Get ALL marker column names (not just enabled ones)
       const allMarkerKeys = Object.keys(fileMarkers);
 
       const data = await getTileDataWasm(
         resourceId,
         index,
-        credentials,
         allMarkerKeys,
-        connectionConfig
       );
 
       return data;

--- a/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
@@ -10,7 +10,6 @@ import { LavaLoader } from "~/components/LavaLoader";
 import { SearchRouteLoaderResponse } from "~/routes/search.route";
 import { useConnectionsStore } from "~/utils/connectionsStore";
 import { convertCsvToParquet } from "~/utils/db/convertCsvToParquet";
-import { createResourceId } from "~/utils/resourceId";
 
 interface AddOverlayProps {
   callback?: () => void;
@@ -91,20 +90,14 @@ export function AddOverlay({ callback, query, onOverlayAdd }: AddOverlayProps) {
         );
       }
 
-      const resourceId = createResourceId(
-        connectionConfig.provider,
-        connectionConfig.bucketName,
-        originalNode.pathName,
-      );
-
       if (query === "csv") {
-        convertCsvToParquet(resourceId, credentials);
+        convertCsvToParquet(originalNode.id, connectionConfig, credentials);
         toast({
           variant: "success",
           message: `Started conversion: ${originalNode.name}`,
         });
       } else {
-        onOverlayAdd?.({ [resourceId]: {} });
+        onOverlayAdd?.({ [originalNode.id]: {} });
         toast({
           variant: "success",
           message: `Overlay added: ${originalNode.name}`,

--- a/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
@@ -8,7 +8,6 @@ import {
 } from "~/components/DirectoryView/buildDirectoryTree";
 import { LavaLoader } from "~/components/LavaLoader";
 import { SearchRouteLoaderResponse } from "~/routes/search.route";
-import { useConnectionsStore } from "~/utils/connectionsStore";
 import { convertCsvToParquet } from "~/utils/db/convertCsvToParquet";
 
 interface AddOverlayProps {
@@ -71,27 +70,8 @@ export function AddOverlay({ callback, query, onOverlayAdd }: AddOverlayProps) {
     if (!originalNode) return;
 
     try {
-      if (!originalNode.pathName) {
-        throw new Error("Invalid node selected");
-      }
-
-      const { connections } = useConnectionsStore.getState();
-      const conn = connections[originalNode.connectionName];
-      const credentials = conn?.credentials;
-      const connectionConfig = conn?.connectionConfig;
-
-      if (!connectionConfig) {
-        throw new Error("Connection configuration not found");
-      }
-
-      if (!credentials) {
-        throw new Error(
-          `No credentials found for connection: ${originalNode.connectionName}`,
-        );
-      }
-
       if (query === "csv") {
-        convertCsvToParquet(originalNode.id, connectionConfig, credentials);
+        convertCsvToParquet(originalNode.id);
         toast({
           variant: "success",
           message: `Started conversion: ${originalNode.name}`,

--- a/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.Item.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.Item.tsx
@@ -14,10 +14,10 @@ import { ChannelsStateColumns, OverlayState } from "../../state/store/types";
 import { useViewerStore } from "../../state/store/ViewerStoreContext";
 import { ChannelsControllerItem } from "../ChannelsController/ChannelsControllerItem";
 import { LavaLoader } from "~/components/LavaLoader";
-import { useConnectionsStore } from "~/utils/connectionsStore";
+import { useConnectionsStore, selectConnection } from "~/utils/connectionsStore";
 import { getMarkerInfoWasm } from "~/utils/db/getMarkerInfoWasm";
 import { useFileStore } from "~/utils/localFilesStore/useFileStore";
-import { buildConnectionPath, getFileName, parseResourceId } from "~/utils/resourceId";
+import { getFileName, parseResourceId } from "~/utils/resourceId";
 
 interface OverlaysControllerItemProps {
   resourceId: string;
@@ -56,26 +56,16 @@ export const OverlaysControllerItem = ({
   );
 
   const { connectionName } = parseResourceId(resourceId);
-  const connection = useConnectionsStore(
-    (state) => state.connections[connectionName],
-  );
+  const connection = useConnectionsStore(selectConnection(connectionName));
 
   // Fetch markers on mount if not already loaded
   useEffect(() => {
-    if (hasMarkers) return; // Already has markers, skip fetch
+    if (hasMarkers || !connection) return;
 
     const fetchMarkers = async () => {
       setIsLoading(true);
       try {
-        if (!connection?.credentials) {
-          throw new Error(`No credentials found for connection: ${connectionName}`);
-        }
-
-        const markerInfo = await getMarkerInfoWasm(
-          resourceId,
-          connection.credentials,
-          connection.connectionConfig,
-        );
+        const markerInfo = await getMarkerInfoWasm(resourceId);
         if (markerInfo && Object.keys(markerInfo).length > 0) {
           const newOverlayState = getOverlayState(markerInfo);
           updateOverlaysState(resourceId, newOverlayState);
@@ -100,11 +90,10 @@ export const OverlaysControllerItem = ({
   }, [
     hasMarkers,
     resourceId,
+    connection,
     updateOverlaysState,
     toast,
     fileName,
-    connection,
-    connectionName,
   ]);
 
   return (
@@ -120,7 +109,7 @@ export const OverlaysControllerItem = ({
         </button>
 
         <IconButtonLink
-          href={buildConnectionPath(connectionName, parseResourceId(resourceId).pathName)}
+          href={`/connections/${resourceId}`}
           icon={ExternalLink}
           aria-label="Open file"
           variant="ghost"

--- a/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.Item.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.Item.tsx
@@ -17,7 +17,7 @@ import { LavaLoader } from "~/components/LavaLoader";
 import { useConnectionsStore } from "~/utils/connectionsStore";
 import { getMarkerInfoWasm } from "~/utils/db/getMarkerInfoWasm";
 import { useFileStore } from "~/utils/localFilesStore/useFileStore";
-import { getFileName, parseResourceId } from "~/utils/resourceId";
+import { buildConnectionPath, getFileName, parseResourceId } from "~/utils/resourceId";
 
 interface OverlaysControllerItemProps {
   resourceId: string;
@@ -55,20 +55,10 @@ export const OverlaysControllerItem = ({
     1, // Prevent division by zero
   );
 
-  // Find connection record matching this resourceId's provider/bucketName
-  const { provider, bucketName } = parseResourceId(resourceId);
-  const connection = useConnectionsStore((state) => {
-    for (const record of Object.values(state.connections)) {
-      if (
-        record.connectionConfig?.provider === provider &&
-        record.connectionConfig?.bucketName === bucketName
-      ) {
-        return record;
-      }
-    }
-    return undefined;
-  });
-  const connectionName = connection?.connectionConfig?.name;
+  const { connectionName } = parseResourceId(resourceId);
+  const connection = useConnectionsStore(
+    (state) => state.connections[connectionName],
+  );
 
   // Fetch markers on mount if not already loaded
   useEffect(() => {
@@ -78,7 +68,7 @@ export const OverlaysControllerItem = ({
       setIsLoading(true);
       try {
         if (!connection?.credentials) {
-          throw new Error(`No credentials found for bucket: ${bucketName}`);
+          throw new Error(`No credentials found for connection: ${connectionName}`);
         }
 
         const markerInfo = await getMarkerInfoWasm(
@@ -114,7 +104,7 @@ export const OverlaysControllerItem = ({
     toast,
     fileName,
     connection,
-    bucketName,
+    connectionName,
   ]);
 
   return (
@@ -130,7 +120,7 @@ export const OverlaysControllerItem = ({
         </button>
 
         <IconButtonLink
-          href={connectionName ? `/connections/${connectionName}/${parseResourceId(resourceId).pathName}` : `#`}
+          href={buildConnectionPath(connectionName, parseResourceId(resourceId).pathName)}
           icon={ExternalLink}
           aria-label="Open file"
           variant="ghost"

--- a/app/components/.client/ImageViewer/state/store/createViewerStore.ts
+++ b/app/components/.client/ImageViewer/state/store/createViewerStore.ts
@@ -728,7 +728,7 @@ export const createViewerStore = (id: string) =>
       ),
       {
         name: "ViewerStore-" + id,
-        version: 1,
+        version: 2,
         migrate: createMigrate<PersistedViewerState>(
           {
             0: (state) => {
@@ -739,6 +739,19 @@ export const createViewerStore = (id: string) =>
                 imagePanels: [],
                 layersStates: [],
                 viewStateActive: s?.viewStateActive ?? null,
+              };
+            },
+            // C-149: resourceId format changed from provider/bucket/path to
+            // connectionName/path. Clear persisted overlay keys — they'll be
+            // re-added on next use.
+            1: (state) => {
+              const s = state as PersistedViewerState;
+              return {
+                ...s,
+                layersStates: (s.layersStates ?? []).map((ls) => ({
+                  ...ls,
+                  overlays: {},
+                })),
               };
             },
           },

--- a/app/components/DataGrid/DataGrid.tsx
+++ b/app/components/DataGrid/DataGrid.tsx
@@ -34,13 +34,9 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
   const [isFetchingMore, setIsFetchingMore] = useState(false);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const { provider, bucketName } = parseResourceId(resourceId);
-  const connection = useConnectionsStore((state) =>
-    Object.values(state.connections).find(
-      (r) =>
-        r.connectionConfig?.provider === provider &&
-        r.connectionConfig?.bucketName === bucketName,
-    ),
+  const { connectionName } = parseResourceId(resourceId);
+  const connection = useConnectionsStore(
+    (state) => state.connections[connectionName],
   );
 
   // Initial data fetch
@@ -50,7 +46,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
       const connectionConfig = connection?.connectionConfig;
 
       if (!credentials) {
-        setError(`No credentials available for bucket: ${bucketName}`);
+        setError(`No credentials available for connection: ${connectionName}`);
         setLoading(false);
         return;
       }
@@ -71,7 +67,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
     };
 
     fetchData();
-  }, [resourceId, connection, bucketName]);
+  }, [resourceId, connection, connectionName]);
 
   // Fetch more rows
   const fetchMore = useCallback(async () => {

--- a/app/components/DataGrid/DataGrid.tsx
+++ b/app/components/DataGrid/DataGrid.tsx
@@ -12,7 +12,7 @@ import { getParquetRows } from "./getParquetRows";
 import { getParquetSchema, ParquetColumn } from "./getParquetSchema";
 import { WktSvg } from "./WktSvg";
 import { LavaLoader } from "../LavaLoader";
-import { useConnectionsStore } from "~/utils/connectionsStore";
+import { useConnectionsStore, selectConnection } from "~/utils/connectionsStore";
 import { parseResourceId } from "~/utils/resourceId";
 
 const isWkt = (value: unknown): value is string => {
@@ -35,26 +35,17 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
 
   const containerRef = useRef<HTMLDivElement>(null);
   const { connectionName } = parseResourceId(resourceId);
-  const connection = useConnectionsStore(
-    (state) => state.connections[connectionName],
-  );
+  const connection = useConnectionsStore(selectConnection(connectionName));
 
   // Initial data fetch
   useEffect(() => {
+    if (!connection) return;
+
     const fetchData = async () => {
-      const credentials = connection?.credentials;
-      const connectionConfig = connection?.connectionConfig;
-
-      if (!credentials) {
-        setError(`No credentials available for connection: ${connectionName}`);
-        setLoading(false);
-        return;
-      }
-
       try {
         const [schema, data] = await Promise.all([
-          getParquetSchema(resourceId, credentials, connectionConfig),
-          getParquetRows(resourceId, credentials, PAGE_SIZE, 0, connectionConfig),
+          getParquetSchema(resourceId),
+          getParquetRows(resourceId, PAGE_SIZE, 0),
         ]);
         setColumns(schema);
         setRows(data);
@@ -67,25 +58,15 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
     };
 
     fetchData();
-  }, [resourceId, connection, connectionName]);
+  }, [resourceId, connection]);
 
   // Fetch more rows
   const fetchMore = useCallback(async () => {
     if (isFetchingMore || !hasMore) return;
 
-    const credentials = connection?.credentials;
-    const connectionConfig = connection?.connectionConfig;
-    if (!credentials) return;
-
     setIsFetchingMore(true);
     try {
-      const newRows = await getParquetRows(
-        resourceId,
-        credentials,
-        PAGE_SIZE,
-        rows.length,
-        connectionConfig,
-      );
+      const newRows = await getParquetRows(resourceId, PAGE_SIZE, rows.length);
       setRows((prev) => [...prev, ...newRows]);
       setHasMore(newRows.length === PAGE_SIZE);
     } catch (err) {
@@ -95,7 +76,6 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
     }
   }, [
     resourceId,
-    connection,
     rows.length,
     isFetchingMore,
     hasMore,

--- a/app/components/DataGrid/getParquetRows.ts
+++ b/app/components/DataGrid/getParquetRows.ts
@@ -1,35 +1,20 @@
-import { Credentials } from "@aws-sdk/client-sts";
-
 import { getFileType, getReadFunction } from "./fileReader";
 import { createDatabase } from "../../utils/db/createDatabase";
-import { parseResourceId } from "../../utils/resourceId";
-import { ConnectionConfig } from "~/.generated/client";
+import { resolveResourceId } from "~/utils/connectionsStore";
 
 /**
- * Fetch rows from a data file on S3
+ * Fetch rows from a data file on S3.
  * Supports: parquet, csv, json
- * @param resourceId Resource identifier (provider/bucketName/pathName)
- * @param credentials AWS credentials with access to the S3 bucket
- * @param limit Maximum number of rows to fetch (default: 100)
- * @param offset Number of rows to skip (default: 0)
- * @param connectionConfig Optional bucket configuration for S3-compatible services
  */
 export async function getParquetRows(
   resourceId: string,
-  credentials: Credentials,
   limit = 100,
   offset = 0,
-  connectionConfig: ConnectionConfig,
 ): Promise<Record<string, unknown>[]> {
-  const connection = await createDatabase(
-    resourceId,
-    credentials,
-    connectionConfig,
-  );
+  const { credentials, connectionConfig, s3Uri } = resolveResourceId(resourceId);
+  const connection = await createDatabase(resourceId, credentials, connectionConfig);
   const fileType = getFileType(resourceId);
-  const { pathName } = parseResourceId(resourceId);
-  const s3Path = `s3://${connectionConfig.bucketName}/${pathName}`;
-  const readFn = getReadFunction(fileType, s3Path);
+  const readFn = getReadFunction(fileType, s3Uri);
 
   const result = await connection.query(/*sql*/ `
     SELECT * FROM ${readFn}

--- a/app/components/DataGrid/getParquetRows.ts
+++ b/app/components/DataGrid/getParquetRows.ts
@@ -2,7 +2,7 @@ import { Credentials } from "@aws-sdk/client-sts";
 
 import { getFileType, getReadFunction } from "./fileReader";
 import { createDatabase } from "../../utils/db/createDatabase";
-import { toS3Uri } from "../../utils/resourceId";
+import { parseResourceId } from "../../utils/resourceId";
 import { ConnectionConfig } from "~/.generated/client";
 
 /**
@@ -19,7 +19,7 @@ export async function getParquetRows(
   credentials: Credentials,
   limit = 100,
   offset = 0,
-  connectionConfig?: ConnectionConfig | null,
+  connectionConfig: ConnectionConfig,
 ): Promise<Record<string, unknown>[]> {
   const connection = await createDatabase(
     resourceId,
@@ -27,7 +27,8 @@ export async function getParquetRows(
     connectionConfig,
   );
   const fileType = getFileType(resourceId);
-  const s3Path = toS3Uri(resourceId);
+  const { pathName } = parseResourceId(resourceId);
+  const s3Path = `s3://${connectionConfig.bucketName}/${pathName}`;
   const readFn = getReadFunction(fileType, s3Path);
 
   const result = await connection.query(/*sql*/ `

--- a/app/components/DataGrid/getParquetSchema.ts
+++ b/app/components/DataGrid/getParquetSchema.ts
@@ -1,9 +1,6 @@
-import { Credentials } from "@aws-sdk/client-sts";
-
 import { getFileType, getReadFunction } from "./fileReader";
 import { createDatabase } from "../../utils/db/createDatabase";
-import { parseResourceId } from "../../utils/resourceId";
-import { ConnectionConfig } from "~/.generated/client";
+import { resolveResourceId } from "~/utils/connectionsStore";
 
 export interface ParquetColumn {
   name: string;
@@ -11,38 +8,26 @@ export interface ParquetColumn {
 }
 
 /**
- * Fetch the schema (column names and types) from a data file on S3
+ * Fetch the schema (column names and types) from a data file on S3.
  * Supports: parquet, csv, json
- * @param resourceId Resource identifier (provider/bucketName/pathName)
- * @param credentials AWS credentials with access to the S3 bucket
- * @param connectionConfig Optional bucket configuration for S3-compatible services
  */
 export async function getParquetSchema(
   resourceId: string,
-  credentials: Credentials,
-  connectionConfig: ConnectionConfig,
 ): Promise<ParquetColumn[]> {
-  const connection = await createDatabase(
-    resourceId,
-    credentials,
-    connectionConfig,
-  );
+  const { credentials, connectionConfig, s3Uri } = resolveResourceId(resourceId);
+  const connection = await createDatabase(resourceId, credentials, connectionConfig);
   const fileType = getFileType(resourceId);
-  const { pathName } = parseResourceId(resourceId);
-  const s3Path = `s3://${connectionConfig.bucketName}/${pathName}`;
 
   let result;
 
   if (fileType === "parquet") {
-    // Parquet has dedicated schema function
     result = await connection.query(/*sql*/ `
       SELECT name, type
-      FROM parquet_schema('${s3Path}')
+      FROM parquet_schema('${s3Uri}')
       WHERE type IS NOT NULL
     `);
   } else {
-    // CSV/JSON: use DESCRIBE on the read function
-    const readFn = getReadFunction(fileType, s3Path);
+    const readFn = getReadFunction(fileType, s3Uri);
     result = await connection.query(/*sql*/ `
       DESCRIBE SELECT * FROM ${readFn}
     `);
@@ -52,7 +37,6 @@ export async function getParquetSchema(
   for (let i = 0; i < result.numRows; i++) {
     const row = result.get(i);
     if (row) {
-      // DESCRIBE returns column_name and column_type
       const name = (row.name ?? row.column_name) as string;
       const type = (row.type ?? row.column_type) as string;
       columns.push({ name, type });

--- a/app/components/DataGrid/getParquetSchema.ts
+++ b/app/components/DataGrid/getParquetSchema.ts
@@ -2,7 +2,7 @@ import { Credentials } from "@aws-sdk/client-sts";
 
 import { getFileType, getReadFunction } from "./fileReader";
 import { createDatabase } from "../../utils/db/createDatabase";
-import { toS3Uri } from "../../utils/resourceId";
+import { parseResourceId } from "../../utils/resourceId";
 import { ConnectionConfig } from "~/.generated/client";
 
 export interface ParquetColumn {
@@ -20,7 +20,7 @@ export interface ParquetColumn {
 export async function getParquetSchema(
   resourceId: string,
   credentials: Credentials,
-  connectionConfig?: ConnectionConfig | null,
+  connectionConfig: ConnectionConfig,
 ): Promise<ParquetColumn[]> {
   const connection = await createDatabase(
     resourceId,
@@ -28,7 +28,8 @@ export async function getParquetSchema(
     connectionConfig,
   );
   const fileType = getFileType(resourceId);
-  const s3Path = toS3Uri(resourceId);
+  const { pathName } = parseResourceId(resourceId);
+  const s3Path = `s3://${connectionConfig.bucketName}/${pathName}`;
 
   let result;
 

--- a/app/components/DirectoryView/DirectoryView.tsx
+++ b/app/components/DirectoryView/DirectoryView.tsx
@@ -51,7 +51,11 @@ export function DirectoryView({
   const isGrid = viewMode === "grid" || viewMode === "grid-compact";
   const isTree = viewMode === "tree";
 
-  const connectionName = name;
+  // On the connections list, each node IS a connection and carries its own
+  // connectionName. Pass undefined so DirectoryViewGrid/Tree fall back to
+  // node.connectionName per node rather than using the page heading.
+  // TODO(C-148): Remove once connections overview has its own rendering path.
+  const connectionName = isConnection ? undefined : name;
   const connections = useConnectionsStore((s) => s.connections);
 
   const showHiddenFiles = useLayoutStore((s) => s.showHiddenFiles);

--- a/app/components/DirectoryView/DirectoryView.tsx
+++ b/app/components/DirectoryView/DirectoryView.tsx
@@ -1,8 +1,7 @@
 import { EmptyState, Input, Switch } from "@cytario/design";
 import { FolderOpen } from "lucide-react";
 import type { ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
-import { useFetcher } from "react-router";
+import { useMemo, useState } from "react";
 
 import { TreeNode } from "./buildDirectoryTree";
 import { DirectoryViewGrid } from "./DirectoryViewGrid";
@@ -18,12 +17,8 @@ import { Container, Section, SectionHeader } from "~/components/Container";
 import { useColumnFilters } from "~/components/Table/useColumnFilters";
 import { useConnectionsStore } from "~/utils/connectionsStore";
 
-export interface DirectoryViewBaseProps {
+interface DirectoryViewProps {
   nodes: TreeNode[];
-  urlPath?: string;
-}
-
-interface DirectoryViewProps extends DirectoryViewBaseProps {
   viewMode: ViewMode;
   name: string;
   showFilters?: boolean;
@@ -39,8 +34,6 @@ export function DirectoryView({
   nodes,
   name,
   showFilters = false,
-  // connectionName,
-  urlPath,
   children,
   secondaryActions,
   flush,
@@ -51,11 +44,6 @@ export function DirectoryView({
   const isGrid = viewMode === "grid" || viewMode === "grid-compact";
   const isTree = viewMode === "tree";
 
-  // On the connections list, each node IS a connection and carries its own
-  // connectionName. Pass undefined so DirectoryViewGrid/Tree fall back to
-  // node.connectionName per node rather than using the page heading.
-  // TODO(C-148): Remove once connections overview has its own rendering path.
-  const connectionName = isConnection ? undefined : name;
   const connections = useConnectionsStore((s) => s.connections);
 
   const showHiddenFiles = useLayoutStore((s) => s.showHiddenFiles);
@@ -87,17 +75,6 @@ export function DirectoryView({
       node.name.toLowerCase().includes(term),
     );
   }, [filteredNodes, filterText]);
-
-  // Track recently viewed directories (DB-backed via server action)
-  const recentFetcher = useFetcher();
-  useEffect(() => {
-    if (!connectionName || !urlPath) return;
-    recentFetcher.submit(
-      { connectionName, pathName: urlPath, name, type: "directory" },
-      { method: "post", action: "/api/recently-viewed" },
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionName, urlPath, name]);
 
   if (nodes.length === 0) {
     return (
@@ -139,12 +116,12 @@ export function DirectoryView({
 
       {isTree ? (
         <Container>
-          <DirectoryViewTree nodes={visibleNodes} searchTerm={filterText} connectionName={connectionName} />
+          <DirectoryViewTree nodes={visibleNodes} searchTerm={filterText} />
         </Container>
       ) : isGrid ? (
         <Container>
           {displayNodes.length > 0 ? (
-            <DirectoryViewGrid nodes={displayNodes} viewMode={viewMode} connectionName={connectionName} />
+            <DirectoryViewGrid nodes={displayNodes} viewMode={viewMode} />
           ) : (
             <p className="py-8 text-center text-sm text-(--color-text-secondary)">
               No items match the current filters. Try adjusting the filter, or

--- a/app/components/DirectoryView/DirectoryViewGrid.tsx
+++ b/app/components/DirectoryView/DirectoryViewGrid.tsx
@@ -157,11 +157,9 @@ function FileCardGridItem({
 export function DirectoryViewGrid({
   nodes,
   viewMode = "grid",
-  connectionName,
 }: {
   nodes: TreeNode[];
   viewMode?: ViewMode;
-  connectionName?: string;
 }) {
   const compact = viewMode === "grid-compact";
   const gridClass = gridClasses[viewMode] ?? gridClasses["grid"];
@@ -169,12 +167,11 @@ export function DirectoryViewGrid({
   return (
     <div className={gridClass}>
       {nodes.map((node) => {
-        const cn = connectionName ?? node.connectionName;
         const key = node.id;
         if (node.type === "bucket") {
-          return <BucketCardGridItem key={key} node={node} connectionName={cn} />;
+          return <BucketCardGridItem key={key} node={node} connectionName={node.connectionName} />;
         }
-        return <FileCardGridItem key={key} node={node} compact={compact} connectionName={cn} />;
+        return <FileCardGridItem key={key} node={node} compact={compact} connectionName={node.connectionName} />;
       })}
     </div>
   );

--- a/app/components/DirectoryView/DirectoryViewTree.tsx
+++ b/app/components/DirectoryView/DirectoryViewTree.tsx
@@ -15,14 +15,11 @@ interface DirectoryViewTreeProps {
   nodes: TreeNode[];
   /** Pass-through search term for the Tree component's built-in filtering. */
   searchTerm?: string;
-  /** Connection name for single-connection views. Falls back to node.connectionName when absent. */
-  connectionName?: string;
 }
 
 export function DirectoryViewTree({
   nodes,
   searchTerm,
-  connectionName,
 }: DirectoryViewTreeProps) {
   const navigate = useNavigate();
 
@@ -39,7 +36,7 @@ export function DirectoryViewTree({
         searchMatch={(node, term) =>
           node.name.toLowerCase().includes(term.toLowerCase())
         }
-        onActivate={(node) => navigate(buildConnectionPath(connectionName ?? node.connectionName, node.pathName))}
+        onActivate={(node) => navigate(buildConnectionPath(node.connectionName, node.pathName))}
       />
     </div>
   );

--- a/app/routes/__tests__/objects.route.test.tsx
+++ b/app/routes/__tests__/objects.route.test.tsx
@@ -134,6 +134,7 @@ describe("Bucket Route", () => {
             user: mock.user(),
             nodes: [],
             pathName: "test/path/to/file.ome.tiff",
+            urlPath: "test/path/to/file.ome.tiff",
             bucketName: "test-bucket",
             name: "file.ome.tiff",
             isSingleFile: true,

--- a/app/routes/objects.route.tsx
+++ b/app/routes/objects.route.tsx
@@ -36,7 +36,6 @@ import { getFileType } from "~/utils/fileType";
 import { getObjects } from "~/utils/getObjects";
 import { getName, getPrefix } from "~/utils/pathUtils";
 import { checkIsPinnedPath } from "~/utils/pinnedPaths.server";
-import { createResourceId } from "~/utils/resourceId";
 import { createSignedFetch } from "~/utils/signedFetch";
 import { constructS3Url, isZarrPath } from "~/utils/zarrUtils";
 // Lazy load Viewer to prevent SSR issues with client-only code
@@ -230,11 +229,7 @@ export default function ObjectsRoute() {
     }
   }, [notification]);
 
-  const resourceId = createResourceId(
-    connectionConfig.provider,
-    connectionConfig.bucketName,
-    pathName,
-  );
+  const resourceId = `${connectionName}/${pathName}`;
   const fileType = getFileType(resourceId);
 
   // Store credentials and connection config in Zustand store (keyed by connection name)

--- a/app/routes/objects.route.tsx
+++ b/app/routes/objects.route.tsx
@@ -229,7 +229,7 @@ export default function ObjectsRoute() {
     }
   }, [notification]);
 
-  const resourceId = `${connectionName}/${pathName}`;
+  const resourceId = `${connectionName}/${urlPath}`;
   const fileType = getFileType(resourceId);
 
   // Store credentials and connection config in Zustand store (keyed by connection name)

--- a/app/routes/objects.route.tsx
+++ b/app/routes/objects.route.tsx
@@ -239,18 +239,24 @@ export default function ObjectsRoute() {
     }
   }, [connectionName, credentials, connectionConfig, setConnection]);
 
-  // Track recently viewed files (DB-backed via server action)
+  // Track recently viewed files and directories (DB-backed via server action).
+  // Only track when urlPath is non-empty — the connection root itself isn't a viewable item.
+  // Server-side loader split for read path is covered by C-81.
   const recentFetcher = useFetcher();
   useEffect(() => {
-    if (isSingleFile) {
-      recentFetcher.submit(
-        { connectionName, pathName: urlPath, name, type: "file" },
-        { method: "post", action: "/api/recently-viewed" },
-      );
-    }
-    // Intentionally depends only on resourceId — it is derived from connectionName + pathName + provider,
+    if (!urlPath) return;
+    recentFetcher.submit(
+      {
+        connectionName,
+        pathName: urlPath,
+        name,
+        type: isSingleFile ? "file" : "directory",
+      },
+      { method: "post", action: "/api/recently-viewed" },
+    );
+    // Intentionally depends only on resourceId — it is derived from connectionName + pathName,
     // so a resourceId change guarantees the captured values are fresh. Other deps (recentFetcher,
-    // connectionName, urlPath, name) are stable within the same resourceId.
+    // connectionName, urlPath, name, isSingleFile) are stable within the same resourceId.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resourceId]);
 
@@ -300,7 +306,6 @@ export default function ObjectsRoute() {
         name={connectionName}
         showFilters
         nodes={nodes}
-        urlPath={urlPath}
         secondaryActions={<ViewModeToggle />}
       >
         <Button

--- a/app/routes/presign.route.tsx
+++ b/app/routes/presign.route.tsx
@@ -26,8 +26,11 @@ export const loader = async ({
     throw new Error("Connection configuration not found");
   }
 
-  const { provider, bucketName } = connectionConfig;
-  console.info(`${label} Presign route: ${provider}/${bucketName}/${pathName}`);
+  const { provider, bucketName, prefix: connPrefix } = connectionConfig;
+  const s3Key = connPrefix
+    ? `${connPrefix.replace(/\/$/, "")}/${pathName}`
+    : pathName;
+  console.info(`${label} Presign route: ${provider}/${bucketName}/${s3Key}`);
 
   const credentials = bucketsCredentials[bucketName];
   if (!credentials) throw new Error(`No credentials for bucket: ${bucketName}`);
@@ -37,7 +40,7 @@ export const loader = async ({
     const presignedUrl = await getPresignedUrl(
       connectionConfig,
       s3Client,
-      pathName,
+      s3Key,
     );
 
     return Response.json({ url: presignedUrl });

--- a/app/routes/search.route.tsx
+++ b/app/routes/search.route.tsx
@@ -70,7 +70,7 @@ export const loader = async ({
     children: buildDirectoryTree(
       files as _Object[],
       config.name,
-      "",
+      config.prefix ?? "",
     ),
   }));
 

--- a/app/utils/__tests__/resourceId.test.ts
+++ b/app/utils/__tests__/resourceId.test.ts
@@ -1,4 +1,4 @@
-import { buildConnectionPath, toIndexS3Key } from "../resourceId";
+import { buildConnectionPath, parseResourceId, toIndexS3Key } from "../resourceId";
 
 describe("toIndexS3Key", () => {
   test("returns index key without prefix", () => {
@@ -23,6 +23,37 @@ describe("toIndexS3Key", () => {
     expect(toIndexS3Key("org/lab/experiment")).toBe(
       "org/lab/experiment/.cytario/index.parquet",
     );
+  });
+});
+
+describe("parseResourceId", () => {
+  test("parses connectionName and pathName", () => {
+    expect(parseResourceId("my-conn/folder/file.txt")).toEqual({
+      connectionName: "my-conn",
+      pathName: "folder/file.txt",
+    });
+  });
+
+  test("handles empty pathName", () => {
+    expect(parseResourceId("my-conn/")).toEqual({
+      connectionName: "my-conn",
+      pathName: "",
+    });
+  });
+
+  test("handles pathName with multiple slashes", () => {
+    expect(parseResourceId("my-conn/a/b/c.parquet")).toEqual({
+      connectionName: "my-conn",
+      pathName: "a/b/c.parquet",
+    });
+  });
+
+  test("throws on missing slash", () => {
+    expect(() => parseResourceId("no-slash")).toThrow("Invalid resourceId");
+  });
+
+  test("throws on empty connectionName", () => {
+    expect(() => parseResourceId("/path")).toThrow("empty connectionName");
   });
 });
 

--- a/app/utils/connectionsStore/index.ts
+++ b/app/utils/connectionsStore/index.ts
@@ -10,4 +10,7 @@ export {
   selectCredentials,
   selectConnectionConfig,
   selectConnectionIndex,
+  selectResolvedResource,
+  resolveResourceId,
 } from "./selectors";
+export type { ResolvedResource } from "./selectors";

--- a/app/utils/connectionsStore/selectors.ts
+++ b/app/utils/connectionsStore/selectors.ts
@@ -1,4 +1,20 @@
-import { ConnectionsStore } from "./useConnectionsStore";
+import type { Credentials } from "@aws-sdk/client-sts";
+
+import { ConnectionsStore, useConnectionsStore } from "./useConnectionsStore";
+import type { ConnectionConfig } from "~/.generated/client";
+import { parseResourceId } from "~/utils/resourceId";
+
+export interface ResolvedResource {
+  connectionName: string;
+  /** Path relative to the connection root (no prefix). */
+  pathName: string;
+  connectionConfig: ConnectionConfig;
+  credentials: Credentials;
+  /** Full S3 object key (prefix + pathName). */
+  s3Key: string;
+  /** S3 URI: `s3://bucketName/s3Key`. */
+  s3Uri: string;
+}
 
 export const select = {
   connections: (state: ConnectionsStore) => state.connections,
@@ -21,3 +37,47 @@ export const selectConnectionConfig =
 export const selectConnectionIndex =
   (key: string) => (state: ConnectionsStore) =>
     state.connections[key]?.connectionIndex ?? null;
+
+/**
+ * Non-reactive resolve for use in async callbacks and utility functions.
+ * Reads current state snapshot — does not subscribe to changes.
+ * @throws Error if the connection is not found in the store
+ */
+export function resolveResourceId(resourceId: string): ResolvedResource {
+  const resolved = selectResolvedResource(resourceId)(useConnectionsStore.getState());
+  if (!resolved) {
+    const { connectionName } = parseResourceId(resourceId);
+    throw new Error(`No connection found for: ${connectionName}`);
+  }
+  return resolved;
+}
+
+/**
+ * Zustand selector that resolves a resourceId (`connectionName/pathName`) into
+ * the full connection record with S3 key and URI.
+ *
+ * Use in components for reactivity:
+ *   `useConnectionsStore(selectResolvedResource(resourceId))`
+ *
+ * Use in async callbacks:
+ *   `resolveResourceId(resourceId)` (non-reactive wrapper above)
+ */
+export const selectResolvedResource =
+  (resourceId: string) =>
+  (state: ConnectionsStore): ResolvedResource | null => {
+    const { connectionName, pathName } = parseResourceId(resourceId);
+    const conn = state.connections[connectionName];
+    if (!conn?.connectionConfig || !conn?.credentials) return null;
+
+    const prefix = conn.connectionConfig.prefix?.replace(/\/$/, "");
+    const s3Key = prefix ? `${prefix}/${pathName}` : pathName;
+
+    return {
+      connectionName,
+      pathName,
+      connectionConfig: conn.connectionConfig,
+      credentials: conn.credentials,
+      s3Key,
+      s3Uri: `s3://${conn.connectionConfig.bucketName}/${s3Key}`,
+    };
+  };

--- a/app/utils/db/__tests__/getGeomQuery.test.ts
+++ b/app/utils/db/__tests__/getGeomQuery.test.ts
@@ -1,13 +1,12 @@
 import { getGeomQuery } from "../getGeomQuery";
 
-describe("getQuery", () => {
+describe("getGeomQuery", () => {
   const tileIndex = { z: 0, x: 0, y: 0 };
-  // Use proper resourceId format: provider/bucketName/pathName
-  const resourceId = "aws/test-bucket/data/results.parquet";
+  const s3Uri = "s3://test-bucket/data/results.parquet";
 
   test("returns polygon query with WKB geometry for z >= -3", () => {
     const markerColumns = ["marker_positive_pd-1", "marker_positive_cd4"];
-    const sql = getGeomQuery(resourceId, tileIndex, markerColumns);
+    const sql = getGeomQuery(s3Uri, tileIndex, markerColumns);
     expect(sql).toContain("object as id");
     expect(sql).toContain("ST_AsWKB(ST_GeomFromText(geom)) as geom");
     expect(sql).toContain("x");
@@ -20,46 +19,31 @@ describe("getQuery", () => {
 
   test("returns point query for z < -2", () => {
     const markerColumns = ["marker_positive_pd-1", "marker_positive_cd4"];
-    const sql = getGeomQuery(resourceId, { z: -5, x: 0, y: 0 }, markerColumns);
-    // At z=-5, this is point mode (not aggregated since isAggregatedMode is disabled)
+    const sql = getGeomQuery(s3Uri, { z: -5, x: 0, y: 0 }, markerColumns);
     expect(sql).toContain("object as id");
     expect(sql).toContain("x");
     expect(sql).toContain("y");
     expect(sql).toContain("marker_bitmask");
-    expect(sql).not.toContain("BIT_OR"); // Not using aggregation
+    expect(sql).not.toContain("BIT_OR");
     expect(sql).not.toContain("ST_AsWKB");
     expect(sql).not.toContain("geom");
   });
 
   test("uses x/y based filtering instead of ST_Contains", () => {
-    const sql = getGeomQuery(resourceId, tileIndex);
+    const sql = getGeomQuery(s3Uri, tileIndex);
     expect(sql).not.toContain("ST_Contains");
     expect(sql).toContain("x BETWEEN");
     expect(sql).toContain("y BETWEEN");
   });
 
   test("calculates correct bounds for tile coordinates", () => {
-    const sql = getGeomQuery(resourceId, { z: 1, x: 2, y: 3 });
-    // At z=1, tile size is 256, so:
-    // minX = 2 * 256 = 512
-    // maxX = 512 + 256 = 768
-    // minY = 3 * 256 = 768
-    // maxY = 768 + 256 = 1024
+    const sql = getGeomQuery(s3Uri, { z: 1, x: 2, y: 3 });
     expect(sql).toContain("x BETWEEN 512 AND 768");
     expect(sql).toContain("y BETWEEN 768 AND 1024");
   });
 
-  test("generates correct S3 URI without provider prefix", () => {
-    const sql = getGeomQuery(resourceId, tileIndex);
-    // Should contain s3://bucket/path, NOT s3://provider/bucket/path
-    expect(sql).toContain("s3://test-bucket/data/results.parquet");
-    expect(sql).not.toContain("s3://aws/");
-  });
-
-  test("handles different providers in resourceId", () => {
-    const minioResourceId = "minio/my-bucket/folder/file.parquet";
-    const sql = getGeomQuery(minioResourceId, tileIndex);
-    expect(sql).toContain("s3://my-bucket/folder/file.parquet");
-    expect(sql).not.toContain("s3://minio/");
+  test("embeds the S3 URI in the query", () => {
+    const sql = getGeomQuery(s3Uri, tileIndex);
+    expect(sql).toContain("read_parquet('s3://test-bucket/data/results.parquet')");
   });
 });

--- a/app/utils/db/__tests__/getTileDataWasm.test.ts
+++ b/app/utils/db/__tests__/getTileDataWasm.test.ts
@@ -1,5 +1,6 @@
 import { Table } from "apache-arrow";
 
+import { resolveResourceId } from "../../connectionsStore";
 import { createDatabase } from "../createDatabase";
 import { getGeomQuery } from "../getGeomQuery";
 import { getTileDataWasm } from "../getTileDataWasm";
@@ -13,30 +14,35 @@ vi.mock("../getGeomQuery", () => ({
   getGeomQuery: vi.fn(),
 }));
 
+vi.mock("../../connectionsStore", () => ({
+  resolveResourceId: vi.fn(),
+}));
+
 describe("getTileDataWasm", () => {
   const mockQuery = vi.fn();
   const mockConnection = { query: mockQuery };
   const defaultTileIndex = { z: 0, x: 0, y: 0 };
-  const credentials = mock.credentials();
   const connectionConfig = mock.connectionConfig();
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(createDatabase).mockResolvedValue(mockConnection as never);
     vi.mocked(getGeomQuery).mockReturnValue("SELECT * FROM test");
+    vi.mocked(resolveResourceId).mockReturnValue({
+      connectionName: "my-conn",
+      pathName: "data/file.parquet",
+      credentials: mock.credentials(),
+      connectionConfig,
+      s3Key: `${connectionConfig.prefix || ""}data/file.parquet`,
+      s3Uri: `s3://${connectionConfig.bucketName}/data/file.parquet`,
+    });
   });
 
   test("returns data table on successful query", async () => {
     const mockTable = { numRows: 10 } as unknown as Table;
     mockQuery.mockResolvedValue(mockTable);
 
-    const result = await getTileDataWasm(
-      "my-conn/data/file.parquet",
-      defaultTileIndex,
-      credentials,
-      [],
-      connectionConfig,
-    );
+    const result = await getTileDataWasm("my-conn/data/file.parquet", defaultTileIndex);
 
     expect(result).toBe(mockTable);
     expect(getGeomQuery).toHaveBeenCalledWith(
@@ -50,13 +56,7 @@ describe("getTileDataWasm", () => {
     const mockTable = { numRows: 0 };
     mockQuery.mockResolvedValue(mockTable);
 
-    const result = await getTileDataWasm(
-      "my-conn/data/file.parquet",
-      defaultTileIndex,
-      credentials,
-      [],
-      connectionConfig,
-    );
+    const result = await getTileDataWasm("my-conn/data/file.parquet", defaultTileIndex);
 
     expect(result).toBeNull();
   });
@@ -66,92 +66,34 @@ describe("getTileDataWasm", () => {
     mockQuery.mockResolvedValue(mockTable);
     const markerColumns = ["marker1", "marker2", "marker3"];
 
-    await getTileDataWasm(
-      "my-conn/data/file.parquet",
-      defaultTileIndex,
-      credentials,
-      markerColumns,
-      connectionConfig,
-    );
+    await getTileDataWasm("my-conn/data/file.parquet", defaultTileIndex, markerColumns);
 
     expect(getGeomQuery).toHaveBeenCalledWith(
       `s3://${connectionConfig.bucketName}/data/file.parquet`,
       defaultTileIndex,
       markerColumns,
-    );
-  });
-
-  test("passes connection config to createDatabase", async () => {
-    const mockTable = { numRows: 5 };
-    mockQuery.mockResolvedValue(mockTable);
-    const customConfig = mock.connectionConfig({
-      endpoint: "https://minio.local:9000",
-    });
-
-    await getTileDataWasm(
-      "my-conn/data/file.parquet",
-      defaultTileIndex,
-      credentials,
-      [],
-      customConfig,
-    );
-
-    expect(createDatabase).toHaveBeenCalledWith(
-      "my-conn/data/file.parquet",
-      credentials,
-      customConfig,
     );
   });
 
   test("throws error on database failure", async () => {
-    const dbError = new Error("Database connection failed");
-    vi.mocked(createDatabase).mockRejectedValue(dbError);
+    vi.mocked(createDatabase).mockRejectedValue(new Error("Database connection failed"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      getTileDataWasm("my-conn/path", defaultTileIndex, credentials, [], connectionConfig),
+      getTileDataWasm("my-conn/path", defaultTileIndex),
     ).rejects.toThrow("Database connection failed");
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "[getTileDataWasm] Error fetching tile data:",
-      dbError,
-    );
     consoleSpy.mockRestore();
   });
 
   test("throws error on query failure", async () => {
-    const queryError = new Error("Query failed");
-    mockQuery.mockRejectedValue(queryError);
+    mockQuery.mockRejectedValue(new Error("Query failed"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      getTileDataWasm("my-conn/path", defaultTileIndex, credentials, [], connectionConfig),
+      getTileDataWasm("my-conn/path", defaultTileIndex),
     ).rejects.toThrow("Query failed");
 
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "[getTileDataWasm] Error fetching tile data:",
-      queryError,
-    );
     consoleSpy.mockRestore();
-  });
-
-  test("uses different tile indices", async () => {
-    const mockTable = { numRows: 3 };
-    mockQuery.mockResolvedValue(mockTable);
-    const tileIndex = { z: 5, x: 10, y: 20 };
-
-    await getTileDataWasm(
-      "my-conn/data/file.parquet",
-      tileIndex,
-      credentials,
-      [],
-      connectionConfig,
-    );
-
-    expect(getGeomQuery).toHaveBeenCalledWith(
-      `s3://${connectionConfig.bucketName}/data/file.parquet`,
-      tileIndex,
-      [],
-    );
   });
 });

--- a/app/utils/db/__tests__/getTileDataWasm.test.ts
+++ b/app/utils/db/__tests__/getTileDataWasm.test.ts
@@ -18,6 +18,7 @@ describe("getTileDataWasm", () => {
   const mockConnection = { query: mockQuery };
   const defaultTileIndex = { z: 0, x: 0, y: 0 };
   const credentials = mock.credentials();
+  const connectionConfig = mock.connectionConfig();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,19 +31,16 @@ describe("getTileDataWasm", () => {
     mockQuery.mockResolvedValue(mockTable);
 
     const result = await getTileDataWasm(
-      "bucket/path",
+      "my-conn/data/file.parquet",
       defaultTileIndex,
       credentials,
+      [],
+      connectionConfig,
     );
 
     expect(result).toBe(mockTable);
-    expect(createDatabase).toHaveBeenCalledWith(
-      "bucket/path",
-      credentials,
-      undefined,
-    );
     expect(getGeomQuery).toHaveBeenCalledWith(
-      "bucket/path",
+      `s3://${connectionConfig.bucketName}/data/file.parquet`,
       defaultTileIndex,
       [],
     );
@@ -53,9 +51,11 @@ describe("getTileDataWasm", () => {
     mockQuery.mockResolvedValue(mockTable);
 
     const result = await getTileDataWasm(
-      "bucket/path",
+      "my-conn/data/file.parquet",
       defaultTileIndex,
       credentials,
+      [],
+      connectionConfig,
     );
 
     expect(result).toBeNull();
@@ -67,14 +67,15 @@ describe("getTileDataWasm", () => {
     const markerColumns = ["marker1", "marker2", "marker3"];
 
     await getTileDataWasm(
-      "bucket/path",
+      "my-conn/data/file.parquet",
       defaultTileIndex,
       credentials,
       markerColumns,
+      connectionConfig,
     );
 
     expect(getGeomQuery).toHaveBeenCalledWith(
-      "bucket/path",
+      `s3://${connectionConfig.bucketName}/data/file.parquet`,
       defaultTileIndex,
       markerColumns,
     );
@@ -83,22 +84,22 @@ describe("getTileDataWasm", () => {
   test("passes connection config to createDatabase", async () => {
     const mockTable = { numRows: 5 };
     mockQuery.mockResolvedValue(mockTable);
-    const connectionConfig = mock.connectionConfig({
+    const customConfig = mock.connectionConfig({
       endpoint: "https://minio.local:9000",
     });
 
     await getTileDataWasm(
-      "bucket/path",
+      "my-conn/data/file.parquet",
       defaultTileIndex,
       credentials,
       [],
-      connectionConfig,
+      customConfig,
     );
 
     expect(createDatabase).toHaveBeenCalledWith(
-      "bucket/path",
+      "my-conn/data/file.parquet",
       credentials,
-      connectionConfig,
+      customConfig,
     );
   });
 
@@ -108,7 +109,7 @@ describe("getTileDataWasm", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      getTileDataWasm("bucket/path", defaultTileIndex, credentials),
+      getTileDataWasm("my-conn/path", defaultTileIndex, credentials, [], connectionConfig),
     ).rejects.toThrow("Database connection failed");
 
     expect(consoleSpy).toHaveBeenCalledWith(
@@ -124,7 +125,7 @@ describe("getTileDataWasm", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(
-      getTileDataWasm("bucket/path", defaultTileIndex, credentials),
+      getTileDataWasm("my-conn/path", defaultTileIndex, credentials, [], connectionConfig),
     ).rejects.toThrow("Query failed");
 
     expect(consoleSpy).toHaveBeenCalledWith(
@@ -139,8 +140,18 @@ describe("getTileDataWasm", () => {
     mockQuery.mockResolvedValue(mockTable);
     const tileIndex = { z: 5, x: 10, y: 20 };
 
-    await getTileDataWasm("bucket/path", tileIndex, credentials);
+    await getTileDataWasm(
+      "my-conn/data/file.parquet",
+      tileIndex,
+      credentials,
+      [],
+      connectionConfig,
+    );
 
-    expect(getGeomQuery).toHaveBeenCalledWith("bucket/path", tileIndex, []);
+    expect(getGeomQuery).toHaveBeenCalledWith(
+      `s3://${connectionConfig.bucketName}/data/file.parquet`,
+      tileIndex,
+      [],
+    );
   });
 });

--- a/app/utils/db/convertCsvToParquet.ts
+++ b/app/utils/db/convertCsvToParquet.ts
@@ -9,11 +9,13 @@ import {
 
 import { getUint8ArrayForResourceId } from "./getBlobFromObjectNode";
 import { buildCreateTableQuery } from "./sqlQueries";
-import { toS3Uri } from "../resourceId";
+import { parseResourceId } from "../resourceId";
+import { ConnectionConfig } from "~/.generated/client";
 
 export async function convertCsvToParquet(
   resourceId: string,
-  credentials: Credentials
+  connectionConfig: ConnectionConfig,
+  credentials: Credentials,
 ) {
   console.log(`[CSV→Parquet] Starting conversion for: ${resourceId}`);
 
@@ -55,12 +57,11 @@ export async function convertCsvToParquet(
     if (credentials.SessionToken) {
       await conn.query(`SET s3_session_token='${credentials.SessionToken}'`);
     }
-    const AWS_REGION = "eu-central-1";
-    await conn.query(`SET s3_region='${AWS_REGION}'`);
+    await conn.query(`SET s3_region='${connectionConfig.region ?? "eu-central-1"}'`);
 
     // Write to Parquet with WKB geometry
-    const s3Uri = toS3Uri(resourceId);
-    const parquetDestination = `${s3Uri}.parquet`;
+    const { pathName } = parseResourceId(resourceId);
+    const parquetDestination = `s3://${connectionConfig.bucketName}/${pathName}.parquet`;
 
     console.log(
       `[CSV→Parquet] Writing to S3 as Parquet (ZSTD compression, 500k row groups)...`

--- a/app/utils/db/convertCsvToParquet.ts
+++ b/app/utils/db/convertCsvToParquet.ts
@@ -1,4 +1,3 @@
-import { Credentials } from "@aws-sdk/client-sts";
 import {
   getJsDelivrBundles,
   selectBundle,
@@ -9,14 +8,9 @@ import {
 
 import { getUint8ArrayForResourceId } from "./getBlobFromObjectNode";
 import { buildCreateTableQuery } from "./sqlQueries";
-import { parseResourceId } from "../resourceId";
-import { ConnectionConfig } from "~/.generated/client";
+import { resolveResourceId } from "../connectionsStore";
 
-export async function convertCsvToParquet(
-  resourceId: string,
-  connectionConfig: ConnectionConfig,
-  credentials: Credentials,
-) {
+export async function convertCsvToParquet(resourceId: string) {
   console.log(`[CSV→Parquet] Starting conversion for: ${resourceId}`);
 
   let db: AsyncDuckDB | null = null;
@@ -48,20 +42,17 @@ export async function convertCsvToParquet(
     const createTableSQL = buildCreateTableQuery(resourceId, "polygon");
     await conn.query(createTableSQL);
 
+    const { credentials, connectionConfig, s3Uri } = resolveResourceId(resourceId);
+
     await conn.query(`SET s3_access_key_id='${credentials.AccessKeyId}'`);
-
-    await conn.query(
-      `SET s3_secret_access_key='${credentials.SecretAccessKey}'`
-    );
-
+    await conn.query(`SET s3_secret_access_key='${credentials.SecretAccessKey}'`);
     if (credentials.SessionToken) {
       await conn.query(`SET s3_session_token='${credentials.SessionToken}'`);
     }
     await conn.query(`SET s3_region='${connectionConfig.region ?? "eu-central-1"}'`);
 
     // Write to Parquet with WKB geometry
-    const { pathName } = parseResourceId(resourceId);
-    const parquetDestination = `s3://${connectionConfig.bucketName}/${pathName}.parquet`;
+    const parquetDestination = `${s3Uri}.parquet`;
 
     console.log(
       `[CSV→Parquet] Writing to S3 as Parquet (ZSTD compression, 500k row groups)...`

--- a/app/utils/db/getBlobFromObjectNode.ts
+++ b/app/utils/db/getBlobFromObjectNode.ts
@@ -1,4 +1,4 @@
-import { useConnectionsStore } from "../connectionsStore";
+
 import {
   useFileStore,
   type DownloadProgress,
@@ -60,35 +60,12 @@ async function downloadFileWithProgress(
 }
 
 /**
- * Find the connection name for a provider/bucketName pair from the store.
- */
-function findConnectionName(provider: string, bucketName: string): string | undefined {
-  const { connections } = useConnectionsStore.getState();
-  for (const [key, record] of Object.entries(connections)) {
-    if (
-      record.connectionConfig?.provider === provider &&
-      record.connectionConfig?.bucketName === bucketName
-    ) {
-      return key; // key is the connection name
-    }
-  }
-  return undefined;
-}
-
-/**
- * Get presigned URL for a given resourceId
+ * Get presigned URL for a given resourceId.
  */
 async function getPresignedUrl(resourceId: string): Promise<string> {
-  const { provider, bucketName, pathName } = parseResourceId(resourceId);
-  const connectionName = findConnectionName(provider, bucketName);
-
-  if (!connectionName) {
-    throw new Error(`No connection found for ${provider}/${bucketName}`);
-  }
-
+  const { connectionName, pathName } = parseResourceId(resourceId);
   const response = await fetch(`/presign/${connectionName}/${pathName}`);
   const data = await response.json();
-
   return data.url;
 }
 

--- a/app/utils/db/getGeomQuery.ts
+++ b/app/utils/db/getGeomQuery.ts
@@ -1,7 +1,6 @@
 import { type TileIndex } from "node_modules/@deck.gl/geo-layers/dist/tileset-2d/types";
 
 import { getTileBoundingBox } from "./getTileBoundingBox";
-import { toS3Uri } from "../resourceId";
 
 export const isPointMode = (z: number): boolean => z < -2;
 
@@ -25,50 +24,40 @@ function buildBitmaskExpression(markerColumns: string[]): string {
 }
 
 /**
- * Get geometries query based on zoom level
- * @param resourceId - Resource identifier (provider/bucketName/pathName)
+ * Get geometries query based on zoom level.
+ * @param s3Uri - S3 URI for the parquet file (s3://bucketName/pathName)
  * @param markerColumns - ALL marker column names from the dataset (not just enabled ones)
  */
 export function getGeomQuery(
-  resourceId: string,
+  s3Uri: string,
   tileIndex: TileIndex,
-  markerColumns: string[] = []
+  markerColumns: string[] = [],
 ): string {
   const [minX, minY, maxX, maxY] = getTileBoundingBox(tileIndex);
   const bitmaskExpression = buildBitmaskExpression(markerColumns);
 
-  const getPoints = (resourceId: string) => {
-    const s3Uri = toS3Uri(resourceId);
-    return /*sql*/ `
-      SELECT
-        object as id,
-        x,
-        y,
-        ${bitmaskExpression} AS marker_bitmask
-      FROM read_parquet('${s3Uri}')
-      WHERE x BETWEEN ${minX} AND ${maxX}
-        AND y BETWEEN ${minY} AND ${maxY}
-    `;
-  };
-
-  const getPolygons = (resourceId: string) => {
-    const s3Uri = toS3Uri(resourceId);
-    return /*sql*/ `
-      SELECT
-        object as id,
-        ST_AsWKB(ST_GeomFromText(geom)) as geom, -- Convert WKT → GEOMETRY → WKB binary
-        x,
-        y,
-        ${bitmaskExpression} AS marker_bitmask
-      FROM read_parquet('${s3Uri}')
-      WHERE x BETWEEN ${minX} AND ${maxX}
-        AND y BETWEEN ${minY} AND ${maxY}
-    `;
-  };
-
   if (isPointMode(tileIndex.z)) {
-    return getPoints(resourceId);
+    return /*sql*/ `
+      SELECT
+        object as id,
+        x,
+        y,
+        ${bitmaskExpression} AS marker_bitmask
+      FROM read_parquet('${s3Uri}')
+      WHERE x BETWEEN ${minX} AND ${maxX}
+        AND y BETWEEN ${minY} AND ${maxY}
+    `;
   }
 
-  return getPolygons(resourceId);
+  return /*sql*/ `
+    SELECT
+      object as id,
+      ST_AsWKB(ST_GeomFromText(geom)) as geom, -- Convert WKT → GEOMETRY → WKB binary
+      x,
+      y,
+      ${bitmaskExpression} AS marker_bitmask
+    FROM read_parquet('${s3Uri}')
+    WHERE x BETWEEN ${minX} AND ${maxX}
+      AND y BETWEEN ${minY} AND ${maxY}
+  `;
 }

--- a/app/utils/db/getMarkerInfoWasm.ts
+++ b/app/utils/db/getMarkerInfoWasm.ts
@@ -1,7 +1,7 @@
 import { Credentials } from "@aws-sdk/client-sts";
 
 import { createDatabase } from "./createDatabase";
-import { toS3Uri } from "../resourceId";
+import { parseResourceId } from "../resourceId";
 import { ConnectionConfig } from "~/.generated/client";
 import { MarkerInfo } from "~/components/.client/ImageViewer/components/OverlaysController/getOverlayState";
 
@@ -14,7 +14,7 @@ import { MarkerInfo } from "~/components/.client/ImageViewer/components/Overlays
 export async function getMarkerInfoWasm(
   resourceId: string,
   credentials: Credentials,
-  connectionConfig?: ConnectionConfig | null,
+  connectionConfig: ConnectionConfig,
 ): Promise<MarkerInfo> {
   const connection = await createDatabase(
     resourceId,
@@ -23,7 +23,8 @@ export async function getMarkerInfoWasm(
   );
 
   try {
-    const parquetPath = toS3Uri(resourceId);
+    const { pathName } = parseResourceId(resourceId);
+    const parquetPath = `s3://${connectionConfig.bucketName}/${pathName}`;
 
     // Select and sum all marker columns
     const countResult = await connection.query(/*sql*/ `

--- a/app/utils/db/getMarkerInfoWasm.ts
+++ b/app/utils/db/getMarkerInfoWasm.ts
@@ -1,41 +1,25 @@
-import { Credentials } from "@aws-sdk/client-sts";
-
 import { createDatabase } from "./createDatabase";
-import { parseResourceId } from "../resourceId";
-import { ConnectionConfig } from "~/.generated/client";
+import { resolveResourceId } from "../connectionsStore";
 import { MarkerInfo } from "~/components/.client/ImageViewer/components/OverlaysController/getOverlayState";
 
 /**
  * Extract marker information from DuckDB-WASM database.
- * @param resourceId - S3 resource identifier (bucketName/pathName)
- * @param credentials - AWS credentials with access to the S3 bucket
- * @param connectionConfig - Optional bucket configuration for S3-compatible services
  */
 export async function getMarkerInfoWasm(
   resourceId: string,
-  credentials: Credentials,
-  connectionConfig: ConnectionConfig,
 ): Promise<MarkerInfo> {
-  const connection = await createDatabase(
-    resourceId,
-    credentials,
-    connectionConfig,
-  );
+  const { credentials, connectionConfig, s3Uri } = resolveResourceId(resourceId);
+  const connection = await createDatabase(resourceId, credentials, connectionConfig);
 
   try {
-    const { pathName } = parseResourceId(resourceId);
-    const parquetPath = `s3://${connectionConfig.bucketName}/${pathName}`;
-
-    // Select and sum all marker columns
     const countResult = await connection.query(/*sql*/ `
       SELECT SUM(COLUMNS('marker_positive_.*'))
-      FROM read_parquet('${parquetPath}')
+      FROM read_parquet('${s3Uri}')
     `);
 
     const row = countResult.toArray()[0] as Record<string, bigint>;
     const markerInfo: Record<string, { count: number }> = {};
 
-    // Column names are preserved in the result
     for (const [column, value] of Object.entries(row)) {
       markerInfo[column] = { count: Number(value || 0) };
     }

--- a/app/utils/db/getTileDataWasm.ts
+++ b/app/utils/db/getTileDataWasm.ts
@@ -1,10 +1,8 @@
-import { Credentials } from "@aws-sdk/client-sts";
 import { type Table } from "apache-arrow";
 
 import { createDatabase } from "./createDatabase";
 import { getGeomQuery } from "./getGeomQuery";
-import { parseResourceId } from "../resourceId";
-import { ConnectionConfig } from "~/.generated/client";
+import { resolveResourceId } from "../connectionsStore";
 
 interface TileIndex {
   z: number;
@@ -18,28 +16,16 @@ export interface PointRow extends Record<string, unknown> {
 }
 
 /**
- * Fetch tile data from DuckDB-WASM database on S3
- * @param resourceId - S3 resource identifier (bucketName/pathName)
- * @param tileIndex - Tile index (z, x, y)
- * @param credentials - AWS credentials with access to the S3 bucket
- * @param markerColumns - Optional list of marker columns to include
- * @param connectionConfig - Optional bucket configuration for S3-compatible services
+ * Fetch tile data from DuckDB-WASM database on S3.
  */
 export async function getTileDataWasm(
   resourceId: string,
   tileIndex: TileIndex,
-  credentials: Credentials,
   markerColumns: string[] = [],
-  connectionConfig: ConnectionConfig,
 ): Promise<Table | null> {
   try {
-    const connection = await createDatabase(
-      resourceId,
-      credentials,
-      connectionConfig,
-    );
-    const { pathName } = parseResourceId(resourceId);
-    const s3Uri = `s3://${connectionConfig.bucketName}/${pathName}`;
+    const { credentials, connectionConfig, s3Uri } = resolveResourceId(resourceId);
+    const connection = await createDatabase(resourceId, credentials, connectionConfig);
     const tileQuery = getGeomQuery(s3Uri, tileIndex, markerColumns);
     const arrowTable = await connection.query(tileQuery);
 

--- a/app/utils/db/getTileDataWasm.ts
+++ b/app/utils/db/getTileDataWasm.ts
@@ -3,6 +3,7 @@ import { type Table } from "apache-arrow";
 
 import { createDatabase } from "./createDatabase";
 import { getGeomQuery } from "./getGeomQuery";
+import { parseResourceId } from "../resourceId";
 import { ConnectionConfig } from "~/.generated/client";
 
 interface TileIndex {
@@ -29,7 +30,7 @@ export async function getTileDataWasm(
   tileIndex: TileIndex,
   credentials: Credentials,
   markerColumns: string[] = [],
-  connectionConfig?: ConnectionConfig | null,
+  connectionConfig: ConnectionConfig,
 ): Promise<Table | null> {
   try {
     const connection = await createDatabase(
@@ -37,7 +38,9 @@ export async function getTileDataWasm(
       credentials,
       connectionConfig,
     );
-    const tileQuery = getGeomQuery(resourceId, tileIndex, markerColumns);
+    const { pathName } = parseResourceId(resourceId);
+    const s3Uri = `s3://${connectionConfig.bucketName}/${pathName}`;
+    const tileQuery = getGeomQuery(s3Uri, tileIndex, markerColumns);
     const arrowTable = await connection.query(tileQuery);
 
     if (arrowTable.numRows === 0) {

--- a/app/utils/resourceId.ts
+++ b/app/utils/resourceId.ts
@@ -1,69 +1,36 @@
 export interface ResourceIdParts {
-  provider: string;
-  bucketName: string;
+  connectionName: string;
   pathName: string;
 }
 
 /**
- * Creates a composite resource identifier for an S3 object.
- * Format: "provider/bucketName/pathName"
- */
-export function createResourceId(
-  provider: string,
-  bucketName: string,
-  pathName = "",
-): string {
-  return `${provider}/${bucketName}/${pathName}`;
-}
-
-/**
- * Parses a resourceId into its constituent parts.
+ * Parses a resourceId (`connectionName/pathName`) into its parts.
  * @throws Error if resourceId is malformed
  */
 export function parseResourceId(resourceId: string): ResourceIdParts {
-  const firstSlashIndex = resourceId.indexOf("/");
-  const secondSlashIndex = resourceId.indexOf("/", firstSlashIndex + 1);
-
-  if (firstSlashIndex === -1 || secondSlashIndex === -1) {
+  const slashIndex = resourceId.indexOf("/");
+  if (slashIndex === -1) {
     throw new Error(
-      `Invalid resourceId: "${resourceId}" - expected format provider/bucketName/pathName`,
+      `Invalid resourceId: "${resourceId}" — expected format connectionName/pathName`,
     );
   }
 
-  const provider = resourceId.slice(0, firstSlashIndex);
-  const bucketName = resourceId.slice(firstSlashIndex + 1, secondSlashIndex);
-  const pathName = resourceId.slice(secondSlashIndex + 1);
+  const connectionName = resourceId.slice(0, slashIndex);
+  const pathName = resourceId.slice(slashIndex + 1);
 
-  if (!provider) {
-    throw new Error(`Invalid resourceId: "${resourceId}" - empty provider`);
+  if (!connectionName) {
+    throw new Error(
+      `Invalid resourceId: "${resourceId}" — empty connectionName`,
+    );
   }
 
-  if (!bucketName) {
-    throw new Error(`Invalid resourceId: "${resourceId}" - empty bucket name`);
-  }
-
-  return { provider, bucketName, pathName };
+  return { connectionName, pathName };
 }
 
-/** Extracts the bucket name from a resourceId. */
-export const getBucketFromResourceId = (resourceId: string): string =>
-  parseResourceId(resourceId).bucketName;
-
-/** Extracts the path name from a resourceId. */
-export const getPathFromResourceId = (resourceId: string): string =>
-  parseResourceId(resourceId).pathName;
-
-/** Extracts the provider from a resourceId. */
-export const getProviderFromResourceId = (resourceId: string): string =>
-  parseResourceId(resourceId).provider;
-
-/**
- * Converts a resourceId to an S3 URI.
- * Format: "s3://bucketName/pathName"
- */
-export function toS3Uri(resourceId: string): string {
-  const { bucketName, pathName } = parseResourceId(resourceId);
-  return `s3://${bucketName}/${pathName}`;
+/** Returns the file name (last path segment) from a resourceId. */
+export function getFileName(resourceId: string): string {
+  const { pathName } = parseResourceId(resourceId);
+  return pathName.split("/").pop() || pathName;
 }
 
 /**
@@ -76,17 +43,6 @@ export function toIndexS3Key(prefix = ""): string {
   return normalized
     ? `${normalized}/.cytario/index.parquet`
     : ".cytario/index.parquet";
-}
-
-/** Returns the file name (last path segment) from a resourceId. */
-export function getFileName(resourceId: string): string {
-  const { pathName } = parseResourceId(resourceId);
-  return pathName.split("/").pop() || pathName;
-}
-
-/** Returns true if the resourceId's path matches the given extension pattern. */
-export function matchesExtension(resourceId: string, pattern: RegExp): boolean {
-  return pattern.test(resourceId);
 }
 
 /** Builds a routable URL path from a connection name and an object path. */

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -4,8 +4,9 @@
  * Creates test fixtures in a fresh database. Runs automatically after
  * `prisma db push` or explicitly via `npx prisma db seed`.
  *
- * The ConnectionConfig uses ownerScope "cytario" so it's visible to any user
- * in the /cytario group (which includes both e2e-test and e2e-admin users).
+ * Both connections point to the same bucket (slashm-ultivue-exchange).
+ * The prefixed connection tests prefix-based directory listing without
+ * requiring a separate bucket or cross-bucket auth setup.
  */
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
@@ -16,25 +17,43 @@ const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 const prisma = new PrismaClient({ adapter: new PrismaPg(pool) });
 
 const TEST_CONNECTION_NAME = process.env.E2E_CONNECTION_NAME || "Exchange";
+const TEST_PREFIX_CONNECTION_NAME =
+  process.env.E2E_PREFIX_CONNECTION_NAME || "Exchange-prefixed";
+
+const SHARED_BUCKET = {
+  ownerScope: "cytario",
+  createdBy: "e2e-seed",
+  bucketName: "slashm-ultivue-exchange",
+  provider: "aws" as const,
+  endpoint: "https://s3.eu-central-1.amazonaws.com",
+  roleArn: "arn:aws:iam::727043715722:role/keycloack-aws-test-iam-role",
+  region: "eu-central-1",
+};
 
 async function seed() {
   await prisma.connectionConfig.upsert({
     where: { name: TEST_CONNECTION_NAME },
     update: {},
     create: {
+      ...SHARED_BUCKET,
       name: TEST_CONNECTION_NAME,
-      ownerScope: "cytario",
-      createdBy: "e2e-seed",
-      bucketName: "slashm-ultivue-exchange",
-      provider: "aws",
-      endpoint: "https://s3.eu-central-1.amazonaws.com",
-      roleArn: "arn:aws:iam::727043715722:role/keycloack-aws-test-iam-role",
-      region: "eu-central-1",
       prefix: "",
     },
   });
 
-  console.log(`Seeded ConnectionConfig: "${TEST_CONNECTION_NAME}"`);
+  await prisma.connectionConfig.upsert({
+    where: { name: TEST_PREFIX_CONNECTION_NAME },
+    update: {},
+    create: {
+      ...SHARED_BUCKET,
+      name: TEST_PREFIX_CONNECTION_NAME,
+      prefix: "Ascent Pharma Group",
+    },
+  });
+
+  console.log(
+    `Seeded ConnectionConfig: "${TEST_CONNECTION_NAME}", "${TEST_PREFIX_CONNECTION_NAME}"`,
+  );
 }
 
 seed()


### PR DESCRIPTION
## Summary

Replaces the `provider/bucketName/path` resource ID format with `connectionName/pathName` — the same string as `TreeNode.id`. Introduces `resolveResourceId()` as a single function that returns credentials, config, S3 key, and URI for any resource.

**Why this matters:**

- **Performance**: O(n) connection store scans replaced by direct `connections[connectionName]` lookup
- **Dev experience**: 8 call sites that each repeated a 3-step parse→lookup→prefix pattern now call one function. DB utilities (`getParquetSchema`, `getParquetRows`, `getTileDataWasm`, etc.) take just a `resourceId` instead of `(resourceId, credentials, connectionConfig)`.
- **Bug fixes found during refactor**: S3 URIs were silently dropping the connection prefix; presign route wasn't prepending prefix server-side; `convertCsvToParquet` had a hardcoded `eu-central-1` region.
- **Foundation for C-148**: the `connectionName/pathName` format is the stable identifier that C-148's single-root-per-connection tree pattern will build on.

**Migration**: ViewerStore v1→v2 clears persisted overlay keys from the old format (SRS-CY-33306). Users see overlays reset once; all other viewer state is preserved.

## Test coverage

- 1085 unit tests (119 files), including dedicated tests for `parseResourceId`, `getGeomQuery`, `getTileDataWasm`, and ViewerStore migration
- 41 E2E tests covering viewer rendering, DataGrid parquet loading, prefix connection browsing, overlay picker, state persistence, and the v1→v2 migration path
- Single-bucket test infrastructure (Exchange + Exchange-prefixed) eliminates cross-bucket auth dependencies in CI

## Companion PR

- **cytario-docs**: [cytario/cytario-docs#21](https://github.com/cytario/cytario-docs/pull/21) — E2E specs, SDS + architecture docs, CI workflow improvements

## Ticket

[C-149](https://app.plane.so/cytario/browse/C-149/)