### PR TITLE
fix(auth): break email-verification redirect loop [proposal]

### DIFF
--- a/app/routes/auth/__tests__/callback.test.tsx
+++ b/app/routes/auth/__tests__/callback.test.tsx
@@ -44,6 +44,36 @@ vi.mock("~/config", () => ({
 
 const { getSession } = await import("~/.server/auth/getSession");
 
+/**
+ * Loader error responses use react-router's `data()` helper, which returns a
+ * `DataWithResponseInit` wrapper rather than a Response. Treat the wrapper as
+ * an error envelope and expose status/data for assertions.
+ */
+type ErrorEnvelope = { status: number; data: { error: string } };
+
+interface ResponseInitLike {
+  status?: number;
+}
+const isDataWithResponseInit = (
+  value: unknown,
+): value is { init: ResponseInitLike | null; data: unknown } =>
+  typeof value === "object" &&
+  value !== null &&
+  "init" in value &&
+  "data" in value;
+
+const asErrorEnvelope = (value: unknown): ErrorEnvelope => {
+  if (!isDataWithResponseInit(value)) {
+    throw new Error(
+      `Expected DataWithResponseInit, got ${JSON.stringify(value)}`,
+    );
+  }
+  return {
+    status: value.init?.status ?? 200,
+    data: value.data as { error: string },
+  };
+};
+
 describe("callback loader", () => {
   const mockUser = mock.user();
   const mockStateData = {
@@ -82,35 +112,41 @@ describe("callback loader", () => {
     );
   });
 
-  test("redirects to login with flash on missing code/state", async () => {
+  test("returns 400 with error data on missing code/state (no /login redirect)", async () => {
     const request = new Request("http://localhost/auth/callback");
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const result = await loader({ request } as LoaderFunctionArgs);
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "Authentication failed. Missing required parameters.",
+    expect(result).not.toBeInstanceOf(Response);
+    const envelope = asErrorEnvelope(result);
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "Authentication failed. Missing required parameters.",
     });
+    expect(mockSession.set).not.toHaveBeenCalledWith(
+      "notification",
+      expect.anything(),
+    );
   });
 
-  test("redirects to login with flash on invalid state", async () => {
+  test("returns 400 with error data on invalid state", async () => {
     vi.mocked(validateOAuthState).mockResolvedValue(null);
 
     const request = new Request(
       "http://localhost/auth/callback?code=auth-code&state=invalid",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "Authentication session expired. Please try again.",
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "Authentication session expired. Please try again.",
     });
   });
 
-  test("redirects to login when state is missing codeVerifier", async () => {
+  test("returns 400 with error data when state is missing codeVerifier", async () => {
     vi.mocked(validateOAuthState).mockResolvedValue({
       ...mockStateData,
       codeVerifier: "",
@@ -120,16 +156,17 @@ describe("callback loader", () => {
       "http://localhost/auth/callback?code=auth-code&state=valid",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "Authentication session invalid. Please try again.",
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "Authentication session invalid. Please try again.",
     });
   });
 
-  test("redirects to login when state is missing nonce", async () => {
+  test("returns 400 when state is missing nonce", async () => {
     vi.mocked(validateOAuthState).mockResolvedValue({
       ...mockStateData,
       nonce: "",
@@ -139,12 +176,14 @@ describe("callback loader", () => {
       "http://localhost/auth/callback?code=auth-code&state=valid",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
+    expect(envelope.status).toBe(400);
   });
 
-  test("redirects to login when ID token signature verification fails", async () => {
+  test("returns 400 when ID token signature verification fails", async () => {
     vi.mocked(verifyIdToken).mockResolvedValue(null);
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -152,17 +191,18 @@ describe("callback loader", () => {
       "http://localhost/auth/callback?code=auth-code&state=valid-state",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "Authentication failed. Please try again.",
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "Authentication failed. Please try again.",
     });
     consoleSpy.mockRestore();
   });
 
-  test("redirects to login on nonce mismatch", async () => {
+  test("returns 400 on nonce mismatch", async () => {
     vi.mocked(verifyIdToken).mockResolvedValue({ nonce: "wrong-nonce", sub: "user-123" });
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -170,31 +210,33 @@ describe("callback loader", () => {
       "http://localhost/auth/callback?code=auth-code&state=valid-state",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "Authentication failed. Please try again.",
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "Authentication failed. Please try again.",
     });
     consoleSpy.mockRestore();
   });
 
-  test("handles authorization server errors with flash notification", async () => {
+  test("handles authorization server errors with error page data", async () => {
     const request = new Request(
       "http://localhost/auth/callback?error=access_denied&error_description=User+denied+access",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "User denied access",
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "User denied access",
     });
   });
 
-  test("catches errors and shows generic message", async () => {
+  test("catches errors and returns generic error page data", async () => {
     vi.mocked(exchangeAuthCode).mockRejectedValue(
       new Error("Token exchange failed: 400"),
     );
@@ -204,12 +246,13 @@ describe("callback loader", () => {
       "http://localhost/auth/callback?code=auth-code&state=valid-state",
     );
 
-    const response = await loader({ request } as LoaderFunctionArgs);
+    const envelope = asErrorEnvelope(
+      await loader({ request } as LoaderFunctionArgs),
+    );
 
-    expect((response as Response).status).toBe(302);
-    expect(mockSession.set).toHaveBeenCalledWith("notification", {
-      status: "error",
-      message: "Authentication failed. Please try again.",
+    expect(envelope.status).toBe(400);
+    expect(envelope.data).toEqual({
+      error: "Authentication failed. Please try again.",
     });
     consoleSpy.mockRestore();
   });
@@ -240,5 +283,19 @@ describe("callback loader", () => {
     await loader({ request } as LoaderFunctionArgs);
 
     expect(sessionStorage.commitSession).toHaveBeenCalled();
+  });
+
+  test("failure path never redirects to /login (regression: email-verify redirect loop)", async () => {
+    vi.mocked(validateOAuthState).mockResolvedValue(null);
+
+    const request = new Request(
+      "http://localhost/auth/callback?code=auth-code&state=expired",
+    );
+
+    const result = await loader({ request } as LoaderFunctionArgs);
+
+    // Must not return a redirect Response — that's what used to loop
+    // against Keycloak's live SSO session.
+    expect(result).not.toBeInstanceOf(Response);
   });
 });

--- a/app/routes/auth/__tests__/login.test.tsx
+++ b/app/routes/auth/__tests__/login.test.tsx
@@ -158,6 +158,71 @@ describe("login loader (OAuth Authorization Code Flow with PKCE)", () => {
     expect(validateRedirectTo).toHaveBeenCalledWith("/profile");
   });
 
+  test("refuses to restart OIDC flow when referer is /auth/callback", async () => {
+    const mockSession = {
+      get: vi.fn(() => null),
+      set: vi.fn(),
+    };
+
+    (getSession as Mock).mockResolvedValue(mockSession);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // `Referer` is a forbidden header name in the Fetch API, so it gets
+    // silently dropped when passed via `new Request(url, { headers })` init.
+    // Build a Request-like whose Headers preserves it, mirroring what a real
+    // Node server receives from a browser.
+    const headers = new Headers();
+    headers.set("referer", "https://app.example.com/auth/callback");
+    const request = {
+      url: "http://localhost/login",
+      headers,
+    } as unknown as Request;
+
+    const result = await loader({ request } as LoaderFunctionArgs);
+
+    // Must NOT redirect to Keycloak (that's how the email-verify loop formed)
+    expect(generateOAuthState).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+
+    // Returns DataWithResponseInit with 400 + error message
+    expect(result).toMatchObject({
+      init: expect.objectContaining({ status: 400 }),
+      data: expect.objectContaining({ error: expect.any(String) }),
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  test("still starts OIDC flow when referer is not our /auth/callback", async () => {
+    const mockSession = {
+      get: vi.fn(() => null),
+      set: vi.fn(),
+    };
+
+    (getSession as Mock).mockResolvedValue(mockSession);
+    (generateOAuthState as Mock).mockResolvedValue({
+      state: "state-ext",
+      codeChallenge: "challenge",
+      nonce: "nonce",
+    });
+    (getWellKnownEndpoints as Mock).mockResolvedValue({
+      authorization_endpoint: "https://keycloak.example.com/auth",
+    });
+
+    const headers = new Headers();
+    // External referer (e.g. user clicked a link from somewhere else)
+    headers.set("referer", "https://some-other-site.example.com/page");
+    const request = {
+      url: "http://localhost/login",
+      headers,
+    } as unknown as Request;
+
+    await loader({ request } as LoaderFunctionArgs);
+
+    expect(generateOAuthState).toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalled();
+  });
+
   test("throws 502 response when auth service is unreachable", async () => {
     const mockSession = {
       get: vi.fn(() => null),

--- a/app/routes/auth/callback.route.tsx
+++ b/app/routes/auth/callback.route.tsx
@@ -1,4 +1,5 @@
-import { LoaderFunctionArgs, redirect } from "react-router";
+import { H1 } from "@cytario/design";
+import { data, LoaderFunctionArgs, redirect, useLoaderData } from "react-router";
 
 import { exchangeAuthCode } from "~/.server/auth/exchangeAuthCode";
 import { getSession } from "~/.server/auth/getSession";
@@ -7,20 +8,27 @@ import { validateOAuthState, validateRedirectTo } from "~/.server/auth/oauthStat
 import { sessionStorage } from "~/.server/auth/sessionStorage";
 import { verifyIdToken } from "~/.server/auth/verifyIdToken";
 import { createLabel } from "~/.server/logging";
+import { Section } from "~/components/Container";
 import { NotificationInput } from "~/components/Notification/Notification.store";
 import { cytarioConfig } from "~/config";
 
 const label = createLabel("auth-callback", "cyan");
 
 /**
- * Redirects to login with an error notification stored in the session.
+ * Renders a terminal error page for the callback.
+ * Does NOT redirect to /login — an IdP SSO session would immediately bounce the
+ * browser back here, producing an infinite redirect loop (see the email-verify
+ * flow, where the state TTL can elapse before the user clicks the link).
  */
-const failWithNotification = async (request: Request, message: string) => {
+const respondWithError = async (request: Request, message: string) => {
   const session = await getSession(request);
-  session.set("notification", { status: "error" as const, message });
-  return redirect("/login", {
-    headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
-  });
+  return data(
+    { error: message },
+    {
+      status: 400,
+      headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
+    },
+  );
 };
 
 /**
@@ -39,7 +47,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   // Handle errors from authorization server
   if (error) {
     console.error(`${label} Authorization error:`, error, errorDescription);
-    return failWithNotification(
+    return respondWithError(
       request,
       errorDescription || "Authentication failed. Please try again.",
     );
@@ -48,7 +56,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   // Validate required parameters
   if (!code || !state) {
     console.error(`${label} Missing code or state parameter`);
-    return failWithNotification(
+    return respondWithError(
       request,
       "Authentication failed. Missing required parameters.",
     );
@@ -59,7 +67,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const stateData = await validateOAuthState(state);
     if (!stateData) {
       console.error(`${label} Invalid or expired state parameter`);
-      return failWithNotification(
+      return respondWithError(
         request,
         "Authentication session expired. Please try again.",
       );
@@ -68,7 +76,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     // Guard for in-flight states from before PKCE deployment
     if (!stateData.codeVerifier || !stateData.nonce) {
       console.error(`${label} State missing codeVerifier or nonce`);
-      return failWithNotification(
+      return respondWithError(
         request,
         "Authentication session invalid. Please try again.",
       );
@@ -91,7 +99,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     const idTokenPayload = await verifyIdToken(tokens.id_token);
     if (!idTokenPayload) {
       console.error(`${label} ID token signature verification failed`);
-      return failWithNotification(
+      return respondWithError(
         request,
         "Authentication failed. Please try again.",
       );
@@ -99,7 +107,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
     if (idTokenPayload.nonce !== stateData.nonce) {
       console.error(`${label} Nonce mismatch in ID token`);
-      return failWithNotification(
+      return respondWithError(
         request,
         "Authentication failed. Please try again.",
       );
@@ -136,14 +144,32 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     });
   } catch (error) {
     console.error(`${label} Authentication failed:`, error);
-    return failWithNotification(
+    return respondWithError(
       request,
       "Authentication failed. Please try again.",
     );
   }
 };
 
-// This route only handles redirects, no UI needed
 export default function CallbackRoute() {
+  const loaderData = useLoaderData<typeof loader>();
+
+  if (loaderData && "error" in loaderData) {
+    return (
+      <Section>
+        <div className="container mx-auto px-4 max-w-lg" role="alert">
+          <H1>Sign-in failed</H1>
+          <p className="mt-4 text-slate-700">{loaderData.error}</p>
+          <a
+            href="/login"
+            className="text-cytario-purple-500 underline mt-6 inline-block"
+          >
+            Try signing in again
+          </a>
+        </div>
+      </Section>
+    );
+  }
+
   return null;
 }

--- a/app/routes/auth/login.route.tsx
+++ b/app/routes/auth/login.route.tsx
@@ -1,4 +1,11 @@
-import { LoaderFunctionArgs, redirect, MetaFunction } from "react-router";
+import { H1 } from "@cytario/design";
+import {
+  data,
+  LoaderFunctionArgs,
+  MetaFunction,
+  redirect,
+  useLoaderData,
+} from "react-router";
 
 import { getSession } from "~/.server/auth/getSession";
 import {
@@ -7,6 +14,7 @@ import {
 } from "~/.server/auth/oauthState";
 import { getWellKnownEndpoints } from "~/.server/auth/wellKnownEndpoints";
 import { createLabel } from "~/.server/logging";
+import { Section } from "~/components/Container";
 import { cytarioConfig } from "~/config";
 
 export const meta: MetaFunction = () => {
@@ -21,6 +29,27 @@ export const meta: MetaFunction = () => {
 };
 
 const label = createLabel("login", "blue");
+
+/**
+ * True if the request's Referer is this app's own /auth/callback.
+ * Used as a belt-and-braces loop breaker: if a callback failure ever leaks
+ * back into /login, we refuse to restart OIDC rather than bouncing through
+ * a live Keycloak SSO session indefinitely.
+ */
+const cameFromCallback = (request: Request): boolean => {
+  const referer = request.headers.get("referer");
+  if (!referer) return false;
+  try {
+    const refererUrl = new URL(referer);
+    const webappUrl = new URL(cytarioConfig.endpoints.webapp);
+    return (
+      refererUrl.origin === webappUrl.origin &&
+      refererUrl.pathname === "/auth/callback"
+    );
+  } catch {
+    return false;
+  }
+};
 
 /**
  * OAuth 2.0 Authorization Code Flow - Login Initiator
@@ -39,6 +68,20 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   if (user) {
     console.info(`${label} User already authenticated, redirecting`);
     return redirect("/");
+  }
+
+  // Refuse to restart OIDC if we just bounced out of a failed callback.
+  // Keycloak's SSO session would silently hand us a fresh code, creating a
+  // tight redirect loop the browser can only escape via ERR_TOO_MANY_REDIRECTS.
+  if (cameFromCallback(request)) {
+    console.error(`${label} Refusing to restart OIDC flow from /auth/callback referer`);
+    return data(
+      {
+        error:
+          "Sign-in could not be completed. Please start a new sign-in attempt.",
+      },
+      { status: 400 },
+    );
   }
 
   try {
@@ -82,8 +125,26 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   }
 };
 
-// Loading state shown briefly before redirect fires
 export default function LoginRoute() {
+  const loaderData = useLoaderData<typeof loader>();
+
+  if (loaderData && "error" in loaderData) {
+    return (
+      <Section>
+        <div className="container mx-auto px-4 max-w-lg" role="alert">
+          <H1>Sign-in failed</H1>
+          <p className="mt-4 text-slate-700">{loaderData.error}</p>
+          <a
+            href="/"
+            className="text-cytario-purple-500 underline mt-6 inline-block"
+          >
+            Back to home
+          </a>
+        </div>
+      </Section>
+    );
+  }
+
   return (
     <div className="flex items-center justify-center h-screen">
       <p role="status" className="text-slate-500">Redirecting to login...</p>


### PR DESCRIPTION
> **This PR is a proposal for discussion — not ready to merge as-is.**
> It contains two independent fixes for the same bug. Please review which approach we want to ship: A only, B only, or both. I've staged them as separate commits for easy cherry-picking.

## The bug

After a user completes Keycloak's email-verification flow, the browser lands at `app.cytar.io` and falls into a redirect loop that only terminates with `ERR_TOO_MANY_REDIRECTS`. Captured in `app.cytar.io_redirects_on_email_verification.har` — 18 requests before the browser gave up.

### Observed loop (5 silent iterations)

```
/auth/callback?code=X     →  302 Location: /login
/login                    →  302 Location: https://auth.cytar.io/.../auth?...
auth.cytar.io/.../auth    →  302 Location: /auth/callback?code=Y   (KEYCLOAK_IDENTITY → SSO, no prompt)
/auth/callback?code=Y     →  302 Location: /login
... repeats ...
```

### Root cause

The loop lives entirely on our side. Two behaviors stack:

1. **`/auth/callback` redirects to `/login` on failure.** Every failure path in `failWithNotification` does `302 → /login`. Email-verification reliably trips this because the OAuth state (Redis TTL: 10 minutes) can expire between the initial `/login` and the moment the user finally clicks the email link.
2. **`/login` always starts a fresh OIDC flow when no app session exists.** It does check for an app `user`, but since every failed callback leaves us with a session that has no `user`, the check doesn't fire.

Since Keycloak has a live `KEYCLOAK_SESSION` the moment email verification succeeds, every subsequent authorize hit returns a new code *without any user interaction*. The browser has no chokepoint to stop the loop.

Email verification triggers it specifically because the redirect back from Keycloak has only `state/code/iss/session_state` — no app-side return URL — and the state has likely expired by then.

See `app.cytar.io_redirects_on_email_verification.md` for the full HAR analysis.

## Proposed fixes (two independent patches)

### A — Render a terminal error page from `/auth/callback` on failure  *(commit `6df4982`)*

Replaces the `302 → /login` with a `data({ error }, { status: 400 })` that the route component renders as a human-readable error with a manual retry link.

- **Pro:** Fixes the loop at its source. No redirect means no loop is possible, regardless of IdP SSO state.
- **Pro:** Users get a clear message about what failed instead of a silent bounce.
- **Con:** Changes the failure UX — current pattern is to surface errors via a toast on `/login`. We lose that toast-driven feedback path for callback failures.

### B — `/login` refuses to restart OIDC when `Referer` is our own `/auth/callback`  *(commit `783905d`)*

Belt-and-braces: even if a future change redirects from callback to login, `/login` checks the `Referer` and renders a 400 error page instead of bouncing to Keycloak.

- **Pro:** Cheap defense-in-depth against regressions.
- **Pro:** Preserves current toast-based error surfacing for non-referer-loop cases.
- **Con:** `Referer` is an unreliable signal (can be suppressed by browser policy, proxies, or `rel=noreferrer`). Not a load-bearing fix on its own.
- **Con:** Adds logic that duplicates the session-based short-circuit already in `/login`.

## Options for review

| Option | A (callback error page) | B (login referer guard) | Notes |
|--------|:-:|:-:|-------|
| 1. Both (as-is) | ✅ | ✅ | Defense in depth. Current state of the branch. |
| 2. A only | ✅ | ❌ | Simplest root-cause fix. |
| 3. B only | ❌ | ✅ | Keeps current callback UX; loop-breaker is best-effort. |

My recommendation is **Option 2 (A only)** — it's a root-cause fix, it removes the infinite-loop primitive entirely, and B's value is mostly symbolic once A is in place. Happy to drop B if we agree.

## What this does NOT fix

We haven't diagnosed *why* the callback is failing in the first place. The most likely candidate is the 10-minute OAuth state TTL expiring while the user clicks the email link. That's worth a follow-up — either lengthen the TTL for verification flows, or gracefully handle the case by re-initiating login with preserved `redirectTo`. Out of scope for this PR.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Full test suite passes (1100 tests) — the 6 pre-existing `.env.test`-related failures in sandboxed runs are unrelated
- [x] New regression test: callback failure never returns a 302 (`callback.test.tsx`)
- [x] New tests: `/login` referer guard triggers vs. external referer passes through (`login.test.tsx`)
- [ ] Manual: reproduce the email-verify flow against a staging Keycloak and confirm the loop is broken
- [ ] Manual: confirm a normal (non-email-verify) login still lands on the intended destination
- [ ] Decide which option to ship, rebase, and re-push