### PR TITLE
fix(viewer): overlay marker color change now propagates to canvas [C-180]

### DIFF
--- a/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
@@ -159,13 +159,15 @@ export const OverlaysLayer = ({
   };
 
   return new TileLayer({
-    id: `MarkersLayer`,
+    // Unique id per overlay resource — multiple overlays would otherwise collide
+    // and deck.gl would reconcile them as the same layer, clobbering each other.
+    id: `MarkersLayer-${resourceId}`,
     refinementStrategy: "no-overlap",
     maxZoom,
     minZoom,
     extent: [0, 0, imageWidth, imageHeight],
 
-    // Only recalculate when relevant data changes
+    // Only recalculate when relevant data changes.
     updateTriggers: {
       // Tile data only changes when the dataset or markers change
       getTileData: [resourceId, Object.keys(fileMarkers).join(",")],
@@ -173,7 +175,6 @@ export const OverlaysLayer = ({
       getMarkerMask: [enabledMarkers, fileMarkers],
       getFillColor: [enabledMarkers, fileMarkers],
       getLineColor: [enabledMarkers, strokeOpacity],
-      markerOpacity: [markerProps.opacity], // GPU-only update
     },
     pickable: true,
     getTileData,

--- a/app/components/.client/ImageViewer/components/Image/Overlays/__tests__/OverlaysLayer.test.ts
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/__tests__/OverlaysLayer.test.ts
@@ -1,0 +1,106 @@
+import { vi } from "vitest";
+
+import type { CellMarker } from "../../../../state/store/types";
+import { createMarkerProps } from "../markerUniforms";
+import { OverlaysLayer } from "../OverlaysLayer";
+
+// deck.gl's TileLayer constructor pulls in the whole runtime (luma.gl, gl
+// matrices, etc.) which happy-dom can't handle. We only care about the
+// props object the layer was constructed with, so stub TileLayer to a
+// minimal class that captures the props verbatim.
+vi.mock("@deck.gl/geo-layers", () => ({
+  TileLayer: class {
+    props: Record<string, unknown>;
+    constructor(props: Record<string, unknown>) {
+      this.props = props;
+    }
+  },
+}));
+
+vi.mock("@deck.gl/layers", () => ({
+  PolygonLayer: class {
+    constructor(public props: Record<string, unknown>) {}
+  },
+}));
+
+vi.mock("../AdditiveScatterplotLayer", () => ({
+  AdditiveScatterplotLayer: class {
+    constructor(public props: Record<string, unknown>) {}
+  },
+}));
+
+vi.mock("../AdditivePolygonLayer", () => ({
+  AdditivePolygonLayer: class {
+    constructor(public props: Record<string, unknown>) {}
+  },
+}));
+
+const makeFileMarkers = (): Record<string, CellMarker> => ({
+  marker_positive_CD3: {
+    color: [255, 0, 0, 1],
+    count: 0,
+    isVisible: true,
+  },
+});
+
+const buildLayer = (
+  overrides: Partial<Parameters<typeof OverlaysLayer>[0]> = {}
+) => {
+  const fileMarkers = makeFileMarkers();
+  const markerProps = createMarkerProps(fileMarkers, 0.8);
+
+  const layer = OverlaysLayer({
+    resourceId: "res-1",
+    fileMarkers,
+    enabledMarkers: ["marker_positive_CD3"],
+    markerProps,
+    imageWidth: 1024,
+    imageHeight: 1024,
+    minZoom: 0,
+    maxZoom: 8,
+    strokeOpacity: 1,
+    loadTile: vi.fn(),
+    finishTile: vi.fn(),
+    ...overrides,
+  });
+
+  return layer as unknown as { props: Record<string, unknown> };
+};
+
+describe("OverlaysLayer", () => {
+  test("uses a TileLayer id that includes the resourceId to avoid collisions across overlays", () => {
+    const a = buildLayer({ resourceId: "alpha" });
+    const b = buildLayer({ resourceId: "beta" });
+
+    expect(a.props.id).toBe("MarkersLayer-alpha");
+    expect(b.props.id).toBe("MarkersLayer-beta");
+    expect(a.props.id).not.toBe(b.props.id);
+  });
+
+  test("updateTriggers.getTileData is unchanged when only markerProps changes (no tile reload)", () => {
+    const fileMarkers = makeFileMarkers();
+    const propsBefore = createMarkerProps(fileMarkers, 0.8);
+    const propsAfter = createMarkerProps(
+      {
+        ...fileMarkers,
+        marker_positive_CD3: {
+          ...fileMarkers.marker_positive_CD3,
+          color: [0, 255, 0, 1],
+        },
+      },
+      0.8
+    );
+
+    const before = buildLayer({ markerProps: propsBefore });
+    const after = buildLayer({ markerProps: propsAfter });
+
+    const getTileDataBefore = (
+      before.props.updateTriggers as { getTileData: unknown[] }
+    ).getTileData;
+    const getTileDataAfter = (
+      after.props.updateTriggers as { getTileData: unknown[] }
+    ).getTileData;
+
+    expect(getTileDataBefore).toEqual(getTileDataAfter);
+  });
+});

--- a/app/components/.client/ImageViewer/components/Image/Overlays/__tests__/markerUniforms.test.ts
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/__tests__/markerUniforms.test.ts
@@ -37,8 +37,12 @@ describe("createMarkerProps", () => {
     });
   });
 
-  describe("cycling behavior for markers >= 8", () => {
-    test("marker at index 8 maps to color slot 0 (8 % 8 = 0)", () => {
+  describe("cycling behavior for markers >= 8 (C-180 regression)", () => {
+    // The shader does color[i % 8] for marker bit i, so markers at indices
+    // 0 and 8 unavoidably share slot 0. The fix here is first-wins: slot 0's
+    // colour comes from marker 0, not marker 8. Editing marker 0's colour
+    // (the visible scenario for users) therefore propagates to the GPU.
+    test("first-wins: marker at index 0 owns slot 0 even when marker 8 exists", () => {
       const markers: Record<string, { color: RGBA }> = {};
       for (let i = 0; i <= 8; i++) {
         markers[`marker${i}`] = { color: [i * 10, i * 10, i * 10, 1] };
@@ -46,35 +50,32 @@ describe("createMarkerProps", () => {
 
       const result = createMarkerProps(markers, 0.8);
 
-      // Marker 8 should override slot 0 (last one wins)
-      expect(result.color0).toEqual([80, 80, 80, 1.0]);
+      expect(result.color0).toEqual([0, 0, 0, 1.0]);
     });
 
-    test("marker at index 9 maps to color slot 1 (9 % 8 = 1)", () => {
-      const markers: Record<string, { color: RGBA }> = {};
-      for (let i = 0; i <= 9; i++) {
-        markers[`marker${i}`] = { color: [i * 10, i * 10, i * 10, 1] };
-      }
-
-      const result = createMarkerProps(markers, 0.8);
-
-      // Marker 9 should override slot 1
-      expect(result.color1).toEqual([90, 90, 90, 1.0]);
-    });
-
-    test("last marker in each slot wins when multiple markers map to same slot", () => {
-      // Create 17 markers so indices 0, 8, 16 all map to slot 0
+    test("first-wins: editing marker 0's colour propagates to color0 (C-180)", () => {
       const markers: Record<string, { color: RGBA }> = {};
       for (let i = 0; i <= 16; i++) {
-        markers[`marker${i}`] = { color: [i * 10, i * 10, i * 10, 1] };
+        markers[`marker${i}`] = { color: [255, 0, 0, 1] };
       }
+      // User flips marker 0 to magenta. Slot 0 must follow.
+      markers["marker0"] = { color: [255, 0, 255, 1] };
 
       const result = createMarkerProps(markers, 0.8);
 
-      // Index 16 maps to slot 0 (16 % 8 = 0), overriding indices 0 and 8
-      expect(result.color0).toEqual([160, 160, 160, 1.0]);
-      // Index 9 maps to slot 1 (9 % 8 = 1), overriding index 1
-      expect(result.color1).toEqual([90, 90, 90, 1.0]);
+      expect(result.color0).toEqual([255, 0, 255, 1.0]);
+    });
+
+    test("slots beyond the marker count default to transparent black", () => {
+      const markers: Record<string, { color: RGBA }> = {
+        marker0: { color: [255, 0, 0, 1] },
+      };
+
+      const result = createMarkerProps(markers, 0.8);
+
+      expect(result.color0).toEqual([255, 0, 0, 1.0]);
+      expect(result.color1).toEqual([0, 0, 0, 0]);
+      expect(result.color7).toEqual([0, 0, 0, 0]);
     });
   });
 

--- a/app/components/.client/ImageViewer/components/Image/Overlays/markerUniforms.ts
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/markerUniforms.ts
@@ -58,8 +58,20 @@ export const markerUniforms = {
 
 /**
  * Create MarkerProps from fileMarkers record.
- * The shader supports 32 marker bits but only 8 color slots (cycling with i % 8).
- * For each color slot, we use the last marker that maps to it (indices: slot, slot+8, slot+16, slot+24).
+ *
+ * The shader supports 32 marker bits but only 8 color slots (the bit-to-color
+ * mapping is `i % 8` in the fragment shader). Multiple markers can therefore
+ * collide on a single slot; the OverlaysController exposes a per-marker color
+ * picker that lets the user override any individual marker's color.
+ *
+ * Slot assignment is FIRST-wins: slot `s` takes its color from
+ * `fileMarkers[keys[s]]` (the lowest-indexed marker that maps to that slot).
+ * Last-wins (the previous behaviour) caused C-180: editing the colour of any
+ * marker with index < 8 had no visible effect once a higher-indexed marker
+ * shared its slot, because the higher index silently overwrote the slot on
+ * every recompute. Markers at indices 8+ still cycle through the same eight
+ * colour slots — a fundamental limit of the 8-slot shader uniform — so they
+ * render in the colour of their cycle partner.
  */
 export function createMarkerProps(
   fileMarkers: Record<string, { color: RGBA }>,
@@ -67,17 +79,9 @@ export function createMarkerProps(
 ): MarkerProps {
   const keys = Object.keys(fileMarkers);
 
-  // For each color slot, find the marker(s) that map to it (i % 8 === slot)
-  // Use the last one that exists to ensure colors for markers 8+ are respected
   const getColor = (slot: number): RGBA => {
-    let color: RGBA = [0, 0, 0, 0];
-    for (let i = slot; i < keys.length; i += 8) {
-      const c = fileMarkers[keys[i]]?.color;
-      if (c) {
-        color = [c[0], c[1], c[2], 1.0];
-      }
-    }
-    return color;
+    const c = fileMarkers[keys[slot]]?.color;
+    return c ? [c[0], c[1], c[2], 1.0] : [0, 0, 0, 0];
   };
 
   return {


### PR DESCRIPTION
## Summary
- Root cause: `createMarkerProps` used last-wins slot cycling (`i % 8`). With 9+ markers, marker 8's default silently overwrote marker 0's slot every recompute, so editing the color of any marker with index `< 8` never reached the GPU. Flipped to first-wins — the user-visible marker drives its slot. Markers ≥ 8 still cycle through the same eight colors (shader-uniform limit, not a correctness bug).
- Latent multi-overlay bug: the per-overlay `TileLayer` had a hardcoded `id: "MarkersLayer"`, so two parquet overlays reconciled as the same layer and one silently clobbered the other. Suffixed the id with `resourceId`.
- Dropped dead `markerOpacity` updateTriggers key (no accessor by that name exists; the trigger invalidated nothing).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npx vitest run app/components/.client/ImageViewer/components/Image/Overlays` — 9 tests pass (incl. new C-180 regression case + new id-uniqueness test)
- [x] E2E reproducer in `cytario-docs#fix/c-180-overlay-color-not-applied` passes against this branch (`overlay-color.spec.ts`)

Ticket: C-180