### PR TITLE
fix(deps): bump @cytario/design 3.3.0 → 3.4.0, import precompiled CSS

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,6 +29,7 @@ import { cytarioConfig } from "./config";
 import { toastBridge, toToastVariant } from "./toast-bridge";
 import { useFileStore } from "./utils/localFilesStore/useFileStore";
 
+import "@cytario/design/styles.css";
 import "@cytario/design/tokens/variables.css";
 import "@cytario/design/tokens/variables-dark.css";
 import "./tailwind.css";

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -2,9 +2,6 @@
 @import "tw-animate-css";
 @plugin "tailwindcss-react-aria-components";
 
-/* Scan @cytario/design dist for class usage */
-@source "@cytario/design/dist";
-
 /* Match cytario-design's selector convention */
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/client-sts": "^3.687.0",
         "@aws-sdk/s3-request-presigner": "^3.693.0",
         "@cornerstonejs/codec-openjpeg": "^1.3.0",
-        "@cytario/design": "^3.3.0",
+        "@cytario/design": "^3.4.0",
         "@deck.gl/core": "~9.1.15",
         "@deck.gl/extensions": "~9.1.15",
         "@deck.gl/geo-layers": "~9.1.15",
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/@cytario/design": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-3.3.0.tgz",
-      "integrity": "sha512-O/TRuzzTlu5/0CjQiprL0ewgPVNm34xwBuZf5wG2L+Cww3gqE98oT5wbNzgaegWHP0CcjZ10gLDHquY2Ae8Lww==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-3.4.0.tgz",
+      "integrity": "sha512-gFgJUWyyOuDPAE4zr5XlT1iJnqRCkjEmvyiHVdBalKtaHgUuAAa+xKIVggWJ5xSP0nT+3CTiHtGNclO9YaSaKQ==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "react-arborist": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-sts": "^3.687.0",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cytario/design": "^3.3.0",
+    "@cytario/design": "^3.4.0",
     "@deck.gl/core": "~9.1.15",
     "@deck.gl/extensions": "~9.1.15",
     "@deck.gl/geo-layers": "~9.1.15",


### PR DESCRIPTION
## Summary

- Bump `@cytario/design` to `3.4.0`, which ships a precompiled `dist/index.css` containing every utility class its components use.
- Add `import "@cytario/design/styles.css"` in `app/root.tsx` alongside the existing token imports.
- Drop `@source "../node_modules/@cytario/design/dist"` from `app/tailwind.css` — no longer needed, and supersedes `d260075`'s broken bare-specifier attempt.

## Background

Tailwind v4's oxide extractor silently dropped some class patterns when reached via `@source` into `node_modules/@cytario/design/dist/index.js` — notably `bg-(--color-badge-*-bg)`, `text-(--color-badge-*-text)`, `aspect-[4/3]`, and `rounded-t-(--border-radius-lg)`. The `border-(--color-badge-*-text)/20` form (with `/20` opacity suffix) extracted correctly, which is why pills rendered with a border but no fill.

Visible regressions this fixes:

- Pills (`Pill`, `ProviderPill`, `ScopePill`): outlined-only → filled with their hashed color.
- `FileCard` previews (Recently Viewed): preview wrapper collapsed to 0px height → renders with the 4/3 aspect ratio and a deck.gl thumbnail.
- Breadcrumb separators: missing → render.

Hoisting compounded the problem in cytario-ee: `cytario-web build` runs with `cwd = node_modules/@cytario/web`, so `../node_modules/@cytario/design/dist` failed to resolve at all once npm hoisted design out of web's nested `node_modules`. The `d260075` bare-specifier attempt didn't fix that either — Tailwind 4.2.x doesn't resolve module specifiers in `@source`.

Migrating CSS generation into the design package itself eliminates the entire class of bug. See `cytario-design/PRECOMPILE.md` for the full rationale.

## Test plan

- [x] `node bin/cytario-web.mjs build` — confirm `build/client/assets/*.css` contains `.bg-\(--color-badge-amber-bg\)`, `.aspect-\[4\/3\]`, `.rounded-t-\(--border-radius-lg\)`.
- [x] `npm run lint` — passes.
- [x] `npm run typecheck` — passes.
- [ ] Smoke against cytario-ee 1.1.x with this cytario-web release: pills filled, Recently Viewed thumbnails render, breadcrumbs show separators.
- [ ] Revert `d260075` lands together with this commit (already superseded by removing the `@source` line entirely).