### PR TITLE
fix(viewer): register geotiff decoders on every TIFF render path

### DIFF
--- a/app/components/.client/ImageViewer/components/Image/ImagePreview.tsx
+++ b/app/components/.client/ImageViewer/components/Image/ImagePreview.tsx
@@ -7,11 +7,16 @@ import { ImageContainer } from "./ImageContainer";
 import { useOverlaysLayers } from "./Overlays/useOverlaysLayer";
 import { useInitializeChannels } from "./useInitializeChannels";
 import { useView } from "./useView";
+import { registerDecoders } from "../../state/decoders/registerDecoders";
 import { select } from "../../state/store/selectors";
 import { ViewPort } from "../../state/store/types";
 import { useViewerStore } from "../../state/store/ViewerStoreContext";
 import { ActiveViewStatePreview } from "../Measurements/ActiveViewStatePreview";
 import { calculateViewStateToFit } from "../Measurements/calculateViewStateToFit";
+
+// Register geotiff decoders so dashboard thumbnails and the full viewer
+// can decode the same set of TIFF compression methods.
+registerDecoders();
 
 interface ViewProps {
   viewPort: ViewPort;

--- a/app/components/.client/ImageViewer/components/ImageViewer.tsx
+++ b/app/components/.client/ImageViewer/components/ImageViewer.tsx
@@ -1,26 +1,9 @@
-import { addDecoder } from "geotiff";
-
 import { FeatureBar } from "./FeatureBar/FeatureBar";
 import { ImagePanels } from "./ImagePanels";
 import { Magnifier } from "./Magnifier";
 import { ViewerHeader } from "./ViewerHeader";
-import { JP2KDecoder } from "../state/decoders/jp2k-decoder";
-import { LZWDecoder } from "../state/decoders/lzwDecoder";
 import { ViewerStoreProvider } from "../state/store/ViewerStoreContext";
 import type { SignedFetch } from "~/utils/signedFetch";
-
-/**
- * Register decoders for GeoTIFF files.
- * Must run client-side only — decoders use Web Workers.
- * Guarded to prevent duplicate registration during HMR.
- * @url https://github.com/vitessce/vitessce/issues/1709#issuecomment-2960537868
- */
-let decodersRegistered = false;
-if (!decodersRegistered) {
-  addDecoder(5, () => LZWDecoder);
-  addDecoder(33005, () => JP2KDecoder);
-  decodersRegistered = true;
-}
 
 interface ViewerProps {
   url: string;

--- a/app/components/.client/ImageViewer/state/decoders/genericDecoder.ts
+++ b/app/components/.client/ImageViewer/state/decoders/genericDecoder.ts
@@ -10,8 +10,16 @@ import { WorkerPool } from "./workerPool";
 const DEFAULT_WORKER_POOL_SIZE = 8;
 const CACHE_SIZE_LIMIT = 1000; // Limit cache to prevent memory leaks
 
-// Create a shared worker pool
-const workerPool = new WorkerPool(DecoderWorkerUrl, DEFAULT_WORKER_POOL_SIZE);
+// Lazy worker pool — instantiated on first decode so module load stays
+// side-effect free (test environments without Web Workers can import this
+// module just to register the decoder class).
+let workerPool: WorkerPool | null = null;
+const getWorkerPool = (): WorkerPool => {
+  if (!workerPool) {
+    workerPool = new WorkerPool(DecoderWorkerUrl, DEFAULT_WORKER_POOL_SIZE);
+  }
+  return workerPool;
+};
 
 // Cache for decoded blocks with LRU eviction
 const bufferCache = new LRUCache<number, ArrayBuffer>({
@@ -69,7 +77,7 @@ export class GenericDecoder extends BaseDecoder {
         }
 
         try {
-            const outputBuffer = await workerPool.runTask({
+            const outputBuffer = await getWorkerPool().runTask({
                 buffer: inputBuffer,
                 maxUncompressedSize: this.maxUncompressedSize,
                 decoderId: this.getDecoderId(),
@@ -125,6 +133,7 @@ export function clearDecoderCache(): void {
  * Terminates the worker pool and releases resources
  */
 export function shutdownDecoderPool(): void {
-    workerPool.terminate();
+    workerPool?.terminate();
+    workerPool = null;
     bufferCache.clear();
 }

--- a/app/components/.client/ImageViewer/state/decoders/registerDecoders.ts
+++ b/app/components/.client/ImageViewer/state/decoders/registerDecoders.ts
@@ -1,0 +1,17 @@
+import { addDecoder } from "geotiff";
+
+import { JP2KDecoder } from "./jp2k-decoder";
+import { LZWDecoder } from "./lzwDecoder";
+
+/**
+ * Register geotiff decoders. Idempotent — safe to call from any code path
+ * that decodes a TIFF (full viewer or dashboard thumbnails).
+ * @url https://github.com/vitessce/vitessce/issues/1709#issuecomment-2960537868
+ */
+let registered = false;
+export function registerDecoders(): void {
+  if (registered) return;
+  addDecoder(5, () => LZWDecoder);
+  addDecoder(33005, () => JP2KDecoder);
+  registered = true;
+}


### PR DESCRIPTION
Dashboard thumbnails on `/` failed to decode JPEG2000 TIFFs (`Unknown compression method 33005`) on a fresh load. Cause: `addDecoder` calls were hidden inside `ImageViewer.tsx`, which the dashboard never imports.

Move registration into a dedicated module (`registerDecoders.ts`) and call it from `ImagePreview` — the leaf rendered by both the thumbnail path and the full viewer's FeatureBar. Make the WorkerPool in `genericDecoder.ts` lazy so module load no longer spawns 8 worker threads on every dashboard visit.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 1043 pass, 8 skipped
- [ ] CI green
- [ ] Hard-reload of `/` on a connection with JPEG2000 TIFFs renders thumbnails