### PR TITLE
fix(search): scope listing to connection prefix

### DIFF
--- a/app/routes/__tests__/search.route.test.tsx
+++ b/app/routes/__tests__/search.route.test.tsx
@@ -70,4 +70,105 @@ describe("SearchRoute", () => {
 
     expect(breadcrumb).toEqual({ label: "Search", to: "/search" });
   });
+
+  test("loader scopes each connection's listing to its own prefix and produces sibling top-level nodes when connections share a bucket", async () => {
+    vi.mocked(getS3Client).mockResolvedValue({} as S3Client);
+
+    const demoConfig = mock.connectionConfig({
+      name: "Repository Demo Deliverables",
+      bucketName: "shared-bucket",
+      prefix: "Repository Demo Deliverables/",
+    });
+    const slashmConfig = mock.connectionConfig({
+      name: "Repository Slash-m Exchange",
+      bucketName: "shared-bucket",
+      prefix: "Repository Slash-m Exchange/",
+    });
+
+    vi.mocked(getObjects).mockImplementation(
+      async (_config, _client, _query, prefix) => {
+        if (prefix === "Repository Demo Deliverables/") {
+          return [
+            {
+              Key: "Repository Demo Deliverables/results/demo.parquet",
+            },
+          ];
+        }
+        if (prefix === "Repository Slash-m Exchange/") {
+          return [
+            {
+              Key: "Repository Slash-m Exchange/results/USL-2022-42307-42.ome.tif/results/results_total.csv.parquet",
+            },
+          ];
+        }
+        return [];
+      },
+    );
+
+    const request = new Request("http://localhost/search?query=parquet");
+    const mockContext = {
+      get: vi.fn((ctx) => {
+        if (ctx === authContext) {
+          return {
+            user: mock.user(),
+            authTokens: {
+              idToken: mock.idToken(),
+              accessToken: "mock-access-token",
+              refreshToken: "mock-refresh-token",
+            },
+            credentials: {
+              [demoConfig.name]: mock.credentials(),
+              [slashmConfig.name]: mock.credentials(),
+            },
+            connectionConfigs: [demoConfig, slashmConfig],
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const result = await loader({
+      request,
+      params: {},
+      context: mockContext as never,
+      unstable_pattern: "",
+      unstable_url: new URL(request.url),
+    });
+
+    // Each connection should have been listed scoped to its own prefix.
+    expect(getObjects).toHaveBeenCalledWith(
+      demoConfig,
+      expect.anything(),
+      "parquet",
+      "Repository Demo Deliverables/",
+    );
+    expect(getObjects).toHaveBeenCalledWith(
+      slashmConfig,
+      expect.anything(),
+      "parquet",
+      "Repository Slash-m Exchange/",
+    );
+
+    // Top-level nodes are siblings — one per connection, neither nested in the other.
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes.map((n) => n.name)).toEqual([
+      "Repository Demo Deliverables",
+      "Repository Slash-m Exchange",
+    ]);
+
+    // Demo's tree must NOT contain the other connection's prefix as a directory.
+    const demoChildNames = result.nodes[0].children.map((c) => c.name);
+    expect(demoChildNames).not.toContain("Repository Slash-m Exchange");
+    expect(demoChildNames).toContain("results");
+
+    // Slash-m's first file path should be cleanly relative to its own prefix.
+    const slashmTree = result.nodes[1];
+    expect(slashmTree.children[0].name).toBe("results");
+    expect(slashmTree.children[0].children[0].name).toBe(
+      "USL-2022-42307-42.ome.tif",
+    );
+    expect(slashmTree.children[0].children[0].pathName).toBe(
+      "results/USL-2022-42307-42.ome.tif/",
+    );
+  });
 });

--- a/app/routes/search.route.tsx
+++ b/app/routes/search.route.tsx
@@ -12,11 +12,13 @@ import {
 } from "~/components/DirectoryView/buildDirectoryTree";
 import { DirectoryTree } from "~/components/DirectoryView/DirectoryViewTree";
 import { getObjects } from "~/utils/getObjects";
+import { getPrefix } from "~/utils/pathUtils";
 
 
 interface ConfigFiles {
   config: ConnectionConfig;
   files: _Object[];
+  prefix?: string;
 }
 
 export interface SearchRouteLoaderResponse {
@@ -51,15 +53,16 @@ export const loader = async ({
     }
 
     const s3Client = await getS3Client(connectionConfig, credentials, user.sub);
+    const prefix = getPrefix(connectionConfig.prefix);
     const files =
-      (await getObjects(connectionConfig, s3Client, searchQuery)) ?? [];
+      (await getObjects(connectionConfig, s3Client, searchQuery, prefix)) ?? [];
 
     if (files.length > 0) {
-      results.push({ config: connectionConfig, files });
+      results.push({ config: connectionConfig, files, prefix });
     }
   }
 
-  const nodes: TreeNode[] = results.map(({ config, files }) => ({
+  const nodes: TreeNode[] = results.map(({ config, files, prefix }) => ({
     id: `${config.name}/`,
     connectionName: config.name,
     name: config.name,
@@ -68,7 +71,7 @@ export const loader = async ({
     children: buildDirectoryTree(
       files as _Object[],
       config.name,
-      config.prefix ?? "",
+      prefix ?? "",
     ),
   }));
 


### PR DESCRIPTION
## Summary
- The search loader listed the entire bucket for every connection because `connectionConfig.prefix` was never forwarded to `getObjects`. When two connections shared a bucket, each connection's tree contained the other's keys — surfacing as a nested directory whose name equalled the foreign connection, with broken `id`/`pathName` strings on every node beneath it.
- Forward `getPrefix(connectionConfig.prefix)` to both `getObjects` (so `ListObjectsV2` only returns matching keys) and `buildDirectoryTree` (so stripping is consistent). This matches the pattern already in `connections.loader.ts` and `objects/objects.loader.ts`.
- Added a regression test in `app/routes/__tests__/search.route.test.tsx` that drives two connections sharing `shared-bucket` with different prefixes and asserts (a) `getObjects` is called with the right prefix per connection, (b) the resulting top-level nodes are siblings, and (c) no foreign-prefix directory leaks into either tree.

Plane: [C-172](https://plane.cytario.com) — added to Sprint 3.

Stacked on top of #87. Rebase once that lands.

## Test plan
- [ ] `npx vitest run app/routes/__tests__/search.route.test.tsx` passes
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] Manual: with two connections pointing to the same bucket but different prefixes, open the image viewer's *Add overlays* modal and confirm both repositories render as siblings, the path indicator shows a single connection's scope, and selecting a file loads correctly