### PR TITLE
feat(viewer): per-asset response-cache-control on signed S3 GETs (C-176)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,28 @@ jobs:
       - name: Dispatch E2E and wait
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
+          WEB_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Dispatch to main — the e2e.yml resolve step checks out the
-          # paired branch if it exists (using github.token which has
-          # contents:read on the docs repo). The App token only needs
-          # actions:write to trigger the workflow.
-          gh workflow run e2e.yml \
-            --repo cytario/cytario-docs \
-            --ref main \
-            -f ref="${{ github.event.pull_request.head.sha }}" \
-            -f docs_branch_hint="${{ github.head_ref }}"
+          # Dispatch the docs e2e workflow against the paired cytario-docs
+          # branch directly when one exists, falling back to main. This
+          # makes `--ref` carry the correct branch on first try; the docs
+          # workflow uses `actions/checkout` with no explicit `ref:` so it
+          # checks out whatever `--ref` was set to.
+          DOCS_REF="$HEAD_REF"
+          if ! gh workflow run e2e.yml \
+              --repo cytario/cytario-docs \
+              --ref "$DOCS_REF" \
+              -f ref="$WEB_SHA" 2>/dev/null; then
+            echo "::notice::No paired cytario-docs/$HEAD_REF branch; dispatching against main"
+            DOCS_REF="main"
+            gh workflow run e2e.yml \
+              --repo cytario/cytario-docs \
+              --ref "$DOCS_REF" \
+              -f ref="$WEB_SHA"
+          else
+            echo "::notice::Using paired cytario-docs branch: $HEAD_REF"
+          fi
 
           sleep 5
           RUN_ID=$(gh run list \

--- a/app/components/.client/ImageViewer/state/transport/__tests__/CredentialedHTTPStore.test.ts
+++ b/app/components/.client/ImageViewer/state/transport/__tests__/CredentialedHTTPStore.test.ts
@@ -103,8 +103,11 @@ describe("CredentialedHTTPStore", () => {
       const result = await store.get(".zattrs");
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
+      // `signedFetch` appends `?response-cache-control=...` so the browser
+      // HTTP cache can store the response. `.zattrs` is non-image data
+      // (1-hour ceiling).
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://bucket.s3.us-west-2.amazonaws.com/zarr/.zattrs",
+        "https://bucket.s3.us-west-2.amazonaws.com/zarr/.zattrs?response-cache-control=private%2C%20max-age%3D3600",
         expect.objectContaining({
           method: "GET",
           headers: expect.objectContaining({
@@ -216,7 +219,7 @@ describe("CredentialedHTTPStore", () => {
       await store.get("/.zattrs");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://bucket.s3.us-west-2.amazonaws.com/zarr/.zattrs",
+        "https://bucket.s3.us-west-2.amazonaws.com/zarr/.zattrs?response-cache-control=private%2C%20max-age%3D3600",
         expect.anything(),
       );
     });
@@ -235,8 +238,10 @@ describe("CredentialedHTTPStore", () => {
 
       await store.get("0/0/0/0/0/0/42");
 
+      // OME-Zarr chunk path (digits-only trailing segment) → image data
+      // → 7-day ceiling.
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://bucket.s3.us-west-2.amazonaws.com/data.zarr/0/0/0/0/0/0/42",
+        "https://bucket.s3.us-west-2.amazonaws.com/data.zarr/0/0/0/0/0/0/42?response-cache-control=private%2C%20max-age%3D604800",
         expect.anything(),
       );
     });
@@ -258,7 +263,7 @@ describe("CredentialedHTTPStore", () => {
       await store.get(".zattrs");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:9000/bucket/data.zarr/.zattrs",
+        "http://localhost:9000/bucket/data.zarr/.zattrs?response-cache-control=private%2C%20max-age%3D3600",
         expect.anything(),
       );
     });
@@ -278,7 +283,7 @@ describe("CredentialedHTTPStore", () => {
       await store.get("key");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:9000/bucket/path/key",
+        "http://localhost:9000/bucket/path/key?response-cache-control=private%2C%20max-age%3D3600",
         expect.anything(),
       );
     });

--- a/app/utils/__tests__/signedFetch.test.ts
+++ b/app/utils/__tests__/signedFetch.test.ts
@@ -143,4 +143,35 @@ describe("createSignedFetch", () => {
     const [, init] = mockFetch.mock.calls[0];
     expect(init.signal).toBe(controller.signal);
   });
+
+  test("appends 7-day response-cache-control for image tile URLs", async () => {
+    const sf = createSignedFetch(() => mockCredentials, mockConfig);
+    await sf(
+      "https://bucket.s3.eu-central-1.amazonaws.com/image.ome.tif",
+    );
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain(
+      "response-cache-control=private%2C%20max-age%3D604800",
+    );
+  });
+
+  test("appends 1-hour response-cache-control for non-image URLs", async () => {
+    const sf = createSignedFetch(() => mockCredentials, mockConfig);
+    await sf(
+      "https://bucket.s3.eu-central-1.amazonaws.com/image.offsets.json",
+    );
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain(
+      "response-cache-control=private%2C%20max-age%3D3600",
+    );
+  });
+
+  test("classifies OME-Zarr chunk paths as image data", async () => {
+    const sf = createSignedFetch(() => mockCredentials, mockConfig);
+    await sf("https://bucket.s3.eu-central-1.amazonaws.com/image.zarr/0/0/0");
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain(
+      "response-cache-control=private%2C%20max-age%3D604800",
+    );
+  });
 });

--- a/app/utils/signedFetch.ts
+++ b/app/utils/signedFetch.ts
@@ -10,9 +10,41 @@ export type SignedFetch = (
 ) => Promise<Response>;
 
 /**
+ * Cache-Control directive set on S3 GetObject responses for image data
+ * (OME-TIFF tiles, OME-Zarr chunks). These bytes are effectively immutable
+ * for the lifetime of an object version, so we let the chromium HTTP cache
+ * (and other Cache-Control-respecting caches) keep them for a week.
+ */
+const IMAGE_DATA_CACHE_CONTROL = "private, max-age=604800";
+
+/**
+ * Cache-Control directive for everything else (sidecars, overlays, JSON
+ * companions). Shorter ceiling so analyst regeneration surfaces within an
+ * hour without an explicit purge.
+ */
+const OTHER_DATA_CACHE_CONTROL = "private, max-age=3600";
+
+/**
+ * Image data per URL path: TIFF / OME-TIFF tile reads, or OME-Zarr chunks
+ * (last path segment is digits-only, e.g. `image.zarr/0/0/0`, or
+ * `image.zarr/0.0.0`).
+ */
+function isImageDataPath(pathname: string): boolean {
+  return (
+    /\.tiff?$/i.test(pathname) || /\/\d+(?:\.\d+)*$/.test(pathname)
+  );
+}
+
+/**
  * Create a fetch function that signs every request with AWS Signature V4.
  * Credentials are resolved lazily via a getter — the signer is recreated
  * automatically when the AccessKeyId changes (credential rotation).
+ *
+ * Every signed GET injects `response-cache-control` as a GetObject query
+ * override so the storage backend echoes a Cache-Control directive on the
+ * response. This lets the browser HTTP cache (chromium sparse-cache 206
+ * entries; Firefox cache 200 entries) serve repeat reads without a network
+ * round-trip — no application-layer cache layer is involved.
  */
 export function createSignedFetch(
   getCredentials: () => Credentials,
@@ -52,8 +84,17 @@ export function createSignedFetch(
     // double-encoded in the canonical request, causing a signature mismatch.
     const decodedPath = decodeURIComponent(parsed.pathname);
 
+    // Pick per-asset directive: image bytes are immutable per object version
+    // (7-day cache); everything else gets the 1-hour ceiling so analyst
+    // re-generations surface without an explicit cache purge.
+    const cacheControl = isImageDataPath(parsed.pathname)
+      ? IMAGE_DATA_CACHE_CONTROL
+      : OTHER_DATA_CACHE_CONTROL;
+
     // Only sign the host header — additional headers like Range are passed
-    // through unsigned to avoid CORS/signature mismatch issues.
+    // through unsigned to avoid CORS/signature mismatch issues. Query params
+    // are passed as a separate `query` field; smithy ignores anything in
+    // `path` after `?` when canonicalizing.
     const callerHeaders = (init?.headers as Record<string, string>) ?? {};
 
     const request = {
@@ -61,7 +102,8 @@ export function createSignedFetch(
       protocol: parsed.protocol,
       hostname: parsed.hostname,
       port: parsed.port ? parseInt(parsed.port) : undefined,
-      path: decodedPath + parsed.search,
+      path: decodedPath,
+      query: { "response-cache-control": cacheControl },
       headers: {
         host: parsed.host,
       },
@@ -69,7 +111,9 @@ export function createSignedFetch(
 
     const signed = await signer.sign(request);
 
-    return fetch(url, {
+    const wireUrl = `${parsed.origin}${parsed.pathname}?response-cache-control=${encodeURIComponent(cacheControl)}`;
+
+    return fetch(wireUrl, {
       ...init,
       method: request.method,
       headers: {


### PR DESCRIPTION
## Summary

Adds a `response-cache-control` GetObject query override to every signed S3 GET so the chromium/Safari HTTP cache stores 206 sparse entries for repeat reads. Per-asset directive: image data (`.tif*`, OME-Zarr chunks) gets `private, max-age=604800` (7 days); everything else gets `private, max-age=3600` (1 hour). No application-layer cache.

Refs C-176 (Plane).

Two commits:

- `feat(viewer)` — the per-asset directive itself + tests
- `chore(ci)` — dispatcher in `ci.yml` now passes the paired docs branch through `--ref` directly with a try-then-fallback on `main`. Paired with the cytario-docs branch's `docs_branch_hint` removal.

## Why not an IndexedDB cache layer?

This branch initially shipped a full IDB-backed cache wrapper (~700 LOC: keying, namespace per `(user, connection)`, LRU + budget eviction, inflight dedup, logout-time purge, identity-change purge via `useSessionFreshness`). Empirical investigation against an 82 GB OME-TIFF showed:

- Chromium HTTP cache stores 206 sparse entries keyed by URL + range when `Cache-Control` is set. Warm reload transfers zero wire bytes (same `x-amz-request-id` replayed from disk).
- Safari behaves equivalently.
- Firefox does **not** cache 206 from client-initiated `Range` headers ([Mozilla bug 286082](https://bugzilla.mozilla.org/show_bug.cgi?id=286082), `RESOLVED INCOMPLETE`, open since 2005).

For the ~80 % of users on chromium-based browsers, the IDB layer was functionally redundant — the browser was already caching for free — and added a small but real cold-write penalty (measurable in TSPEC-PERF-002 ratios). The Firefox-only benefit didn't justify the persistent-storage + identity-change-purge + LRU surface area. Decision recorded as SDS §7.6.

## Implementation

### Per-asset directive (`app/utils/signedFetch.ts`)

- Image data: `.tif`/`.tiff`/`.ome.tif`/`.ome.tiff` and OME-Zarr chunks (trailing path segment matches `\d+(\.\d+)*`) → `private, max-age=604800`.
- Other paths: `private, max-age=3600`.
- Directive is set as a smithy `query` field (separate from `path`) so SigV4 canonicalisation handles the parameter correctly. The wire URL re-assembles it after signing.

### CI dispatcher (`.github/workflows/ci.yml`)

Tries `gh workflow run e2e.yml --ref <head_ref>` first; falls back to `--ref main` when the paired docs branch doesn't exist. Drops the `-f docs_branch_hint=` indirection. Aligns with the docs branch dropping `docs_branch_hint` + the "Resolve cytario-docs ref" step.

### What changed vs main

- `app/utils/signedFetch.ts` — adds the `isImageDataPath()` classifier + per-asset directive injection.
- `app/utils/__tests__/signedFetch.test.ts` — 3 new tests: 7-day directive for `.tif`/`.tiff`, 1-hour for `.json`, OME-Zarr chunk classification.
- `app/components/.client/ImageViewer/state/transport/__tests__/CredentialedHTTPStore.test.ts` — 5 URL-shape assertions updated to include the new query suffix.
- `.github/workflows/ci.yml` — paired-branch `--ref` dispatch with `main` fallback.

That's it. No `signedFetchCache.ts`, no `useSessionFreshness`, no gated `/logout?purged=1` flow, no IDB hooks.

## Tests

- `npm run lint` / `npm run typecheck` — clean
- Full Vitest suite passes (pre-existing `.env.test` sandbox-denied file-level FAILs unrelated — same on main)
- Manual smoke in chromium via Playwright MCP: cold load → `cache-control: private, max-age=604800` on tile responses; F5 reload → identical `x-amz-request-id` replayed, zero wire bytes

## Test plan

- [x] Unit tests (signedFetch + CredentialedHTTPStore)
- [x] Manual chromium smoke (Playwright MCP) — cold/warm verified via response `x-amz-request-id`
- [x] e2e perf benchmark (TSPEC-PERF-002 in cytario-docs `feat/c-176-response-cache-control`) confirms warm/cold bytes ratio ≈ 0 % on chromium without regression vs main
- [ ] **Functional smoke in Safari** — same flow as chromium expected
- [ ] **Functional smoke in Firefox** — image will not be cached (bug 286082); accepted

## Companion docs branch

`cytario-docs` branch `feat/c-176-response-cache-control` (PR #34) contains:

- URS v2.2 + SRS v1.3 + SDS v1.1 (single consolidated version bump per doc).
- e2e: `viewer-cache-control.spec.ts` (per-asset directive + zero-byte warm reload assertions); `viewer-cache.perf.ts` (TSPEC-PERF-002).
- CI: ARM64 self-hosted runner; `docs_branch_hint` input dropped; `--ref` dispatch.

## Out of scope

- Firefox 206 caching: covered by Mozilla bug 286082; nothing we can fix here.
- Cytario-docs blog post on the decision: published separately (`cytario-com`).