### PR TITLE
fix(s3): always use path-style URLs [C-164]

### DIFF
--- a/app/components/DashboardSection.tsx
+++ b/app/components/DashboardSection.tsx
@@ -31,6 +31,7 @@ export function DashboardSection({
 
   const visible = nodes.slice(0, maxItems);
   const hasMore = nodes.length > maxItems;
+  const kind = nodes[0].type === "bucket" ? "connections" : "entries";
 
   return (
     <Section flush>
@@ -52,7 +53,7 @@ export function DashboardSection({
         {viewMode === "list" ? (
           <DirectoryViewTableDirectory nodes={visible} />
         ) : (
-          <DirectoryViewGrid nodes={visible} viewMode={viewMode} kind="entries" />
+          <DirectoryViewGrid nodes={visible} viewMode={viewMode} kind={kind} />
         )}
       </Container>
     </Section>

--- a/app/utils/__tests__/resourceId.test.ts
+++ b/app/utils/__tests__/resourceId.test.ts
@@ -89,7 +89,7 @@ describe("buildHttpsUrl", () => {
     };
 
     expect(buildHttpsUrl(config, "USL-2022-42307-42.ome.tif")).toBe(
-      "https://my-bucket.s3.eu-central-1.amazonaws.com/vericura/USL-2022-42307-42.ome.tif",
+      "https://s3.eu-central-1.amazonaws.com/my-bucket/vericura/USL-2022-42307-42.ome.tif",
     );
   });
 
@@ -102,7 +102,7 @@ describe("buildHttpsUrl", () => {
     };
 
     expect(buildHttpsUrl(config, "file.ome.tif")).toBe(
-      "https://bucket.s3.eu-central-1.amazonaws.com/data/file.ome.tif",
+      "https://s3.eu-central-1.amazonaws.com/bucket/data/file.ome.tif",
     );
   });
 
@@ -115,7 +115,7 @@ describe("buildHttpsUrl", () => {
     };
 
     expect(buildHttpsUrl(config, "file.ome.tif")).toBe(
-      "https://bucket.s3.eu-central-1.amazonaws.com/file.ome.tif",
+      "https://s3.eu-central-1.amazonaws.com/bucket/file.ome.tif",
     );
   });
 
@@ -135,7 +135,7 @@ describe("buildHttpsUrl", () => {
 
 describe("constructS3Url", () => {
   describe("AWS S3 URLs", () => {
-    test("constructs virtual-hosted style URL with region", () => {
+    test("constructs path-style URL with region", () => {
       const config = {
         bucketName: "my-bucket",
         region: "us-west-2",
@@ -145,7 +145,7 @@ describe("constructS3Url", () => {
       const result = constructS3Url(config, "images/sample.zarr");
 
       expect(result).toBe(
-        "https://my-bucket.s3.us-west-2.amazonaws.com/images/sample.zarr",
+        "https://s3.us-west-2.amazonaws.com/my-bucket/images/sample.zarr",
       );
     });
 
@@ -159,7 +159,7 @@ describe("constructS3Url", () => {
       const result = constructS3Url(config, "data.zarr");
 
       expect(result).toBe(
-        "https://my-bucket.s3.eu-central-1.amazonaws.com/data.zarr",
+        "https://s3.eu-central-1.amazonaws.com/my-bucket/data.zarr",
       );
     });
 
@@ -173,7 +173,7 @@ describe("constructS3Url", () => {
       const result = constructS3Url(config, "images/sample.zarr/");
 
       expect(result).toBe(
-        "https://bucket.s3.eu-west-1.amazonaws.com/images/sample.zarr/",
+        "https://s3.eu-west-1.amazonaws.com/bucket/images/sample.zarr/",
       );
     });
   });
@@ -253,7 +253,7 @@ describe("constructS3Url", () => {
 
       const result = constructS3Url(config, "");
 
-      expect(result).toBe("https://bucket.s3.us-east-1.amazonaws.com/");
+      expect(result).toBe("https://s3.us-east-1.amazonaws.com/bucket/");
     });
 
     test("handles deeply nested path", () => {
@@ -270,10 +270,10 @@ describe("constructS3Url", () => {
       );
     });
 
-    test("falls back to path-style for AWS buckets whose name contains dots", () => {
-      // Virtual-hosted style breaks TLS because the wildcard cert
-      // `*.s3.<region>.amazonaws.com` only matches a single DNS label —
-      // matches AWS SDK v3 behaviour for dotted buckets over HTTPS.
+    test("handles AWS buckets whose name contains dots", () => {
+      // Dotted buckets must not end up in a vhost URL because the wildcard
+      // TLS cert `*.s3.<region>.amazonaws.com` only matches one DNS label.
+      // Path-style (the only style constructS3Url emits) sidesteps this.
       const config = {
         bucketName: "my.bucket.name",
         region: "us-west-2",

--- a/app/utils/connectionsStore/__tests__/useConnectionsStore.test.ts
+++ b/app/utils/connectionsStore/__tests__/useConnectionsStore.test.ts
@@ -281,7 +281,7 @@ describe("useConnectionsStore", () => {
       );
 
       expect(url).toBe(
-        "https://my-bucket.s3.eu-central-1.amazonaws.com/vericura/USL-2022-42307-42.ome.tif",
+        "https://s3.eu-central-1.amazonaws.com/my-bucket/vericura/USL-2022-42307-42.ome.tif",
       );
     });
 
@@ -303,7 +303,7 @@ describe("useConnectionsStore", () => {
       );
 
       expect(url).toBe(
-        "https://my-bucket.s3.eu-central-1.amazonaws.com/file.ome.tif",
+        "https://s3.eu-central-1.amazonaws.com/my-bucket/file.ome.tif",
       );
     });
 

--- a/app/utils/db/__tests__/createDatabase.test.ts
+++ b/app/utils/db/__tests__/createDatabase.test.ts
@@ -6,11 +6,7 @@ import {
   ConsoleLogger,
 } from "@duckdb/duckdb-wasm";
 
-import {
-  getDuckDbUrlStyle,
-  shouldUseSSL,
-  getEndpointHostname,
-} from "../../s3Provider";
+import { shouldUseSSL, getEndpointHostname } from "../../s3Provider";
 import { createDatabase } from "../createDatabase";
 import mock from "~/utils/__tests__/__mocks__";
 
@@ -23,7 +19,6 @@ vi.mock("@duckdb/duckdb-wasm", () => ({
 }));
 
 vi.mock("../../s3Provider", () => ({
-  getDuckDbUrlStyle: vi.fn(),
   shouldUseSSL: vi.fn(),
   getEndpointHostname: vi.fn(),
 }));
@@ -58,7 +53,6 @@ describe("createDatabase", () => {
     mockQuery.mockResolvedValue({});
 
     // Setup s3Provider mocks
-    vi.mocked(getDuckDbUrlStyle).mockReturnValue("vhost");
     vi.mocked(shouldUseSSL).mockReturnValue(true);
     vi.mocked(getEndpointHostname).mockReturnValue("s3.amazonaws.com");
   });
@@ -116,7 +110,7 @@ describe("createDatabase", () => {
     expect(mockQuery).toHaveBeenCalledWith(
       "SET s3_endpoint='s3.amazonaws.com'",
     );
-    expect(mockQuery).toHaveBeenCalledWith("SET s3_url_style='vhost'");
+    expect(mockQuery).toHaveBeenCalledWith("SET s3_url_style='path'");
     expect(mockQuery).toHaveBeenCalledWith("SET s3_use_ssl=true");
   });
 
@@ -133,7 +127,6 @@ describe("createDatabase", () => {
       endpoint: "https://minio.local:9000",
     });
     vi.mocked(getEndpointHostname).mockReturnValue("minio.local:9000");
-    vi.mocked(getDuckDbUrlStyle).mockReturnValue("path");
     vi.mocked(shouldUseSSL).mockReturnValue(true);
 
     await createDatabase("test-resource-minio", credentials, connectionConfig);
@@ -141,7 +134,6 @@ describe("createDatabase", () => {
     expect(getEndpointHostname).toHaveBeenCalledWith(
       "https://minio.local:9000",
     );
-    expect(getDuckDbUrlStyle).toHaveBeenCalledWith("https://minio.local:9000");
     expect(mockQuery).toHaveBeenCalledWith(
       "SET s3_endpoint='minio.local:9000'",
     );

--- a/app/utils/db/createDatabase.ts
+++ b/app/utils/db/createDatabase.ts
@@ -8,11 +8,7 @@ import {
 } from "@duckdb/duckdb-wasm";
 
 import { createSingleton } from "./createSingleton";
-import {
-  getDuckDbUrlStyle,
-  shouldUseSSL,
-  getEndpointHostname,
-} from "../s3Provider";
+import { shouldUseSSL, getEndpointHostname } from "../s3Provider";
 import { ConnectionConfig } from "~/.generated/client";
 
 /**
@@ -61,20 +57,21 @@ const createDatabaseInternal = async (
   await connection.query(`SET s3_secret_access_key='${SecretAccessKey}'`);
   await connection.query(`SET s3_session_token='${SessionToken}'`);
 
-  // Configure S3 endpoint and URL style for S3-compatible services (MinIO, etc.)
+  // Configure S3 endpoint. Always path-style: works for every bucket shape
+  // (dotted names break the vhost wildcard cert `*.s3.<region>.amazonaws.com`)
+  // and keeps a single URL form across AWS and S3-compatible endpoints.
   const endpoint = connectionConfig?.endpoint;
   const region = connectionConfig?.region ?? "eu-central-1";
-  const urlStyle = getDuckDbUrlStyle(endpoint);
   const useSSL = shouldUseSSL(endpoint);
   const hostname = getEndpointHostname(endpoint);
 
   await connection.query(`SET s3_region='${region}'`);
   await connection.query(`SET s3_endpoint='${hostname}'`);
-  await connection.query(`SET s3_url_style='${urlStyle}'`);
+  await connection.query(`SET s3_url_style='path'`);
   await connection.query(`SET s3_use_ssl=${useSSL}`);
 
   console.info(
-    `[createDatabase] DuckDB initialized (endpoint: ${hostname}, style: ${urlStyle})`,
+    `[createDatabase] DuckDB initialized (endpoint: ${hostname}, style: path)`,
   );
 
   return connection;

--- a/app/utils/resourceId.ts
+++ b/app/utils/resourceId.ts
@@ -85,24 +85,19 @@ export function buildHttpsUrl(
 }
 
 /**
- * Builds the HTTPS URL for a full S3 object key. Uses virtual-hosted style
- * for AWS S3, falls back to path-style for dotted bucket names (TLS wildcard
- * cert limitation), and uses path-style for custom endpoints (MinIO, R2).
- * Path segments are URI-encoded — callers pass raw keys.
+ * Builds the HTTPS URL for a full S3 object key. Always path-style — works
+ * for every bucket shape (including dotted names, which break the vhost
+ * wildcard cert) and keeps a single URL form across AWS and S3-compatible
+ * endpoints. Path segments are URI-encoded — callers pass raw keys.
  *
  * The `s3Key` is the **full object key including any connection prefix**.
  * If you have a prefix-relative `pathName`, use `buildHttpsUrl` instead to
  * have the prefix rejoined for you.
  *
  * @example
- * // AWS virtual-hosted:
+ * // AWS:
  * constructS3Url({ bucketName: "my-bucket", region: "eu-central-1" }, "data/image.ome.tif")
- * // → "https://my-bucket.s3.eu-central-1.amazonaws.com/data/image.ome.tif"
- *
- * @example
- * // Dotted bucket (path-style fallback):
- * constructS3Url({ bucketName: "my.bucket", region: "us-east-1" }, "file.txt")
- * // → "https://s3.us-east-1.amazonaws.com/my.bucket/file.txt"
+ * // → "https://s3.eu-central-1.amazonaws.com/my-bucket/data/image.ome.tif"
  *
  * @example
  * // MinIO / R2 custom endpoint:
@@ -124,13 +119,9 @@ export function constructS3Url(
 
   const isAwsEndpoint = !endpoint || /\.amazonaws\.com$/i.test(endpoint);
 
+  // TODO: Check if this can be fixed on db-level
   if (isAwsEndpoint) {
-    // Dotted bucket names break the wildcard cert `*.s3.<region>.amazonaws.com`
-    // (wildcards match a single DNS label). AWS SDK v3 does the same fallback.
-    if (bucket.includes(".")) {
-      return `https://s3.${region}.amazonaws.com/${bucket}/${encodedPath}`;
-    }
-    return `https://${bucket}.s3.${region}.amazonaws.com/${encodedPath}`;
+    return `https://s3.${region}.amazonaws.com/${bucket}/${encodedPath}`;
   }
 
   return `${endpoint}/${bucket}/${encodedPath}`;

--- a/app/utils/resourceId.ts
+++ b/app/utils/resourceId.ts
@@ -18,7 +18,11 @@ export function parseResourceId(resourceId: string): ResourceIdParts {
   }
 
   const connectionName = resourceId.slice(0, slashIndex);
-  const pathName = resourceId.slice(slashIndex + 1);
+
+  const pathName = resourceId
+    .slice(slashIndex + 1)
+    // Strip leading slash
+    .replace(/^\/+/, "");
 
   if (!connectionName) {
     throw new Error(

--- a/app/utils/s3Provider.test.ts
+++ b/app/utils/s3Provider.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from "vitest";
 import {
   isAwsS3Endpoint,
   getS3ProviderConfig,
-  getDuckDbUrlStyle,
   shouldUseSSL,
   getEndpointHostname,
 } from "./s3Provider";
@@ -71,20 +70,6 @@ describe("s3Provider utilities", () => {
       expect(config.usePathStyle).toBe(true);
       expect(config.stsEndpoint).toBe("http://localhost:9000");
       expect(config.s3Endpoint).toBe("http://localhost:9000");
-    });
-  });
-
-  describe("getDuckDbUrlStyle", () => {
-    it("returns 'vhost' for AWS S3", () => {
-      expect(getDuckDbUrlStyle(undefined)).toBe("vhost");
-      expect(getDuckDbUrlStyle(null)).toBe("vhost");
-      expect(getDuckDbUrlStyle("https://s3.amazonaws.com")).toBe("vhost");
-    });
-
-    it("returns 'path' for S3-compatible services", () => {
-      expect(getDuckDbUrlStyle("https://s3.cytar.io")).toBe("path");
-      expect(getDuckDbUrlStyle("http://localhost:9000")).toBe("path");
-      expect(getDuckDbUrlStyle("https://s3.wasabisys.com")).toBe("path");
     });
   });
 

--- a/app/utils/s3Provider.ts
+++ b/app/utils/s3Provider.ts
@@ -51,17 +51,6 @@ export function getS3ProviderConfig(
 }
 
 /**
- * Gets the DuckDB URL style setting based on provider
- * @param endpoint - The S3 endpoint URL
- * @returns 'vhost' for AWS S3, 'path' for S3-compatible services
- */
-export function getDuckDbUrlStyle(
-  endpoint?: string | null
-): "vhost" | "path" {
-  return isAwsS3Endpoint(endpoint) ? "vhost" : "path";
-}
-
-/**
  * Determines if SSL should be used based on endpoint
  * @param endpoint - The S3 endpoint URL
  * @returns True if endpoint starts with https://


### PR DESCRIPTION
## Summary

- **`parseResourceId` strips leading slashes** from the parsed pathName. `buildDirectoryTree` in the search route produces node ids like `conn//path` when a connection prefix lacks a trailing slash; that double-slash cascaded into `s3://bucket/prefix//path` URIs and 404'd DuckDB.
- **`constructS3Url` always returns path-style URLs.** Vhost only works for label-safe bucket names — the wildcard TLS cert `*.s3.<region>.amazonaws.com` doesn't cover dotted buckets like `ultivue.cytario` (single-label wildcard). This is the same class of issue as PR #75, which only fixed the direct-browser-fetch code path; DuckDB-WASM kept using vhost until now.
- **DuckDB's `s3_url_style` is hardcoded to `'path'`** to match. The now-unused `getDuckDbUrlStyle` helper is removed.
- Drive-by: `fix: dashboard section kind` (small, unrelated fix bundled into the branch).

Path-style works for every bucket shape, has no active AWS deprecation plan, and keeps a single URL form across AWS and S3-compatible endpoints (MinIO, R2).

## Test plan

- [ ] Open an OME-TIFF in the \`ultivue.cytario\` bucket and add a parquet overlay — DuckDB query should succeed where it previously 404'd.
- [ ] Regression: standard (non-dotted) AWS bucket still loads imagery + parquet overlays.
- [ ] Regression: MinIO / R2 connection still loads imagery.
- [ ] \`npx vitest run\` green (1097 passing locally).