### PR TITLE
fix(c-200): grant kms:Decrypt in inline STS session policy

### DIFF
--- a/app/.server/auth/__tests__/getSessionCredentials.test.ts
+++ b/app/.server/auth/__tests__/getSessionCredentials.test.ts
@@ -244,7 +244,11 @@ describe("getAllSessionCredentials", () => {
       RoleSessionName: "Test-User",
       WebIdentityToken: "id-token-for-sts",
       DurationSeconds: 3600,
-      Policy: buildSessionPolicy({ bucketName: "test-bucket", prefix: "" }),
+      Policy: buildSessionPolicy({
+        bucketName: "test-bucket",
+        prefix: "",
+        region: "us-west-2",
+      }),
     });
   });
 
@@ -260,6 +264,7 @@ describe("getAllSessionCredentials", () => {
     const expectedPolicy = buildSessionPolicy({
       bucketName: "scoped-bucket",
       prefix: "tenant-a",
+      region: "us-east-1",
     });
 
     expect(AssumeRoleWithWebIdentityCommand).toHaveBeenCalledWith(
@@ -276,7 +281,11 @@ describe("getAllSessionCredentials", () => {
       }),
     ]);
 
-    const expectedPolicy = buildSessionPolicy({ bucketName: "whole-bucket", prefix: "" });
+    const expectedPolicy = buildSessionPolicy({
+      bucketName: "whole-bucket",
+      prefix: "",
+      region: "us-east-1",
+    });
 
     expect(AssumeRoleWithWebIdentityCommand).toHaveBeenCalledWith(
       expect.objectContaining({ Policy: expectedPolicy }),

--- a/app/.server/auth/__tests__/sessionPolicy.test.ts
+++ b/app/.server/auth/__tests__/sessionPolicy.test.ts
@@ -9,6 +9,9 @@ interface PolicyStatement {
     StringLike?: {
       "s3:prefix"?: string[];
     };
+    StringEquals?: {
+      "kms:ViaService"?: string;
+    };
   };
 }
 
@@ -25,9 +28,13 @@ const findStatement = (policy: ParsedPolicy, action: string): PolicyStatement =>
   return stmt;
 };
 
+const REGION = "eu-central-1";
+
 describe("buildSessionPolicy", () => {
   test("empty prefix → whole-bucket scope (no s3:prefix Condition, GetObject on bucket/*)", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "", region: REGION }),
+    );
 
     expect(policy.Version).toBe("2012-10-17");
 
@@ -45,21 +52,27 @@ describe("buildSessionPolicy", () => {
   });
 
   test("null prefix → whole-bucket scope (no s3:prefix Condition)", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: null }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: null, region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition).toBeUndefined();
     expect(findStatement(policy, "s3:GetObject").Resource).toBe("arn:aws:s3:::my-bucket/*");
   });
 
   test("undefined prefix → whole-bucket scope (no s3:prefix Condition)", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: undefined }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: undefined, region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition).toBeUndefined();
     expect(findStatement(policy, "s3:GetObject").Resource).toBe("arn:aws:s3:::my-bucket/*");
   });
 
   test("non-empty prefix → restricted listing and GetObject scope", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo", region: REGION }),
+    );
 
     const list = findStatement(policy, "s3:ListBucket");
     expect(list.Resource).toBe("arn:aws:s3:::my-bucket");
@@ -74,7 +87,9 @@ describe("buildSessionPolicy", () => {
     // slash so a `ListBucket prefix=foo` (no slash) would not match —
     // which prevents the leak of cross-tenant keys whose names happen
     // to start with the connection prefix.
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo", region: REGION }),
+    );
 
     const allowed = findStatement(policy, "s3:ListBucket").Condition?.StringLike?.["s3:prefix"];
     expect(allowed).not.toContain("foo");
@@ -83,7 +98,9 @@ describe("buildSessionPolicy", () => {
   });
 
   test("multi-segment prefix preserved verbatim", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "tenant-a/data" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "tenant-a/data", region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition?.StringLike?.["s3:prefix"]).toEqual([
       "tenant-a/data/",
@@ -95,7 +112,9 @@ describe("buildSessionPolicy", () => {
   });
 
   test("leading slash stripped from prefix", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "/foo" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "/foo", region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition?.StringLike?.["s3:prefix"]).toEqual([
       "foo/",
@@ -105,7 +124,9 @@ describe("buildSessionPolicy", () => {
   });
 
   test("trailing slash stripped from prefix", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo/" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo/", region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition?.StringLike?.["s3:prefix"]).toEqual([
       "foo/",
@@ -115,7 +136,9 @@ describe("buildSessionPolicy", () => {
   });
 
   test("leading and trailing slashes both stripped from prefix", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "/foo/" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "/foo/", region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition?.StringLike?.["s3:prefix"]).toEqual([
       "foo/",
@@ -125,14 +148,16 @@ describe("buildSessionPolicy", () => {
   });
 
   test("only-slashes prefix collapses to whole-bucket scope (no s3:prefix Condition)", () => {
-    const policy = parse(buildSessionPolicy({ bucketName: "my-bucket", prefix: "///" }));
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "///", region: REGION }),
+    );
 
     expect(findStatement(policy, "s3:ListBucket").Condition).toBeUndefined();
     expect(findStatement(policy, "s3:GetObject").Resource).toBe("arn:aws:s3:::my-bucket/*");
   });
 
   test("stringified output is valid, parseable JSON", () => {
-    const json = buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo" });
+    const json = buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo", region: REGION });
     expect(() => JSON.parse(json)).not.toThrow();
     const parsed = JSON.parse(json) as ParsedPolicy;
     expect(parsed).toHaveProperty("Version", "2012-10-17");
@@ -141,20 +166,55 @@ describe("buildSessionPolicy", () => {
 
   test("stringified output is well under 2048 chars for a max-realistic prefix (64 chars)", () => {
     const prefix = "a".repeat(64);
-    const json = buildSessionPolicy({ bucketName: "my-bucket-with-some-length", prefix });
+    const json = buildSessionPolicy({
+      bucketName: "my-bucket-with-some-length",
+      prefix,
+      region: REGION,
+    });
     // AWS strips whitespace before counting; JSON.stringify without indentation has none.
     expect(json.length).toBeLessThanOrEqual(2048);
   });
 
   test("rejects prefix containing IAM `*` wildcard", () => {
-    expect(() => buildSessionPolicy({ bucketName: "shared", prefix: "tenant-a*" })).toThrow(
-      /wildcard/i,
-    );
+    expect(() =>
+      buildSessionPolicy({ bucketName: "shared", prefix: "tenant-a*", region: REGION }),
+    ).toThrow(/wildcard/i);
   });
 
   test("rejects prefix containing IAM `?` wildcard", () => {
-    expect(() => buildSessionPolicy({ bucketName: "shared", prefix: "tenant-?" })).toThrow(
-      /wildcard/i,
+    expect(() =>
+      buildSessionPolicy({ bucketName: "shared", prefix: "tenant-?", region: REGION }),
+    ).toThrow(/wildcard/i);
+  });
+
+  test("includes kms:Decrypt statement constrained to S3 via service for the connection region", () => {
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo", region: REGION }),
     );
+
+    const kms = findStatement(policy, "kms:Decrypt");
+    expect(kms.Effect).toBe("Allow");
+    // Resource is `*` because cytario does not store the customer's KMS key
+    // ARN — the role's attached policy is the authoritative key allowlist.
+    expect(kms.Resource).toBe("*");
+    expect(kms.Condition?.StringEquals?.["kms:ViaService"]).toBe("s3.eu-central-1.amazonaws.com");
+  });
+
+  test("kms:ViaService tracks the requested region", () => {
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "foo", region: "us-east-1" }),
+    );
+
+    expect(findStatement(policy, "kms:Decrypt").Condition?.StringEquals?.["kms:ViaService"]).toBe(
+      "s3.us-east-1.amazonaws.com",
+    );
+  });
+
+  test("kms:Decrypt statement is present even for whole-bucket (empty prefix) policies", () => {
+    const policy = parse(
+      buildSessionPolicy({ bucketName: "my-bucket", prefix: "", region: REGION }),
+    );
+
+    expect(() => findStatement(policy, "kms:Decrypt")).not.toThrow();
   });
 });

--- a/app/.server/auth/getSessionCredentials.ts
+++ b/app/.server/auth/getSessionCredentials.ts
@@ -52,7 +52,9 @@ const fetchTemporaryCredentials = async (
     // Non-AWS providers (e.g. MinIO) may ignore or reject the `Policy` field,
     // so we omit it there — the role's intrinsic scope is the only bound.
     const sessionPolicy =
-      provider === "aws" ? buildSessionPolicy({ bucketName, prefix }) : undefined;
+      provider === "aws"
+        ? buildSessionPolicy({ bucketName, prefix, region: actualRegion })
+        : undefined;
 
     const command = new AssumeRoleWithWebIdentityCommand({
       RoleArn: roleArn ?? undefined,

--- a/app/.server/auth/sessionPolicy.ts
+++ b/app/.server/auth/sessionPolicy.ts
@@ -12,12 +12,13 @@
 export interface SessionPolicyArgs {
   bucketName: string;
   prefix: string | null | undefined;
+  region: string;
 }
 
 const stripSlashes = (prefix: string): string => prefix.replace(/^\/+|\/+$/g, "");
 
 /** Build an inline IAM session policy for `AssumeRoleWithWebIdentityCommand`. */
-export const buildSessionPolicy = ({ bucketName, prefix }: SessionPolicyArgs): string => {
+export const buildSessionPolicy = ({ bucketName, prefix, region }: SessionPolicyArgs): string => {
   const normalised = typeof prefix === "string" ? stripSlashes(prefix) : "";
   // Defense-in-depth: refuse wildcards here so the schema is not the only gate
   // protecting cross-tenant `StringLike` conditions.
@@ -52,6 +53,23 @@ export const buildSessionPolicy = ({ bucketName, prefix }: SessionPolicyArgs): s
         Resource: bucketArn,
       };
 
+  // STS intersects this policy with the role's attached policy. Without an
+  // explicit `kms:Decrypt` here, the role's KMS grant is stripped and
+  // `GetObject` against SSE-KMS-encrypted buckets fails. `kms:ViaService`
+  // restricts use of the minted credential to the S3 data path; the role's
+  // attached policy remains the authoritative key allowlist.
+  const decryptStatement = {
+    Sid: "DecryptViaS3",
+    Effect: "Allow",
+    Action: "kms:Decrypt",
+    Resource: "*",
+    Condition: {
+      StringEquals: {
+        "kms:ViaService": `s3.${region}.amazonaws.com`,
+      },
+    },
+  };
+
   const policy = {
     Version: "2012-10-17",
     Statement: [
@@ -62,6 +80,7 @@ export const buildSessionPolicy = ({ bucketName, prefix }: SessionPolicyArgs): s
         Action: "s3:GetObject",
         Resource: objectArn,
       },
+      decryptStatement,
     ],
   };
 


### PR DESCRIPTION
## Summary

- Add `kms:Decrypt` statement to the inline IAM session policy on every `AssumeRoleWithWebIdentity` call so `GetObject` against SSE-KMS-encrypted buckets stops failing with `no session policy allows the kms:Decrypt action`.
- Statement scope: `Resource: "*"` with `Condition.StringEquals."kms:ViaService" = "s3.<region>.amazonaws.com"` — the role's attached policy is the authoritative key allowlist; the `ViaService` condition keeps the minted credential constrained to the S3 data path so it cannot be used to call KMS directly.
- Region threaded from `connectionConfig.region` into `buildSessionPolicy`, sharing the existing `eu-central-1` fallback applied to the STS endpoint in `fetchTemporaryCredentials`.

## Root cause

C-198 introduced the inline session policy to bound the minted credential to the connection prefix. STS intersects the inline policy with the role's attached policy, so any action absent from the inline allowance is dropped from the minted credential. The inline policy granted only `s3:ListBucket` and `s3:GetObject`, which silently stripped the role's `kms:Decrypt` grant. Result: `GetObject` against any SSE-KMS-encrypted bucket (CMK or AWS-managed `aws/s3`) returned `403 AccessDenied` even when the role policy permitted it. SSE-S3 and MinIO connections were unaffected (no caller-side KMS step; MinIO skips the inline policy entirely).

Reproduction string was the exact error AWS returns: `User: arn:aws:sts::…:assumed-role/… is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:…:key/… because no session policy allows the kms:Decrypt action`.

## Docs

Companion PR in `cytario-docs` (branch `fix/sse-kms-session-policy`) covers URS-CY-10512, SRS-CY-42107, SDS-CY-010307, §7.8 compensating control (1), and the handbook `bucket-permissions.md` SSE-KMS section.

## Test plan

- [x] `sessionPolicy.test.ts` — three new tests: KMS statement present with correct `ViaService`, region tracking, KMS statement included even for whole-bucket (empty prefix) policies.
- [x] `getSessionCredentials.test.ts` — call-site assertions updated to thread `region` through `buildSessionPolicy`.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npx prettier --check` clean.
- [x] Manual verification in browser against an SSE-KMS-encrypted bucket (`ultivue.cytario`, customer-managed CMK): pre-fix returns `kms:Decrypt … no session policy allows`; post-fix `GetObject` succeeds after re-login to bust the cached STS credential.

[C-200]