### PR TITLE
fix(viewer): retry transient range-request failures in SigV4TiffClient

### DIFF
--- a/app/components/.client/ImageViewer/state/transport/SigV4TiffClient.ts
+++ b/app/components/.client/ImageViewer/state/transport/SigV4TiffClient.ts
@@ -9,32 +9,114 @@ import type { SignedFetch } from "~/utils/signedFetch";
  * per-request headers geotiff passes (e.g. `Range`) so the per-request
  * `Range` always wins — caller-supplied headers describe load-wide
  * intent (Accept, If-None-Match, Cache-Control), not byte ranges.
+ *
+ * Transient range-request failures are retried with exponential backoff +
+ * jitter. geotiff's BlockedSource aggregates any single failed block into
+ * an AggregateError that poisons the whole IFD parse, and geotiff itself
+ * does not retry HTTP errors — so the retry must live here.
  */
+
+export interface SigV4TiffClientRetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 100;
+const DEFAULT_MAX_DELAY_MS = 2000;
+
+function isTransientStatus(status: number): boolean {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function backoffDelayMs(attempt: number, baseMs: number, maxMs: number): number {
+  const exp = Math.min(maxMs, baseMs * 2 ** attempt);
+  return exp / 2 + Math.random() * (exp / 2);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export class SigV4TiffClient {
   url: string;
   private signedFetch: SignedFetch;
   private extraHeaders: Record<string, string>;
+  private maxAttempts: number;
+  private baseDelayMs: number;
+  private maxDelayMs: number;
 
-  constructor(url: string, signedFetch: SignedFetch, extraHeaders?: Record<string, string>) {
+  constructor(
+    url: string,
+    signedFetch: SignedFetch,
+    extraHeaders?: Record<string, string>,
+    retry?: SigV4TiffClientRetryOptions,
+  ) {
     this.url = url;
     this.signedFetch = signedFetch;
     this.extraHeaders = extraHeaders ?? {};
+    this.maxAttempts = Math.max(1, retry?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+    this.baseDelayMs = retry?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+    this.maxDelayMs = retry?.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
   }
 
   async request({ headers, signal }: { headers?: HeadersInit; signal?: AbortSignal } = {}) {
-    const response = await this.signedFetch(this.url, {
-      headers: {
-        ...this.extraHeaders,
-        ...(headers as Record<string, string> | undefined),
-      },
-      signal,
-    });
-
-    return {
-      ok: response.ok,
-      status: response.status,
-      getHeader: (name: string) => response.headers.get(name) ?? "",
-      getData: () => response.arrayBuffer(),
+    const mergedHeaders = {
+      ...this.extraHeaders,
+      ...(headers as Record<string, string> | undefined),
     };
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < this.maxAttempts; attempt++) {
+      if (signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
+      try {
+        const response = await this.signedFetch(this.url, {
+          headers: mergedHeaders,
+          signal,
+        });
+
+        if (!response.ok && isTransientStatus(response.status) && attempt < this.maxAttempts - 1) {
+          lastError = new Error(`Transient HTTP ${response.status} from ${this.url}`);
+          await sleep(backoffDelayMs(attempt, this.baseDelayMs, this.maxDelayMs), signal);
+          continue;
+        }
+
+        return {
+          ok: response.ok,
+          status: response.status,
+          getHeader: (name: string) => response.headers.get(name) ?? "",
+          getData: () => response.arrayBuffer(),
+        };
+      } catch (error) {
+        if (isAbortError(error)) throw error;
+        lastError = error;
+        if (attempt >= this.maxAttempts - 1) throw error;
+        await sleep(backoffDelayMs(attempt, this.baseDelayMs, this.maxDelayMs), signal);
+      }
+    }
+
+    throw lastError ?? new Error("SigV4TiffClient: retry loop exhausted without result");
   }
 }

--- a/app/components/.client/ImageViewer/state/transport/__tests__/SigV4TiffClient.test.ts
+++ b/app/components/.client/ImageViewer/state/transport/__tests__/SigV4TiffClient.test.ts
@@ -1,10 +1,13 @@
 import type { Credentials } from "@aws-sdk/client-sts";
 
 import { SigV4TiffClient } from "../SigV4TiffClient";
+import type { SignedFetch } from "~/utils/signedFetch";
 import { createSignedFetch } from "~/utils/signedFetch";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
+
+const FAST_RETRY = { baseDelayMs: 0, maxDelayMs: 0 };
 
 const credentials: Credentials = {
   AccessKeyId: "AKIAIOSFODNN7EXAMPLE",
@@ -84,5 +87,155 @@ describe("SigV4TiffClient opts.headers forwarding (SDS-CY-010050)", () => {
     const [, fetchOptions] = mockFetch.mock.calls[0];
     expect(fetchOptions.headers.Range).toBe("bytes=0-1023");
     expect(fetchOptions.headers["If-None-Match"]).toBeUndefined();
+  });
+});
+
+describe("SigV4TiffClient retry on transient failures", () => {
+  function makeResponse(status: number, ok = status >= 200 && status < 300) {
+    return {
+      ok,
+      status,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      headers: new Map([["content-length", "0"]]),
+    };
+  }
+
+  test("retries on 503 and succeeds on second attempt", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeResponse(503, false))
+      .mockResolvedValueOnce(makeResponse(206));
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      FAST_RETRY,
+    );
+
+    const result = await client.request({ headers: { Range: "bytes=0-1023" } });
+
+    expect(result.status).toBe(206);
+    expect(result.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("retries on 429 then 500 and surfaces last response after maxAttempts", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeResponse(429, false))
+      .mockResolvedValueOnce(makeResponse(500, false))
+      .mockResolvedValueOnce(makeResponse(503, false));
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      { maxAttempts: 3, ...FAST_RETRY },
+    );
+
+    const result = await client.request({ headers: { Range: "bytes=0-1023" } });
+
+    expect(result.status).toBe(503);
+    expect(result.ok).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not retry on 4xx non-transient (403)", async () => {
+    mockFetch.mockResolvedValueOnce(makeResponse(403, false));
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      FAST_RETRY,
+    );
+
+    const result = await client.request({ headers: { Range: "bytes=0-1023" } });
+
+    expect(result.status).toBe(403);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries thrown network errors", async () => {
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(makeResponse(206));
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      FAST_RETRY,
+    );
+
+    const result = await client.request({ headers: { Range: "bytes=0-1023" } });
+
+    expect(result.status).toBe(206);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry on AbortError", async () => {
+    const abort = new DOMException("Aborted", "AbortError");
+    mockFetch.mockRejectedValueOnce(abort);
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      FAST_RETRY,
+    );
+
+    await expect(client.request({ headers: { Range: "bytes=0-1023" } })).rejects.toBe(abort);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws AbortError immediately if signal already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      FAST_RETRY,
+    );
+
+    await expect(
+      client.request({ headers: { Range: "bytes=0-1023" }, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test("rethrows last error after exhausting attempts", async () => {
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    const client = new SigV4TiffClient(
+      "https://bucket.s3.us-west-2.amazonaws.com/img.tif",
+      signedFetch,
+      undefined,
+      { maxAttempts: 2, ...FAST_RETRY },
+    );
+
+    // signedFetch wraps the underlying TypeError as CorsLikelyError; what
+    // matters here is that the final error after exhausting attempts is
+    // surfaced rather than swallowed.
+    await expect(client.request({ headers: { Range: "bytes=0-1023" } })).rejects.toMatchObject({
+      name: "CorsLikelyError",
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("maxAttempts=1 disables retries", async () => {
+    const fakeFetch = vi
+      .fn<SignedFetch>()
+      .mockResolvedValue(new Response(new ArrayBuffer(0), { status: 503 }));
+
+    const client = new SigV4TiffClient("https://example/x", fakeFetch, undefined, {
+      maxAttempts: 1,
+      ...FAST_RETRY,
+    });
+
+    const result = await client.request({ headers: { Range: "bytes=0-1023" } });
+    expect(result.status).toBe(503);
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Add exponential-backoff retry (3 attempts, 100ms→2s, jitter) inside `SigV4TiffClient.request` for transient range-request failures (`408` / `429` / `5xx` + thrown network errors).
- Skip retry on `AbortError`; short-circuit on pre-aborted signals.
- Caller signature backwards compatible — new `SigV4TiffClientRetryOptions` is optional.

## Why

Prod intermittently shows `AggregateError: Request failed` (from `geotiff` `BlockedSource`) while overlays render fine. Mechanism:

- `geotiff` fans out many parallel range GETs per IFD.
- `RemoteSource.fetchSlice` throws on any non-2xx.
- `BlockedSource` aggregates ANY single failed block into one `AggregateError` and does NOT retry HTTP errors (only `AbortError`).
- Overlays survive because they are a single Parquet/JSON fetch — no fan-out, no aggregation.

Result: one transient `S3 SlowDown` / 5xx / network blip poisons the whole pyramidal OME-TIFF read. Fixing inside `SigV4TiffClient` is the cheapest containment — it is the seam geotiff calls into.

## Test plan

- [x] `vitest run app/components/.client/ImageViewer/state/transport/__tests__/SigV4TiffClient.test.ts` — 11/11 pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [ ] Smoke test in staging: open OME-TIFF with overlays, verify tiles render
- [ ] Inject 1/N synthetic 503 in DevTools → confirm tile load completes after retry instead of throwing `AggregateError`