### PR TITLE
fix(routing): hoist RouterProvider into Layout so AppHeader is in scope

### DIFF
--- a/app/components/LavaLoader.tsx
+++ b/app/components/LavaLoader.tsx
@@ -1,15 +1,27 @@
 import { useState, useEffect, useCallback } from "react";
 import { twMerge } from "tailwind-merge";
 
-export const LavaLoader = ({
-  absolute = false,
-  rows = 3,
-  cols = 3,
-}: {
+import { ClientOnly } from "./ClientOnly";
+
+interface LavaLoaderProps {
   absolute?: boolean;
   rows?: number;
   cols?: number;
-}) => {
+}
+
+export const LavaLoader = (props: LavaLoaderProps) => (
+  // Inner uses Math.random() during render — wrap in ClientOnly so SSR
+  // doesn't disagree with hydration on the active dot's `r` attribute.
+  <ClientOnly>
+    <LavaLoaderInner {...props} />
+  </ClientOnly>
+);
+
+const LavaLoaderInner = ({
+  absolute = false,
+  rows = 3,
+  cols = 3,
+}: LavaLoaderProps) => {
   const totalDots = rows * cols;
   const size = 12;
   const duration = 500;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -99,6 +99,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   const data = useRouteLoaderData<RootLoaderResponse>("root");
   const location = useLocation();
   const navigation = useNavigation();
+  const navigate = useNavigate();
   const isInitialRender = useRef(true);
 
   useEffect(() => {
@@ -154,14 +155,16 @@ export function Layout({ children }: { children: React.ReactNode }) {
           </div>
         )}
 
-        {data?.user && <AppHeader />}
+        <RouterProvider navigate={navigate} useHref={useHref}>
+          {data?.user && <AppHeader />}
 
-        <main
-          id="main-content"
-          className="relative flex-1 min-h-0 outline-none"
-        >
-          {children}
-        </main>
+          <main
+            id="main-content"
+            className="relative flex-1 min-h-0 outline-none"
+          >
+            {children}
+          </main>
+        </RouterProvider>
 
         <div id="tooltip" />
         <ScrollRestoration />
@@ -172,14 +175,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const navigate = useNavigate();
-
   return (
-    <RouterProvider navigate={navigate} useHref={useHref}>
-      <ToastProvider bridge={toastBridge} placement="top-center">
-        <Outlet />
-      </ToastProvider>
-    </RouterProvider>
+    <ToastProvider bridge={toastBridge} placement="top-center">
+      <Outlet />
+    </ToastProvider>
   );
 }
 


### PR DESCRIPTION
`@cytario/design`'s `Breadcrumbs` uses `Link` from `react-aria-components`, which only does SPA navigation when wrapped in `RouterProvider`. We had `RouterProvider` inside the `App` default export, which only protects whatever's under `<Outlet/>` — but `AppHeader` (with the breadcrumbs) is rendered by `Layout`, outside the outlet. Every breadcrumb click triggered a full document reload.

Move `RouterProvider` into `Layout` wrapping `AppHeader` + `<main>`. `App` becomes just the toast-wrapped outlet.

Also fix a `LavaLoader` hydration mismatch: `Math.random()` was running during render, so SSR and client picked different active dots. Wrap the inner component in `ClientOnly` so the random init only happens client-side.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 1043 pass, 8 skipped
- [ ] CI green
- [ ] Click any breadcrumb, confirm SPA navigation (no document reload)
- [ ] Hard-reload a directory page, no React hydration warning in the console