### PR TITLE
perf(auth): cache Keycloak group ID lookups by path

### DIFF
--- a/app/.server/auth/__tests__/createGroup.test.ts
+++ b/app/.server/auth/__tests__/createGroup.test.ts
@@ -1,4 +1,5 @@
 import { createGroup } from "../keycloakAdmin";
+import { __resetGroupIdCache } from "../keycloakAdmin/groups";
 
 vi.mock("~/config", () => ({
   cytarioConfig: {
@@ -38,6 +39,7 @@ function mockFetchSequence(responses: Array<Partial<Response>>) {
 describe("createGroup", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetGroupIdCache();
   });
 
   test("creates group and admins subgroup under parent", async () => {

--- a/app/.server/auth/__tests__/findGroupByPath.test.ts
+++ b/app/.server/auth/__tests__/findGroupByPath.test.ts
@@ -1,4 +1,5 @@
 import { findGroupByPath } from "../keycloakAdmin";
+import { __resetGroupIdCache } from "../keycloakAdmin/groups";
 
 vi.mock("~/config", () => ({
   cytarioConfig: {
@@ -44,6 +45,7 @@ const mockGroupTree = [
 describe("findGroupByPath", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetGroupIdCache();
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({

--- a/app/.server/auth/__tests__/getKeycloakGroups.test.ts
+++ b/app/.server/auth/__tests__/getKeycloakGroups.test.ts
@@ -1,5 +1,8 @@
 import { getManageableScopes } from "../keycloakAdmin";
-import { flattenGroups } from "../keycloakAdmin/groups";
+import {
+  __resetGroupIdCache,
+  flattenGroups,
+} from "../keycloakAdmin/groups";
 import mock from "~/utils/__tests__/__mocks__";
 
 vi.mock("~/config", () => ({
@@ -90,6 +93,7 @@ describe("flattenGroups", () => {
 describe("getManageableScopes", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetGroupIdCache();
   });
 
   test("fetches and returns descendant groups for admin scopes", async () => {

--- a/app/.server/auth/__tests__/groupIdCache.test.ts
+++ b/app/.server/auth/__tests__/groupIdCache.test.ts
@@ -1,0 +1,279 @@
+import { createGroup, inviteUser } from "../keycloakAdmin";
+import { KeycloakAdminError } from "../keycloakAdmin/client";
+import {
+  __resetGroupIdCache,
+  cacheGroupId,
+  findGroupByPath,
+  findGroupIdByPath,
+  invalidateGroupIdCache,
+} from "../keycloakAdmin/groups";
+
+vi.mock("~/config", () => ({
+  cytarioConfig: {
+    auth: {
+      baseUrl: "http://localhost:8080/realms/master",
+    },
+  },
+}));
+
+vi.mock("../keycloakAdmin/serviceAccountToken", () => ({
+  getAdminToken: vi.fn().mockResolvedValue("mock-admin-token"),
+}));
+
+const BASE = "http://localhost:8080/admin/realms/master";
+
+const mockParentGroup = {
+  id: "parent-123",
+  name: "lab",
+  path: "/cytario/lab",
+  subGroups: [],
+};
+
+const mockTopLevelTree = [
+  {
+    id: "root",
+    name: "cytario",
+    path: "/cytario",
+    subGroups: [mockParentGroup],
+  },
+];
+
+function mockFetchSequence(responses: Array<Partial<Response>>) {
+  const fn = vi.fn();
+  for (const res of responses) {
+    fn.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(null),
+      headers: new Headers(),
+      ...res,
+    });
+  }
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  __resetGroupIdCache();
+});
+
+describe("fetchGroups URL contract", () => {
+  test("includes search, exact=true, and max for non-empty term", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockTopLevelTree),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await findGroupByPath("cytario");
+
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/groups?");
+    expect(url).toContain("search=cytario");
+    expect(url).toContain("exact=true");
+    expect(url).toContain("max=1000");
+  });
+});
+
+describe("findGroupIdByPath cache behavior", () => {
+  test("cache hit returns ID without fetching", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    cacheGroupId("cytario/lab", "parent-123");
+
+    const id = await findGroupIdByPath("cytario/lab");
+
+    expect(id).toBe("parent-123");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("cache miss falls back to findGroupByPath and warms the cache", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockTopLevelTree),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await findGroupIdByPath("cytario/lab");
+    const second = await findGroupIdByPath("cytario/lab");
+
+    expect(first).toBe("parent-123");
+    expect(second).toBe("parent-123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("findGroupByPath populates the cache as a side effect", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockTopLevelTree),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await findGroupByPath("cytario/lab");
+    fetchMock.mockClear();
+
+    const id = await findGroupIdByPath("cytario/lab");
+
+    expect(id).toBe("parent-123");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns undefined for a missing path without poisoning the cache", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = await findGroupIdByPath("nonexistent");
+    expect(first).toBeUndefined();
+
+    const second = await findGroupIdByPath("nonexistent");
+    expect(second).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("invalidateGroupIdCache", () => {
+  test("drops only the named entry", async () => {
+    cacheGroupId("cytario/lab", "parent-123");
+    cacheGroupId("cytario/other", "other-456");
+
+    invalidateGroupIdCache("cytario/lab");
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await findGroupIdByPath("cytario/other")).toBe("other-456");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("createGroup cache integration", () => {
+  test("pre-populates cache for new group and its admins subgroup", async () => {
+    mockFetchSequence([
+      // findGroupByPath → fetchGroups
+      { json: () => Promise.resolve(mockTopLevelTree) },
+      // POST /groups/{parentId}/children → new group
+      {
+        status: 201,
+        headers: new Headers({ location: `${BASE}/groups/new-group-id` }),
+      },
+      // POST /groups/{newGroupId}/children → admins subgroup
+      {
+        status: 201,
+        headers: new Headers({ location: `${BASE}/groups/admins-group-id` }),
+      },
+    ]);
+
+    await createGroup("cytario/lab", "Ultivue");
+
+    // Cache should now be warm for both the new group and its admins subgroup.
+    const verifyMock = vi.fn();
+    vi.stubGlobal("fetch", verifyMock);
+
+    expect(await findGroupIdByPath("cytario/lab/Ultivue")).toBe("new-group-id");
+    expect(await findGroupIdByPath("cytario/lab/Ultivue/admins")).toBe(
+      "admins-group-id",
+    );
+    expect(verifyMock).not.toHaveBeenCalled();
+  });
+
+  test("invalidates parent cache when POST returns 404", async () => {
+    cacheGroupId("cytario/lab", "stale-parent-id");
+
+    const fetchMock = mockFetchSequence([
+      // POST /groups/stale-parent-id/children → 404
+      { ok: false, status: 404, statusText: "Not Found" },
+    ]);
+
+    await expect(createGroup("cytario/lab", "Ultivue")).rejects.toBeInstanceOf(
+      KeycloakAdminError,
+    );
+
+    // Cache entry should be gone, so the next lookup re-fetches.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockTopLevelTree),
+      headers: new Headers(),
+    });
+
+    const id = await findGroupIdByPath("cytario/lab");
+    expect(id).toBe("parent-123");
+  });
+
+  test("rollback leaves cache untouched (no half-created entries)", async () => {
+    mockFetchSequence([
+      // findGroupByPath → fetchGroups (populates parent in cache)
+      { json: () => Promise.resolve(mockTopLevelTree) },
+      // POST /groups/{parentId}/children → success
+      {
+        status: 201,
+        headers: new Headers({ location: `${BASE}/groups/new-group-id` }),
+      },
+      // POST /groups/{newGroupId}/children (admins) → 500
+      { ok: false, status: 500, statusText: "Internal Server Error" },
+      // DELETE /groups/{newGroupId} → rollback success
+      { ok: true, status: 204 },
+    ]);
+
+    await expect(createGroup("cytario/lab", "broken")).rejects.toBeInstanceOf(
+      KeycloakAdminError,
+    );
+
+    const noFetch = vi.fn();
+    vi.stubGlobal("fetch", noFetch);
+
+    // Parent stays cached (it does exist). New paths are NOT cached.
+    expect(await findGroupIdByPath("cytario/lab")).toBe("parent-123");
+    expect(noFetch).not.toHaveBeenCalled();
+
+    // Lookup of the rolled-back path is a cache miss — would re-fetch.
+    const rolledBackFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", rolledBackFetch);
+
+    expect(await findGroupIdByPath("cytario/lab/broken")).toBeUndefined();
+    expect(rolledBackFetch).toHaveBeenCalled();
+  });
+});
+
+describe("inviteUser cache invalidation", () => {
+  test("invalidates the group path when PUT returns 404", async () => {
+    cacheGroupId("cytario/lab", "stale-group-id");
+
+    mockFetchSequence([
+      // POST /users → success
+      {
+        status: 201,
+        headers: new Headers({ location: `${BASE}/users/new-user-id` }),
+      },
+      // PUT /users/{id}/groups/{stale-group-id} → 404
+      { ok: false, status: 404, statusText: "Not Found" },
+    ]);
+
+    await expect(
+      inviteUser("test@example.com", "Test", "User", "cytario/lab", true),
+    ).rejects.toBeInstanceOf(KeycloakAdminError);
+
+    // Next lookup must re-fetch — the cached ID was stale.
+    const refetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockTopLevelTree),
+      headers: new Headers(),
+    });
+    vi.stubGlobal("fetch", refetch);
+
+    const id = await findGroupIdByPath("cytario/lab");
+    expect(id).toBe("parent-123");
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/app/.server/auth/__tests__/inviteUser.test.ts
+++ b/app/.server/auth/__tests__/inviteUser.test.ts
@@ -1,4 +1,5 @@
 import { inviteUser } from "../keycloakAdmin";
+import { __resetGroupIdCache } from "../keycloakAdmin/groups";
 
 vi.mock("~/config", () => ({
   cytarioConfig: {
@@ -38,6 +39,7 @@ function mockFetchSequence(responses: Array<Partial<Response>>) {
 describe("inviteUser", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetGroupIdCache();
   });
 
   test("creates user, adds to group, sends email", async () => {

--- a/app/.server/auth/__tests__/updateUser.test.ts
+++ b/app/.server/auth/__tests__/updateUser.test.ts
@@ -1,4 +1,5 @@
 import { updateUser } from "../keycloakAdmin";
+import { __resetGroupIdCache } from "../keycloakAdmin/groups";
 
 vi.mock("~/config", () => ({
   cytarioConfig: {
@@ -17,6 +18,7 @@ const BASE = "http://localhost:8080/admin/realms/master";
 describe("updateUser", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    __resetGroupIdCache();
   });
 
   test("sends PUT request with user data", async () => {

--- a/app/.server/auth/keycloakAdmin/groups.ts
+++ b/app/.server/auth/keycloakAdmin/groups.ts
@@ -1,3 +1,5 @@
+import { LRUCache } from "lru-cache";
+
 import type { UserProfile } from "../getUserInfo";
 import {
   adminFetch,
@@ -6,6 +8,19 @@ import {
   type KeycloakGroup,
   type KeycloakUser,
 } from "./client";
+
+/**
+ * Maps a normalized group path (e.g. "cytario/lab") to its Keycloak group ID.
+ *
+ * Group IDs are stable for the lifetime of a group, but a path may go stale if
+ * a group is renamed or deleted. The TTL bounds staleness; mutating callers
+ * (createGroup) refresh entries explicitly. On a write that targets a cached
+ * parent ID and gets a 404, the entry is dropped so the next attempt rebuilds it.
+ */
+const groupIdByPath = new LRUCache<string, string>({
+  max: 500,
+  ttl: 10 * 60 * 1000,
+});
 
 export interface GroupWithMembers {
   id: string;
@@ -28,9 +43,15 @@ export interface GroupInfo {
   isAdmin: boolean;
 }
 
+/**
+ * Searches Keycloak groups by name. `exact=true` is load-bearing — it makes
+ * `search` an exact-name match instead of a substring match. `max=1000`
+ * defeats Keycloak's default page size of 20, which would silently truncate
+ * results for realms with many top-level groups.
+ */
 async function fetchGroups(search?: string): Promise<KeycloakGroup[]> {
-  const params = new URLSearchParams({ exact: "true" });
-  if (search) params.set("q", search);
+  const params = new URLSearchParams({ exact: "true", max: "1000" });
+  if (search) params.set("search", search);
   return adminFetch(`/groups?${params}`);
 }
 
@@ -90,6 +111,8 @@ export async function getManageableScopes(
 
 /**
  * Finds a Keycloak group by its normalized path (e.g. "cytario/lab").
+ * Populates the path-to-id cache as a side effect so subsequent ID-only
+ * lookups (createGroup, addUserToGroup) skip the round trip.
  */
 export async function findGroupByPath(
   scope: string,
@@ -106,7 +129,46 @@ export async function findGroupByPath(
     }
   };
 
-  return search(groups);
+  const result = search(groups);
+  if (result) groupIdByPath.set(scope, result.id);
+  return result;
+}
+
+/**
+ * Resolves a normalized group path to its Keycloak group ID. Uses an in-memory
+ * cache to avoid the `/groups` round trip on warm paths. On a cache miss,
+ * falls back to {@link findGroupByPath}, which also populates the cache.
+ */
+export async function findGroupIdByPath(
+  scope: string,
+): Promise<string | undefined> {
+  const cached = groupIdByPath.get(scope);
+  if (cached) return cached;
+
+  const group = await findGroupByPath(scope);
+  return group?.id;
+}
+
+/**
+ * Drops the cached ID for a group path. Call when a write fails with 404,
+ * indicating the underlying group was deleted or renamed.
+ */
+export function invalidateGroupIdCache(scope: string): void {
+  groupIdByPath.delete(scope);
+}
+
+/**
+ * Records a known path → ID mapping. Used after createGroup so the freshly
+ * created group's children/members lookups (e.g. the post-redirect loader)
+ * hit the cache immediately.
+ */
+export function cacheGroupId(scope: string, id: string): void {
+  groupIdByPath.set(scope, id);
+}
+
+/** Test-only: clears all cached path → ID mappings. */
+export function __resetGroupIdCache(): void {
+  groupIdByPath.clear();
 }
 
 function collectGroupIds(group: KeycloakGroup): string[] {
@@ -180,16 +242,22 @@ export async function createGroup(
   parentScope: string,
   name: string,
 ): Promise<{ id: string; path: string; adminsGroupId: string }> {
-  const parent = await findGroupByPath(parentScope);
-  if (!parent) {
+  const parentId = await findGroupIdByPath(parentScope);
+  if (!parentId) {
     throw new KeycloakAdminError(404, `Parent group not found: ${parentScope}`);
   }
 
-  const response = await adminMutate(
-    "POST",
-    `/groups/${parent.id}/children`,
-    { name },
-  );
+  let response: Response;
+  try {
+    response = await adminMutate("POST", `/groups/${parentId}/children`, {
+      name,
+    });
+  } catch (e) {
+    if (e instanceof KeycloakAdminError && e.status === 404) {
+      invalidateGroupIdCache(parentScope);
+    }
+    throw e;
+  }
 
   const location = response.headers.get("location");
   if (!location) {
@@ -222,9 +290,13 @@ export async function createGroup(
     throw e;
   }
 
+  const newGroupPath = `${parentScope}/${name}`;
+  cacheGroupId(newGroupPath, newGroupId);
+  cacheGroupId(`${newGroupPath}/admins`, adminsGroupId);
+
   return {
     id: newGroupId,
-    path: `${parentScope}/${name}`,
+    path: newGroupPath,
     adminsGroupId,
   };
 }

--- a/app/.server/auth/keycloakAdmin/index.ts
+++ b/app/.server/auth/keycloakAdmin/index.ts
@@ -3,6 +3,8 @@ export { type KeycloakGroup, type KeycloakUser } from "./client";
 export {
   createGroup,
   findGroupByPath,
+  findGroupIdByPath,
+  invalidateGroupIdCache,
   getManageableScopes,
   getGroupWithMembers,
   flattenGroupsWithIds,

--- a/app/.server/auth/keycloakAdmin/users.ts
+++ b/app/.server/auth/keycloakAdmin/users.ts
@@ -4,7 +4,7 @@ import {
   KeycloakAdminError,
   type KeycloakUser,
 } from "./client";
-import { findGroupByPath } from "./groups";
+import { findGroupIdByPath, invalidateGroupIdCache } from "./groups";
 
 export async function getUser(userId: string): Promise<KeycloakUser> {
   return adminFetch<KeycloakUser>(`/users/${userId}`);
@@ -45,8 +45,8 @@ export async function inviteUser(
   groupPath: string,
   enabled: boolean,
 ): Promise<void> {
-  const group = await findGroupByPath(groupPath);
-  if (!group) throw new Error(`Group not found: ${groupPath}`);
+  const groupId = await findGroupIdByPath(groupPath);
+  if (!groupId) throw new Error(`Group not found: ${groupPath}`);
 
   let userId: string;
   let isNewUser = true;
@@ -76,7 +76,14 @@ export async function inviteUser(
     }
   }
 
-  await adminMutate("PUT", `/users/${userId}/groups/${group.id}`);
+  try {
+    await adminMutate("PUT", `/users/${userId}/groups/${groupId}`);
+  } catch (e) {
+    if (e instanceof KeycloakAdminError && e.status === 404) {
+      invalidateGroupIdCache(groupPath);
+    }
+    throw e;
+  }
 
   if (isNewUser) {
     await adminMutate("PUT", `/users/${userId}/execute-actions-email`, [


### PR DESCRIPTION
## Description

Create-group action took >10s. Two root causes, both addressed here:

1. **`fetchGroups` used the wrong Keycloak query param.** Passing `q=<name>&exact=true` silently ignored the filter — `q` is for attribute search, and `exact=true` only modifies `search`. Keycloak returned the unfiltered top-level group set on every call.
2. **No caching of path → ID lookups.** The same parent scope was resolved on every call: in the action itself, and again in the post-redirect loader.

### Correctness fix (`fetchGroups`)

- Switch `q` → `search` so `exact=true` is honored.
- Add `max=1000` to defeat Keycloak's default page size of 20, which would silently truncate results in realms with many top-level groups.

### Perf addition (cache layer)

- In-process `LRUCache<path, id>` in `groups.ts` (max 500, TTL 10 min).
- New `findGroupIdByPath` for ID-only callers — cache hit = 0 network calls. Used by `createGroup` and `inviteUser`.
- `createGroup` pre-populates entries for the new group and its admins subgroup so the post-redirect loader is warm.
- Stale entries are invalidated when the parent POST in `createGroup` or the membership PUT in `inviteUser` returns 404. The asymmetric staleness on the write path was a review finding — symmetric handling now in both call sites.
- `cacheGroupId` is intentionally kept internal (not re-exported from `index.ts`) — only `findGroupIdByPath` and `invalidateGroupIdCache` are part of the public surface.

### Tests

- New `groupIdCache.test.ts` (10 tests): cache hit, miss → populate, side-effect warming, no-poison-on-undefined, `invalidateGroupIdCache`, `createGroup` pre-population, 404 invalidation in `createGroup`, rollback leaves cache clean, 404 invalidation in `inviteUser`, and the `fetchGroups` URL contract (`search` + `exact=true` + `max=1000` all present).
- The 5 existing test files that exercise `keycloakAdmin` now call `__resetGroupIdCache()` in `beforeEach` to isolate the module-level cache between tests.

## Related Issue

N/A — internal perf finding while investigating an unrelated Keycloak slowness report.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally (1107 passing)
- [x] I have updated documentation as needed (JSDoc on the cache + `fetchGroups`; no external docs touched)