### PR TITLE
fix(c-201): pass external URLs through React Aria RouterProvider [C-201]

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -7,7 +7,6 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-  useHref,
   useLocation,
   useNavigate,
   useNavigation,
@@ -156,7 +155,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
           </div>
         )}
 
-        <RouterProvider navigate={navigate} useHref={useHref}>
+        {/* No `useHref`: RR's collapses `//` in absolute URLs (C-201).
+            Only needed for basename / hash routing — neither is in use. */}
+        <RouterProvider navigate={navigate}>
           {data?.user && <AppHeader />}
 
           <main id="main-content" className="relative flex-1 min-h-0 outline-none">


### PR DESCRIPTION
## Summary
- React Router's `useHref` collapsed `//` in absolute URLs and re-anchored them against the current origin, so the Account Settings menu item's `https://auth.…` href rendered as `https://app.…/https:/auth.…/…` (C-201).
- `RouterProvider`'s `useHref` prop is only needed for basename or hash routing — neither is configured here. Dropping it lets React Aria's default identity function pass hrefs through unchanged; its click handler still routes same-origin links through `navigate` and falls through to native navigation for cross-origin links.

## Test plan
- [ ] E2E `e2e/specs/account-settings.spec.ts` (SRS-CY-31301) passes — both `menuitem` href assertion and popup origin assertion.
- [ ] In-app links (`/admin/users`, `/logout`, etc.) still navigate via React Router without full page loads.
- [ ] Account Settings opens Keycloak account console at `https://auth.<env>/realms/cytario/account?referrer=cytario-web&referrer_uri=<webapp origin>` in a new tab.

Refs: SRS-CY-31301, SDS-CY-010201