### PR TITLE
feat(auth): redirect invitee to webapp after password setup (C-168)

### DIFF
--- a/app/.server/auth/__tests__/inviteUser.test.ts
+++ b/app/.server/auth/__tests__/inviteUser.test.ts
@@ -4,6 +4,10 @@ vi.mock("~/config", () => ({
   cytarioConfig: {
     auth: {
       baseUrl: "http://localhost:8080/realms/master",
+      clientId: "cytario-web",
+    },
+    endpoints: {
+      webapp: "https://webapp.example.com",
     },
   },
 }));
@@ -75,9 +79,9 @@ describe("inviteUser", () => {
       expect.objectContaining({ method: "PUT" }),
     );
 
-    // PUT to send email action
+    // PUT to send email action with redirect back to the webapp after password setup
     expect(fetchMock).toHaveBeenCalledWith(
-      `${BASE}/users/new-user-id/execute-actions-email`,
+      `${BASE}/users/new-user-id/execute-actions-email?client_id=cytario-web&redirect_uri=https%3A%2F%2Fwebapp.example.com`,
       expect.objectContaining({
         method: "PUT",
         body: JSON.stringify(["UPDATE_PASSWORD"]),
@@ -107,7 +111,9 @@ describe("inviteUser", () => {
 
     // Should NOT send email to existing user
     expect(fetchMock).not.toHaveBeenCalledWith(
-      `${BASE}/users/existing-user-id/execute-actions-email`,
+      expect.stringContaining(
+        `${BASE}/users/existing-user-id/execute-actions-email`,
+      ),
       expect.anything(),
     );
   });

--- a/app/.server/auth/keycloakAdmin/users.ts
+++ b/app/.server/auth/keycloakAdmin/users.ts
@@ -5,6 +5,7 @@ import {
   type KeycloakUser,
 } from "./client";
 import { findGroupByPath } from "./groups";
+import { cytarioConfig } from "~/config";
 
 export async function getUser(userId: string): Promise<KeycloakUser> {
   return adminFetch<KeycloakUser>(`/users/${userId}`);
@@ -79,8 +80,14 @@ export async function inviteUser(
   await adminMutate("PUT", `/users/${userId}/groups/${group.id}`);
 
   if (isNewUser) {
-    await adminMutate("PUT", `/users/${userId}/execute-actions-email`, [
-      "UPDATE_PASSWORD",
-    ]);
+    const params = new URLSearchParams({
+      client_id: cytarioConfig.auth.clientId,
+      redirect_uri: cytarioConfig.endpoints.webapp,
+    });
+    await adminMutate(
+      "PUT",
+      `/users/${userId}/execute-actions-email?${params}`,
+      ["UPDATE_PASSWORD"],
+    );
   }
 }


### PR DESCRIPTION
## Description

The `inviteUser` flow asks Keycloak to email a new user the `UPDATE_PASSWORD` required action via `PUT /admin/realms/{realm}/users/{user-id}/execute-actions-email`. Without `client_id` + `redirect_uri`, Keycloak strands the user on its account-management page once the action completes.

This change passes both query params (per the [Keycloak Admin REST API](https://www.keycloak.org/docs-api/latest/rest-api/index.html#_put_adminrealmsrealmusersuser_idexecute_actions_email)) so the user is redirected back to the webapp — and, since the `UPDATE_PASSWORD` flow ends with the user authenticated, they land signed in without a second login prompt.

- `client_id` = `cytarioConfig.auth.clientId` (the main webapp client)
- `redirect_uri` = `cytarioConfig.endpoints.webapp` (already a Valid Redirect URI on that client)

The body of the request is unchanged.

## Related Issue

C-168

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [ ] I have updated documentation as needed