### PR TITLE
fix(objects): keep absolute pathName for viewer URL (C-161 follow-up)

### DIFF
--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -31,7 +31,7 @@ import { toastBridge, toToastVariant } from "~/toast-bridge";
 import { select, useConnectionsStore } from "~/utils/connectionsStore";
 import { getFileType } from "~/utils/fileType";
 import { getName } from "~/utils/pathUtils";
-import { buildHttpsUrl } from "~/utils/resourceId";
+import { constructS3Url } from "~/utils/resourceId";
 import { createSignedFetch } from "~/utils/signedFetch";
 
 // Lazy load Viewer to prevent SSR issues with client-only code
@@ -255,7 +255,11 @@ export default function ObjectsRoute() {
       fileType === "TIFF" || fileType === "OME-TIFF" || fileType === "OME-Zarr";
 
     if (isViewableImage) {
-      const s3Url = buildHttpsUrl(connectionConfig, pathName);
+      // `pathName` from objects.loader is ALREADY the full S3 key (connection
+      // prefix joined with the URL splat server-side — see objects.loader.ts).
+      // Use `constructS3Url` directly; `buildHttpsUrl` would re-join the
+      // prefix and produce a double-prefixed URL.
+      const s3Url = constructS3Url(connectionConfig, pathName);
       const signedFetch = createSignedFetch(
         () =>
           useConnectionsStore.getState().connections[connectionName]


### PR DESCRIPTION
## Summary

Follow-up to #76 — reverts one buggy hunk that slipped through review.

The merged C-161 fix swapped `constructS3Url(config, pathName)` → `buildHttpsUrl(config, pathName)` in the single-file viewer route. That was wrong: the `objects.loader` already joins the connection prefix into `pathName` server-side ([objects.loader.ts:55-61](../blob/main/app/routes/objects/objects.loader.ts#L55-L61)), so the value is already absolute. `buildHttpsUrl` then re-joins the prefix and produces a double-prefixed URL.

## Observed on prod

Opening a file in a connection that has a non-empty `prefix` (e.g. `Repository Slash-m Exchange` where alias == prefix):

```
GET .../Repository%20Slash-m%20Exchange/Repository%20Slash-m%20Exchange/All/USL-....ome.tif  →  404
```

(Prefix segment duplicated.)

## Fix

Restore `constructS3Url(config, pathName)` for this call site — matches v1.52.1 pre-C-161 behavior for the viewer route. Added a comment explaining why `buildHttpsUrl` is wrong here, to prevent the mistake from recurring.

The C-161 URL-construction bug lived only in `DirectoryViewGrid.FileCardGridItem`'s preview logic (which is still fixed by #76). This route was never broken pre-#76.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npx vitest run` — 1099/1099 pass
- [ ] Manual: open a TIFF in a prefixed connection on dev — URL should contain the prefix exactly once

## Remaining prod issue

A separate symptom (connection card previews showing "Preview unavailable" on prod despite successful 206 fetches + React #418 in console) is **not** addressed by this PR. Tracked in [C-162](https://app.plane.so/cytario/browse/C-162/) — hypothesis downgraded after local prod build failed to reproduce.