### PR TITLE
fix: eliminate duplicate loader calls on objects route (C-153)

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -40,7 +40,7 @@ const appRoutes = [
   },
   {
     path: "/connections/:name/*",
-    file: "routes/objects.route.tsx",
+    file: "routes/objects/objects.route.tsx",
   },
 ];
 

--- a/app/routes/objects/__tests__/objects.route.test.tsx
+++ b/app/routes/objects/__tests__/objects.route.test.tsx
@@ -3,7 +3,7 @@ import { ActionFunctionArgs, createRoutesStub } from "react-router";
 import { describe, expect, test, vi } from "vitest";
 
 import { getCrumbs } from "~/components/Breadcrumbs/getCrumbs";
-import ObjectsRoute, { handle } from "~/routes/objects.route";
+import ObjectsRoute, { handle } from "~/routes/objects/objects.route";
 import mock from "~/utils/__tests__/__mocks__";
 
 vi.mock("~/.server/auth/authMiddleware", () => ({

--- a/app/routes/objects/objects.loader.ts
+++ b/app/routes/objects/objects.loader.ts
@@ -1,0 +1,147 @@
+import { _Object } from "@aws-sdk/client-s3";
+import { Credentials } from "@aws-sdk/client-sts";
+import { type LoaderFunctionArgs } from "react-router";
+
+import { ConnectionConfig } from "~/.generated/client";
+import { authContext } from "~/.server/auth/authMiddleware";
+import { getS3Client } from "~/.server/auth/getS3Client";
+import {
+  buildDirectoryTree,
+  TreeNode,
+} from "~/components/DirectoryView/buildDirectoryTree";
+import { type NotificationInput } from "~/components/Notification/Notification.store";
+import { getConnection } from "~/routes/connections/connections.server";
+import { getObjects } from "~/utils/getObjects";
+import { getName, getPrefix } from "~/utils/pathUtils";
+import { checkIsPinnedPath } from "~/utils/pinnedPaths.server";
+import { isZarrPath } from "~/utils/zarrUtils";
+
+export interface BucketRouteLoaderResponse {
+  connectionName: string;
+  nodes: TreeNode[];
+  bucketName: string;
+  /** URL path segment after /connections/:name/ (relative to connection root) */
+  urlPath: string;
+  /** Full S3 key (connection prefix + urlPath) */
+  pathName: string;
+  name: string;
+  /** True when navigating to a single viewable file (not a directory listing) */
+  isSingleFile?: boolean;
+  notification?: NotificationInput;
+  credentials: Credentials;
+  connectionConfig: ConnectionConfig;
+  isPinned: boolean;
+}
+
+export const loader = async ({
+  params,
+  context,
+}: LoaderFunctionArgs): Promise<BucketRouteLoaderResponse> => {
+  const { user, credentials: bucketsCredentials } = context.get(authContext);
+  const { name: connectionName } = params;
+
+  if (!connectionName) throw new Error("Connection name is required");
+
+  const connectionConfig = await getConnection(user, connectionName);
+  if (!connectionConfig) {
+    throw new Error("Connection configuration not found");
+  }
+
+  const { bucketName } = connectionConfig;
+
+  const credentials = bucketsCredentials[bucketName];
+  if (!credentials) throw new Error(`No credentials for bucket: ${bucketName}`);
+
+  const urlPath = params["*"] ?? "";
+  const connPrefix = connectionConfig.prefix?.replace(/\/$/, "") ?? "";
+  const pathName = connPrefix
+    ? urlPath
+      ? `${connPrefix}/${urlPath}`
+      : connPrefix
+    : urlPath;
+  const prefix = getPrefix(pathName);
+  const name = getName(pathName, bucketName);
+
+  const isPinned = await checkIsPinnedPath(user.sub, connectionName, urlPath);
+
+  try {
+    const s3Client = await getS3Client(connectionConfig, credentials, user.sub);
+
+    // Check for zarr before listing objects — zarr directories can contain
+    // thousands of chunk files, so we skip the expensive ListObjects call.
+    if (isZarrPath(pathName)) {
+      return {
+        credentials,
+        connectionConfig,
+        isPinned,
+        name,
+        nodes: [],
+        bucketName,
+        connectionName,
+        pathName,
+        urlPath,
+        isSingleFile: true,
+      };
+    }
+
+    const objects: Readonly<_Object>[] = await getObjects(
+      connectionConfig,
+      s3Client,
+      undefined,
+      prefix,
+    );
+
+    if (objects.length > 0) {
+      const nodes = buildDirectoryTree(
+        objects,
+        connectionName,
+        prefix,
+        urlPath,
+      );
+
+      return {
+        connectionName,
+        credentials,
+        connectionConfig,
+        name,
+        nodes,
+        bucketName,
+        urlPath,
+        pathName,
+        isPinned,
+      };
+    }
+
+    // Single file — viewer or unsupported format
+    return {
+      connectionName,
+      credentials,
+      connectionConfig,
+      name,
+      nodes: [],
+      bucketName,
+      urlPath,
+      pathName,
+      isSingleFile: true,
+      isPinned,
+    };
+  } catch (error) {
+    console.error("Error in objects loader:", error);
+    return {
+      connectionName,
+      credentials,
+      connectionConfig,
+      name,
+      nodes: [],
+      bucketName,
+      urlPath,
+      pathName,
+      isPinned,
+      notification: {
+        message:
+          "We couldn't load the objects for this bucket. Please check your connection or try again later.",
+        status: "error",
+      },
+    };
+  }
+};

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -1,50 +1,47 @@
-import { _Object } from "@aws-sdk/client-s3";
-import { Credentials } from "@aws-sdk/client-sts";
 import { Button, EmptyState } from "@cytario/design";
 import { Ban, Bookmark, BookmarkCheck, Download } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect } from "react";
 import {
-  type LoaderFunctionArgs,
   type MetaFunction,
   useFetcher,
   useLoaderData,
   useNavigate,
 } from "react-router";
 
-import { ConnectionConfig } from "~/.generated/client";
-import { authContext, authMiddleware } from "~/.server/auth/authMiddleware";
-import { getS3Client } from "~/.server/auth/getS3Client";
+import {
+  type BucketRouteLoaderResponse,
+  loader,
+} from "./objects.loader";
+import { authMiddleware } from "~/.server/auth/authMiddleware";
 import { requestDurationMiddleware } from "~/.server/requestDurationMiddleware";
 import { getCrumbs } from "~/components/Breadcrumbs/getCrumbs";
 import { ClientOnly } from "~/components/ClientOnly";
 import { DataGrid } from "~/components/DataGrid/DataGrid";
 import {
-  buildDirectoryTree,
   computeDirectoryLastModified,
   computeDirectorySize,
-  TreeNode,
 } from "~/components/DirectoryView/buildDirectoryTree";
 import { DirectoryView } from "~/components/DirectoryView/DirectoryView";
 import { ShowFiltersToggle } from "~/components/DirectoryView/ShowFiltersToggle";
 import { useLayoutStore } from "~/components/DirectoryView/useLayoutStore";
 import { ViewModeToggle } from "~/components/DirectoryView/ViewModeToggle";
-import { type NotificationInput } from "~/components/Notification/Notification.store";
 import { useModal } from "~/hooks/useModal";
-import { getConnection } from "~/routes/connections/connections.server";
 import { toastBridge, toToastVariant } from "~/toast-bridge";
 import { select, useConnectionsStore } from "~/utils/connectionsStore";
 import { getFileType } from "~/utils/fileType";
-import { getObjects } from "~/utils/getObjects";
-import { getName, getPrefix } from "~/utils/pathUtils";
-import { checkIsPinnedPath } from "~/utils/pinnedPaths.server";
+import { getName } from "~/utils/pathUtils";
 import { createSignedFetch } from "~/utils/signedFetch";
-import { constructS3Url, isZarrPath } from "~/utils/zarrUtils";
+import { constructS3Url } from "~/utils/zarrUtils";
+
 // Lazy load Viewer to prevent SSR issues with client-only code
 const Viewer = lazy(() =>
   import("~/components/.client/ImageViewer/components/ImageViewer").then(
     (module) => ({ default: module.Viewer }),
   ),
 );
+
+export { loader };
+export type { BucketRouteLoaderResponse };
 
 export const middleware = [requestDurationMiddleware, authMiddleware];
 
@@ -69,136 +66,6 @@ export const handle = {
       dataConnectionPath: basePath,
     });
   },
-};
-
-export interface BucketRouteLoaderResponse {
-  connectionName: string;
-  nodes: TreeNode[];
-  bucketName: string;
-  /** URL path segment after /connections/:name/ (relative to connection root) */
-  urlPath: string;
-  /** Full S3 key (connection prefix + urlPath) */
-  pathName: string;
-  name: string;
-  /** True when navigating to a single viewable file (not a directory listing) */
-  isSingleFile?: boolean;
-  notification?: NotificationInput;
-  credentials: Credentials;
-  connectionConfig: ConnectionConfig;
-  isPinned: boolean;
-}
-
-export const loader = async ({
-  params,
-  context,
-}: LoaderFunctionArgs): Promise<BucketRouteLoaderResponse> => {
-  const { user, credentials: bucketsCredentials } = context.get(authContext);
-  const { name: connectionName } = params;
-
-  if (!connectionName) throw new Error("Connection name is required");
-
-  const connectionConfig = await getConnection(user, connectionName);
-  if (!connectionConfig) {
-    throw new Error("Connection configuration not found");
-  }
-
-  const { bucketName } = connectionConfig;
-
-  const credentials = bucketsCredentials[bucketName];
-  if (!credentials) throw new Error(`No credentials for bucket: ${bucketName}`);
-
-  const urlPath = params["*"] ?? "";
-  const connPrefix = connectionConfig.prefix?.replace(/\/$/, "") ?? "";
-  const pathName = connPrefix
-    ? urlPath
-      ? `${connPrefix}/${urlPath}`
-      : connPrefix
-    : urlPath;
-  const prefix = getPrefix(pathName);
-  const name = getName(pathName, bucketName);
-
-  const isPinned = await checkIsPinnedPath(user.sub, connectionName, urlPath);
-
-  try {
-    const s3Client = await getS3Client(connectionConfig, credentials, user.sub);
-
-    // Check for zarr before listing objects — zarr directories can contain
-    // thousands of chunk files, so we skip the expensive ListObjects call.
-    if (isZarrPath(pathName)) {
-      return {
-        credentials,
-        connectionConfig,
-        isPinned,
-        name,
-        nodes: [],
-        bucketName,
-        connectionName,
-        pathName,
-        urlPath,
-        isSingleFile: true,
-      };
-    }
-
-    const objects: Readonly<_Object>[] = await getObjects(
-      connectionConfig,
-      s3Client,
-      undefined,
-      prefix,
-    );
-
-    if (objects.length > 0) {
-      const nodes = buildDirectoryTree(
-        objects,
-        connectionName,
-        prefix,
-        urlPath,
-      );
-
-      return {
-        connectionName,
-        credentials,
-        connectionConfig,
-        name,
-        nodes,
-        bucketName,
-        urlPath,
-        pathName,
-        isPinned,
-      };
-    }
-
-    // Single file — viewer or unsupported format
-    return {
-      connectionName,
-      credentials,
-      connectionConfig,
-      name,
-      nodes: [],
-      bucketName,
-      urlPath,
-      pathName,
-      isSingleFile: true,
-      isPinned,
-    };
-  } catch (error) {
-    console.error("Error in objects loader:", error);
-    return {
-      connectionName,
-      credentials,
-      connectionConfig,
-      name,
-      nodes: [],
-      bucketName,
-      urlPath,
-      pathName,
-      isPinned,
-      notification: {
-        message:
-          "We couldn't load the objects for this bucket. Please check your connection or try again later.",
-        status: "error",
-      },
-    };
-  }
 };
 
 export default function ObjectsRoute() {

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -3,6 +3,7 @@ import { Ban, Bookmark, BookmarkCheck, Download } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect } from "react";
 import {
   type MetaFunction,
+  type ShouldRevalidateFunction,
   useFetcher,
   useLoaderData,
   useNavigate,
@@ -66,6 +67,22 @@ export const handle = {
       dataConnectionPath: basePath,
     });
   },
+};
+
+/**
+ * Prevent redundant loader revalidation when auxiliary fetchers (e.g.
+ * POST /api/recently-viewed, POST /api/pinned) complete. React Router's
+ * default is to revalidate every active loader after any action, which on
+ * this route fires the loader 1.5-3x per client-side navigation (see
+ * TSPEC-PERF-001 Table 10.2 in cytario-docs). Only revalidate when a form
+ * submission targets this route.
+ */
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  formAction,
+  defaultShouldRevalidate,
+}) => {
+  if (formAction) return defaultShouldRevalidate;
+  return false;
 };
 
 export default function ObjectsRoute() {


### PR DESCRIPTION
## Summary

Adds \`shouldRevalidate\` to the objects route (\`/connections/:name/*\`) so that fetcher actions on auxiliary endpoints — notably the \`POST /api/recently-viewed\` fired from \`ObjectsRoute\`'s own \`useEffect\` on mount, and the \`POST /api/pinned\` from "Pin directory" — no longer trigger a full re-execution of this route's loader.

Also refactors the route file into an \`objects/\` subdirectory with a separate \`objects.loader.ts\`, matching the \`admin/users\` and \`connections\` route conventions.

## Measured impact — before / after (3-run comparison)

Perf harness: TSPEC-PERF-001 in cytario-docs; 20 measured iterations + 1 warmup; GitHub-hosted \`ubuntu-latest\`.

- BEFORE: cytario-web \`main\` (no fix). cytario-docs [run #24667351812](https://github.com/cytario/cytario-docs/actions/runs/24667351812).
- AFTER-1: this branch. cytario-docs [run #24672828416](https://github.com/cytario/cytario-docs/actions/runs/24672828416).
- AFTER-2: this branch, confirmation run. cytario-docs [run #24673891743](https://github.com/cytario/cytario-docs/actions/runs/24673891743).

AFTER-1 looked spectacular (step-3 TTMC 1548 → 365 ms, duplicate ratio 2.00× → 1.00×). AFTER-2, same branch and harness, shows the more sober numbers below. Treat AFTER-2 as representative; AFTER-1 was on the lucky side of the ±25% CI that TSPEC-PERF-001 Section 7.1 already documents for n=20.

### Warm-navigation duplicate-request ratio (median / p95)

| Step | BEFORE | AFTER-2 |
|---|---|---|
| \`/ → /connections\` (connections route, already had shouldRevalidate) | 1.30× / 1.41× | 1.30× / 1.51× |
| \`/connections → /connections/Exchange\` (objects route, destination) | 1.00× / 1.38× | **1.00× / 1.28×** |
| \`/connections/Exchange → subfolder\` (objects route, destination) | **1.53× / 2.00×** | **1.30× / 1.73×** |

**Interpretation**: every step shows a ~1.30× median "noise floor" attributable to asset fetches (icons/images on transition) that the test's \`page.on('request')\` counter catches. That's not the loader bug; it's present on step 1 (which already had \`shouldRevalidate\`) as well.

Before the fix, step 3 sat at **1.53× median** = baseline (1.30×) plus loader-bug duplicates (~0.23×).
After the fix, step 3 drops to **1.30×** — equal to the baseline on step 1. The loader-bug duplicates are gone.

### Warm-navigation TTMC p95 (ms)

| Step | BEFORE | AFTER-2 | Δ |
|---|---:|---:|---:|
| \`/ → /connections\` | 1707 | 1699 | ≈0 (not targeted) |
| \`/connections → /connections/Exchange\` | 1582 | 1342 | **−15%** |
| \`/connections/Exchange → subfolder\` | 1548 | 1345 | **−13%** |

Both warm steps whose destination is the objects route shave ~13–15% p95 latency.

### Cold load

Cold-load numbers (TTFB, TTMC) drift both ways between runs within ±15–25% — consistent with documented p95 variance at n=20 on shared GitHub runners. \`shouldRevalidate\` has no effect on cold/first-visit loads (no fetcher has fired yet), so no signal expected there. Not a regression.

### What this PR does **not** fix

Step 1 (\`/ → /connections\`) still has a 1.30× median duplicate ratio. The connections route already has \`shouldRevalidate\`; the remaining duplicates there come from either the baseline asset-fetch floor or another route in the layout chain (\`recent.route.tsx\`, \`config.route.tsx\`, \`search.route.tsx\` are candidates). Out of scope — separate audit ticket to follow.

## Ticket

[C-153](https://app.plane.so/cytario/browse/C-153/) — Fix shouldRevalidate on objects route — eliminate duplicate loader calls.

## Commits

- \`refactor(objects): split route into objects/ subdirectory\` — pure file moves, no behavioural change.
- \`fix(objects): prevent redundant loader calls via shouldRevalidate (C-153)\` — 17-line actual fix.

## Test plan

- [x] Typecheck (\`npm run typecheck\`) passes.
- [x] Unit tests (\`npx vitest run app/routes/objects\`) pass.
- [x] CI functional E2E (auto-dispatched to cytario-docs main) passes.
- [x] Perf suite run twice on this branch to bound measurement noise; duplicate-ratio and TTMC improvements on the objects-route warm steps confirmed in both runs.