### PR TITLE
fix(publish): bundle duckdb extensions in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "prepare": "husky || true",
-    "prepublishOnly": "npm run build:server",
+    "prepack": "npm run build:server && node scripts/prebuild.mjs",
     "prebuild": "node scripts/prebuild.mjs",
     "build": "node bin/cytario-web.mjs build",
     "build:server": "tsup --config tsup.server.config.ts",


### PR DESCRIPTION
## Summary

- Move `npm run build:server` from `prepublishOnly` to `prepack` and chain `scripts/prebuild.mjs` so DuckDB-WASM extensions (`httpfs`, `spatial`, `parquet` × `wasm_mvp`/`wasm_eh`/`wasm_threads`) are downloaded into `public/duckdb-extensions/v1.4.3/` before npm assembles the tarball.
- Fixes downstream consumers (e.g. cytario-ee) installing `@cytario/web` from the npm registry — previously the published tarball shipped only `public/duckdb-extensions/checksums.json`, so runtime fetches of `/duckdb-extensions/v1.4.3/wasm_eh/httpfs.duckdb_extension.wasm` returned the SPA index.html fallback and DuckDB rejected with `need to see wasm magic number`.
- `prepack` fires on both `npm publish` (via semantic-release) and `npm pack` (local verification), keeping the tarball consistent across both paths. Avoids the CDN fallback to `extensions.duckdb.org`, preserving the C-198 CSP/egress posture.

## Test plan

- [ ] `npm pack --dry-run` lists 9 `.wasm` paths under `public/duckdb-extensions/v1.4.3/`
- [ ] `npm pack` produces tarball; extract and confirm `public/duckdb-extensions/v1.4.3/wasm_eh/httpfs.duckdb_extension.wasm` is real WASM (`file <path>` shows `WebAssembly`)
- [ ] Install packed tarball into cytario-ee, boot, open a page that issues `INSTALL httpfs;` — DuckDB loads without `need to see wasm magic number`
- [ ] CI green (lint + typecheck + tests + format:check)