### PR TITLE
ci(cd): dispatch cytario-ee rebuild on web release (C-156)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,3 +26,28 @@ jobs:
     if: ${{ needs.release.outputs.version != '' }}
     with:
       version: ${{ needs.release.outputs.version }}
+
+  dispatch-ee:
+    name: Dispatch cytario-ee rebuild
+    needs: release
+    if: ${{ needs.release.outputs.version != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CYTARIO_DEPLOY_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.CYTARIO_DEPLOY_DISPATCH_APP_PRIVATE_KEY }}
+          repositories: cytario-ee
+
+      - name: Dispatch to cytario-ee
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          jq -n --arg version "$VERSION" '{
+            event_type: "cytario-web-published",
+            client_payload: { version: $version }
+          }' | gh api repos/cytario/cytario-ee/dispatches \
+            --method POST --input -


### PR DESCRIPTION
## Description

After a `cytario-web` main merge publishes `@cytario/web` to npm, dispatch a `repository_dispatch` (`cytario-web-published`) to `cytario-ee` using the `cytario-deploy-dispatcher` GitHub App. `cytario-ee` pins the new version via `npm install --save-exact` and rebuilds its container image. The dev tfvars bump moves to `cytario-ee`'s release pipeline (separate follow-up).

This replaces the original C-156 design, which dispatched `cytario-web` → `cytario-infrastructure` directly and bumped `cytario_web.image.tag`. Since then, `cytario-ee` has become the deploy assembly (consumes `@cytario/web` + closed-source plugins from npm and builds `ghcr.io/cytario/cytario-ee`), so the dispatch chain is now `web release → EE rebuild → infra tfvars bump`.

### New flow

```
cytario-web merge to main
  → CD: qa, semantic-release (npm publish @cytario/web), container build
  → dispatch-ee job mints App token, repository_dispatch(cytario-web-published) → cytario-ee
  → cytario-ee bump-web.yml: npm install @cytario/web@X.Y.Z --save-exact, commit + push as cytario-deploy-dispatcher[bot]
  → cytario-ee release.yml builds ghcr.io/cytario/cytario-ee:X.Y.Z
  → cytario-ee dispatch-dev job: repository_dispatch(deploy-cytario-ee) → cytario-infrastructure
  → bump-dev-image-tag.yml rewrites cytario_ee.image.tag in dev.tfvars, commits to dev branch
  → Scalr terraform apply rolls dev forward
```

### Decisions

- **Dispatch target = `cytario-ee`.** EE owns the deployable artifact, so EE owns the deploy trigger downstream. Web only triggers EE.
- **`needs: release` (not `build`).** EE consumes the npm package, not the web container, so the EE rebuild starts as soon as `npm publish` finishes (saves ~5–10 min vs gating on the multi-arch image).
- **Web container build kept as-is.** Not consumed by EE, but still useful for PR previews / ad-hoc debug.
- **EE pins `@cytario/web` exactly** via `npm install --save-exact`. Makes EE release notes show the bump and keeps builds reproducible.

### Why `gh api` instead of `peter-evans/repository-dispatch`

- **No third-party action on the token path.** A short-lived GitHub App token with write permissions on another repo is a sensitive credential. Keeping it in a step-scoped env var and handing it only to the official `gh` CLI removes a whole class of supply-chain risk.
- **Consistency with E2E.** The E2E workflow already avoids reusable/third-party actions for the same reason.
- **Payload safety.** `jq -n --arg version "$VERSION"` builds the JSON so the version string is properly escaped rather than interpolated into a YAML string literal.

## Follow-up (tracked in C-156)

- `cytario-ee`: install the `cytario-deploy-dispatcher` App; add `bump-web.yml` listener for `cytario-web-published`; extend `release.yml` with a `dispatch-dev` job that fires `deploy-cytario-ee` → `cytario-infrastructure`.
- `cytario-infrastructure`: rename tfvars field `cytario_web.image.tag` → `cytario_ee.image.tag`; update `bump-dev-image-tag.yml` to handle `deploy-cytario-ee`; switch TF/helm module image source to `ghcr.io/cytario/cytario-ee`.

## Related Issue

C-156

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed

_Note: CI workflow change — validated end-to-end once the cytario-ee follow-up lands and a web release triggers the chain. No unit tests apply._