### PR TITLE
fix(s3): use path-style URLs for AWS buckets with dots in the name

### DIFF
--- a/app/utils/__tests__/zarrUtils.test.ts
+++ b/app/utils/__tests__/zarrUtils.test.ts
@@ -257,7 +257,10 @@ describe("constructS3Url", () => {
       );
     });
 
-    test("handles bucket name with dots", () => {
+    test("falls back to path-style for AWS buckets whose name contains dots", () => {
+      // Virtual-hosted style breaks TLS because the wildcard cert
+      // `*.s3.<region>.amazonaws.com` only matches a single DNS label —
+      // matches AWS SDK v3 behaviour for dotted buckets over HTTPS.
       const config = {
         bucketName: "my.bucket.name",
         region: "us-west-2",
@@ -267,7 +270,21 @@ describe("constructS3Url", () => {
       const result = constructS3Url(config, "data.zarr");
 
       expect(result).toBe(
-        "https://my.bucket.name.s3.us-west-2.amazonaws.com/data.zarr",
+        "https://s3.us-west-2.amazonaws.com/my.bucket.name/data.zarr",
+      );
+    });
+
+    test("uses path-style for dotted AWS bucket with explicit amazonaws endpoint", () => {
+      const config = {
+        bucketName: "ultivue.cytario",
+        region: "us-east-1",
+        endpoint: "https://s3.us-east-1.amazonaws.com",
+      };
+
+      const result = constructS3Url(config, "USL-2023-52702-11.ome.tif");
+
+      expect(result).toBe(
+        "https://s3.us-east-1.amazonaws.com/ultivue.cytario/USL-2023-52702-11.ome.tif",
       );
     });
   });

--- a/app/utils/zarrUtils.ts
+++ b/app/utils/zarrUtils.ts
@@ -32,6 +32,13 @@ export function constructS3Url(
   const isAwsEndpoint = !endpoint || /\.amazonaws\.com$/i.test(endpoint);
 
   if (isAwsEndpoint) {
+    // Bucket names containing dots break the TLS wildcard cert
+    // `*.s3.<region>.amazonaws.com` (wildcards match a single DNS label),
+    // so fall back to path-style for dotted buckets — mirrors what the
+    // AWS SDK does automatically.
+    if (bucket.includes(".")) {
+      return `https://s3.${region}.amazonaws.com/${bucket}/${encodedPath}`;
+    }
     return `https://${bucket}.s3.${region}.amazonaws.com/${encodedPath}`;
   }
 


### PR DESCRIPTION
## Description

Buckets whose name contains dots (e.g. `ultivue.cytario`) break virtual-hosted-style S3 access over HTTPS. The URL `https://ultivue.cytario.s3.us-east-1.amazonaws.com/...` is served with AWS's wildcard cert `*.s3.<region>.amazonaws.com`, which only matches a single DNS label — so the browser rejects the TLS handshake with `net::ERR_CERT_COMMON_NAME_INVALID`. Because the preflight `OPTIONS` never completes, the failure surfaces as a blocked CORS request with no response headers.

The regression was masked before the switch to SigV4 signed fetch:
- Presigned URLs were produced by the AWS SDK, which auto-detects dotted buckets and falls back to path-style.
- Simple `GET`s used in `<img>`/`<video>` also didn't trigger a preflight.

`constructS3Url` is hand-rolled and hardcoded virtual-hosted for every AWS endpoint. This PR mirrors the SDK's behaviour: when the bucket name contains a dot and the endpoint is AWS, emit a path-style URL (`https://s3.<region>.amazonaws.com/<bucket>/<key>`).

Dotted buckets created before 2020-09-30 (when path-style was deprecated for new buckets) continue to accept path-style — any dotted bucket in production falls into that window by definition.

### Follow-up (out of scope)

`app/.server/auth/getS3Client.ts` sets `forcePathStyle: !isAwsS3`, so *server-side* AWS operations against dotted buckets may hit the same TLS issue. Worth a separate PR.

## Related Issue

Slack thread: `ERR_CERT_COMMON_NAME_INVALID` on `ultivue.cytario` bucket.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed