### PR TITLE
fix(redis): enforce TLS for Valkey session store [C-204] 

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,11 +17,14 @@ KC_ADMIN_CLIENT_SECRET=change-me
 # Redis / Valkey
 REDIS_HOST=localhost
 REDIS_PORT=6379
-
+REDIS_INSECURE_ALLOW_PLAINTEXT=true
 # Optional: Authentication for Redis/Valkey
 # Leave commented out if your server doesn't require authentication
 # REDIS_USERNAME=myuser  # For Redis 6+ ACL or Valkey with username-based auth
 # REDIS_PASSWORD=mypassword
+# REDIS_CA_CERT=
+# REDIS_TLS_SERVER_NAME=
+# REDIS_INSECURE_ALLOW_PLAINTEXT=
 
 ## Secrets
 COOKIE_SECRET=dev-secret-change-in-production

--- a/.github/workflows/smoke-install.yml
+++ b/.github/workflows/smoke-install.yml
@@ -112,6 +112,7 @@ jobs:
           SCOPES: openid
           COOKIE_SECRET: smoke-cookie-secret
           WEB_HOST: http://127.0.0.1:3000
+          REDIS_INSECURE_ALLOW_PLAINTEXT: true
         run: |
           cd "$CONSUMER"
           npx --no-install cytario-web start &

--- a/README.md
+++ b/README.md
@@ -230,6 +230,21 @@ cp .env.template .env    # Pre-configured for the Podman cluster
 npm run dev
 ```
 
+### Session Cache (Redis/Valkey)
+
+Sessions hold OAuth access/refresh/ID tokens and short-lived STS credentials. **TLS is required in production.** The app refuses to boot when `NODE_ENV !== "development"` unless one of the following is true:
+
+| Env var                          | Value    | Meaning                                                                                              |
+| -------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `REDIS_TLS`                      | `"true"` | Wrap the ioredis connection in TLS (recommended).                                                    |
+| `REDIS_CA_CERT`                  | PEM      | Optional CA bundle for self-signed deployments. Multi-line PEM string.                               |
+| `REDIS_TLS_SERVER_NAME`          | hostname | Optional SNI / certificate hostname override.                                                        |
+| `REDIS_INSECURE_ALLOW_PLAINTEXT` | `"true"` | Explicit opt-out for trusted private networks. Logs a warning. Not for use on shared infrastructure. |
+
+The local Podman cluster runs Valkey without TLS, which is allowed because `NODE_ENV=development`. Managed Valkey deployments (helm chart, AWS ElastiCache, etc.) should set `REDIS_TLS=true`. Valkey reuses the standard `6379` port for TLS when `tls.enabled` is set — it does not move the listener to `6380` and refuses plaintext on the same port — so leave `REDIS_PORT` at `6379` unless your provider explicitly publishes a separate TLS endpoint.
+
+In the production cluster (see `cytario-infrastructure`, C-212) the Valkey leaf cert is signed by a cluster-internal CA managed by cert-manager. The CA's public cert is distributed to every namespace as a `cytario-internal-ca` ConfigMap by trust-manager, and the `cytario-web` helm chart's `redis.caCertConfigMap.{name,key}` wires it into the pod as `REDIS_CA_CERT` via `valueFrom.configMapKeyRef`. The app sees the PEM through the normal env var path — no code-side knowledge of the trust source is required.
+
 ### Database
 
 PostgreSQL with [Prisma ORM](https://www.prisma.io/). Connection configured via `DATABASE_URL` in `.env`.

--- a/app/.server/db/__tests__/redisOptions.test.ts
+++ b/app/.server/db/__tests__/redisOptions.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { buildRedisOptions } from "../redisOptions";
+
+const baseEnv = (
+  overrides: Record<string, string | undefined> = {},
+): Record<string, string | undefined> => ({
+  NODE_ENV: "development",
+  REDIS_HOST: "valkey.example.com",
+  REDIS_PORT: "6379",
+  ...overrides,
+});
+
+describe("buildRedisOptions", () => {
+  describe("defaults", () => {
+    test("falls back to localhost:6379 when host/port are unset", () => {
+      const options = buildRedisOptions({ NODE_ENV: "development" });
+      expect(options.host).toBe("localhost");
+      expect(options.port).toBe(6379);
+    });
+
+    test("omits username/password when not provided", () => {
+      const options = buildRedisOptions(baseEnv());
+      expect(options.username).toBeUndefined();
+      expect(options.password).toBeUndefined();
+    });
+
+    test("includes username and password when provided", () => {
+      const options = buildRedisOptions(
+        baseEnv({ REDIS_USERNAME: "alice", REDIS_PASSWORD: "secret" }),
+      );
+      expect(options.username).toBe("alice");
+      expect(options.password).toBe("secret");
+    });
+  });
+
+  describe("TLS off", () => {
+    test("does not set the tls option when REDIS_TLS is unset", () => {
+      const options = buildRedisOptions(baseEnv());
+      expect(options.tls).toBeUndefined();
+    });
+
+    test("does not set the tls option when REDIS_TLS is anything but the literal string 'true'", () => {
+      const options = buildRedisOptions(baseEnv({ REDIS_TLS: "1" }));
+      expect(options.tls).toBeUndefined();
+    });
+
+    test("allows plaintext in development", () => {
+      expect(() => buildRedisOptions(baseEnv({ NODE_ENV: "development" }))).not.toThrow();
+    });
+
+    test("allows plaintext under NODE_ENV=test so the vitest harness can import redis.ts without mocking", () => {
+      expect(() => buildRedisOptions(baseEnv({ NODE_ENV: "test" }))).not.toThrow();
+    });
+
+    test("throws in production when TLS is off and no opt-out flag is set", () => {
+      expect(() => buildRedisOptions(baseEnv({ NODE_ENV: "production" }))).toThrow(
+        /Refusing to start.*REDIS_TLS/,
+      );
+    });
+
+    test("throws in any non-development NODE_ENV (e.g. staging) when TLS is off", () => {
+      expect(() => buildRedisOptions(baseEnv({ NODE_ENV: "staging" }))).toThrow(
+        /Refusing to start/,
+      );
+    });
+
+    test("does not throw in production when REDIS_INSECURE_ALLOW_PLAINTEXT=true", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(() =>
+          buildRedisOptions(
+            baseEnv({ NODE_ENV: "production", REDIS_INSECURE_ALLOW_PLAINTEXT: "true" }),
+          ),
+        ).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringMatching(/REDIS_INSECURE_ALLOW_PLAINTEXT/));
+      } finally {
+        warn.mockRestore();
+      }
+    });
+  });
+
+  describe("TLS on", () => {
+    test("sets an empty tls object when REDIS_TLS=true with no CA/SNI", () => {
+      const options = buildRedisOptions(baseEnv({ NODE_ENV: "production", REDIS_TLS: "true" }));
+      expect(options.tls).toEqual({});
+    });
+
+    test("passes the CA certificate through to the tls option", () => {
+      const ca = "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----";
+      const options = buildRedisOptions(
+        baseEnv({ NODE_ENV: "production", REDIS_TLS: "true", REDIS_CA_CERT: ca }),
+      );
+      expect(options.tls).toEqual({ ca });
+    });
+
+    test("passes the SNI/server name through to the tls option", () => {
+      const options = buildRedisOptions(
+        baseEnv({
+          NODE_ENV: "production",
+          REDIS_TLS: "true",
+          REDIS_TLS_SERVER_NAME: "valkey.internal",
+        }),
+      );
+      expect(options.tls).toEqual({ servername: "valkey.internal" });
+    });
+
+    test("does not throw in production when TLS is on", () => {
+      expect(() =>
+        buildRedisOptions(baseEnv({ NODE_ENV: "production", REDIS_TLS: "true" })),
+      ).not.toThrow();
+    });
+  });
+});

--- a/app/.server/db/redis.ts
+++ b/app/.server/db/redis.ts
@@ -1,6 +1,6 @@
 import Redis from "ioredis";
 
-import { cytarioConfig } from "~/config";
+import { buildRedisOptions } from "./redisOptions";
 
 /**
  * Redis/Valkey client instance
@@ -14,55 +14,39 @@ import { cytarioConfig } from "~/config";
  * - REDIS_PORT: Server port (default: 6379)
  * - REDIS_USERNAME: Optional username for authenticated connections (Redis 6+ / Valkey)
  * - REDIS_PASSWORD: Optional password for authenticated connections
+ * - REDIS_TLS: Set to "true" to wrap the connection in TLS (required in production)
+ * - REDIS_CA_CERT: Optional PEM-encoded CA certificate (string) for self-signed deployments
+ * - REDIS_TLS_SERVER_NAME: Optional SNI / certificate hostname override
+ * - REDIS_INSECURE_ALLOW_PLAINTEXT: Set to "true" to opt out of the production TLS requirement
  *
  * @example
- * // Use with Redis without authentication
- * REDIS_HOST=redis.example.com
- * REDIS_PORT=6379
- *
- * @example
- * // Use with Valkey with authentication
+ * // Use with managed Valkey over TLS — Valkey reuses 6379 for TLS when tls.enabled is set
  * REDIS_HOST=valkey.example.com
  * REDIS_PORT=6379
  * REDIS_USERNAME=myuser
  * REDIS_PASSWORD=mypassword
+ * REDIS_TLS=true
  *
  * @example
- * // Use with Redis/Valkey with password-only authentication (legacy)
- * REDIS_HOST=redis.example.com
+ * // Local development without TLS (only allowed when NODE_ENV=development)
+ * REDIS_HOST=localhost
  * REDIS_PORT=6379
- * REDIS_PASSWORD=mypassword
  */
 
-const {
-  redis: { host, port, username, password },
-} = cytarioConfig;
+const options = buildRedisOptions(process.env);
 
-export const redis = new Redis({
-  host,
-  port,
-  // Only include username if provided (Redis 6+ ACL support)
-  ...(username && { username }),
-  // Only include password if provided (backwards compatible)
-  ...(password && { password }),
-  maxRetriesPerRequest: 3,
-  retryStrategy(times) {
-    const delay = Math.min(times * 50, 2000);
-    return delay;
-  },
-  lazyConnect: false,
-});
+export const redis = new Redis(options);
 
-// Log connection errors
 redis.on("error", (err) => {
   console.error("Redis/Valkey connection error:", err);
 });
 
 redis.on("connect", () => {
-  const authInfo = username
-    ? ` (authenticated as ${username})`
-    : password
+  const authInfo = options.username
+    ? ` (authenticated as ${options.username})`
+    : options.password
       ? " (authenticated)"
       : "";
-  console.log(`Connected to Redis/Valkey at ${host}:${port}${authInfo}`);
+  const tlsInfo = options.tls ? " over TLS" : "";
+  console.log(`Connected to Redis/Valkey at ${options.host}:${options.port}${authInfo}${tlsInfo}`);
 });

--- a/app/.server/db/redisOptions.ts
+++ b/app/.server/db/redisOptions.ts
@@ -1,0 +1,72 @@
+import type { RedisOptions } from "ioredis";
+
+/**
+ * Build ioredis connection options from environment variables.
+ *
+ * Recognised env vars:
+ * - `REDIS_HOST` (default: `localhost`)
+ * - `REDIS_PORT` (default: `6379`)
+ * - `REDIS_USERNAME` — optional ACL username
+ * - `REDIS_PASSWORD` — optional password
+ * - `REDIS_TLS` — `"true"` to wrap the connection in TLS
+ * - `REDIS_CA_CERT` — PEM-encoded CA certificate (string) used to verify
+ *   the server when the cert chain is not in the system trust store
+ * - `REDIS_TLS_SERVER_NAME` — SNI / certificate hostname override
+ * - `REDIS_INSECURE_ALLOW_PLAINTEXT` — `"true"` to opt out of the
+ *   production TLS requirement (escape hatch for trusted in-cluster
+ *   networks; logs a warning)
+ *
+ * Fails fast outside development if TLS is off and the opt-out flag is
+ * not set — session blobs contain OAuth tokens and STS credentials and
+ * must not traverse plaintext links in production. See C-204.
+ */
+export function buildRedisOptions(env: Record<string, string | undefined>): RedisOptions {
+  const host = env.REDIS_HOST || "localhost";
+  const port = Number(env.REDIS_PORT) || 6379;
+  const username = env.REDIS_USERNAME;
+  const password = env.REDIS_PASSWORD;
+  const tlsEnabled = env.REDIS_TLS === "true";
+  const caCert = env.REDIS_CA_CERT;
+  const tlsServerName = env.REDIS_TLS_SERVER_NAME;
+  const allowPlaintext = env.REDIS_INSECURE_ALLOW_PLAINTEXT === "true";
+  const nodeEnv = env.NODE_ENV;
+
+  const isLocalEnv = nodeEnv === "development" || nodeEnv === "test";
+
+  if (!tlsEnabled && !isLocalEnv && !allowPlaintext) {
+    throw new Error(
+      "Refusing to start: Redis/Valkey TLS is disabled. Set REDIS_TLS=true " +
+        "(recommended) or REDIS_INSECURE_ALLOW_PLAINTEXT=true to opt out. " +
+        "See C-204 / OWASP A02:2021.",
+    );
+  }
+
+  if (!tlsEnabled && allowPlaintext && !isLocalEnv) {
+    console.warn(
+      "REDIS_INSECURE_ALLOW_PLAINTEXT=true — session tokens will traverse " +
+        "an unencrypted connection. Only safe on a trusted private network.",
+    );
+  }
+
+  const options: RedisOptions = {
+    host,
+    port,
+    ...(username && { username }),
+    ...(password && { password }),
+    maxRetriesPerRequest: 3,
+    retryStrategy(times) {
+      const delay = Math.min(times * 50, 2000);
+      return delay;
+    },
+    lazyConnect: false,
+  };
+
+  if (tlsEnabled) {
+    options.tls = {
+      ...(caCert && { ca: caCert }),
+      ...(tlsServerName && { servername: tlsServerName }),
+    };
+  }
+
+  return options;
+}


### PR DESCRIPTION
## Description

Session blobs contain OAuth access/refresh/ID tokens and short-lived STS credentials. They previously traversed Redis/Valkey over plaintext TCP, allowing any on-path observer between the app pod and the cache to passively harvest tokens for every active user (OWASP A02:2021).

Extract a pure `buildRedisOptions(env)` factory under `app/.server/db/redisOptions.ts` that wires the ioredis `tls` option from `REDIS_TLS` / `REDIS_CA_CERT` / `REDIS_TLS_SERVER_NAME` and refuses to start when `NODE_ENV` is not `"development"` or `"test"` without either TLS or an explicit `REDIS_INSECURE_ALLOW_PLAINTEXT=true` opt-out. The opt-out logs a warning and is intended only for trusted private networks.

Production deployments are covered by the matching infrastructure work in C-212, which enables server-side TLS on the existing Valkey service port (Valkey reuses `6379` for TLS rather than moving to `6380` and refuses plaintext on the same port) and ships the cluster-internal CA into every namespace as a trust-manager Bundle ConfigMap. The `cytario-web` helm chart (cytario-helm-charts#6) wires that ConfigMap into the pod as `REDIS_CA_CERT` via `valueFrom.configMapKeyRef`, so no code-side knowledge of the trust source is required — the app just reads the PEM out of the env var.

## Related Issue

- Closes [C-204](https://app.plane.so/cytario/projects/c-204) — Enable TLS for Redis/Valkey session store
- Refs C-212 (cytario-infrastructure) — server-side TLS + cluster-internal CA
- Refs cytario/cytario-helm-charts#6 — chart wiring for `REDIS_TLS` / `REDIS_CA_CERT*` / `REDIS_INSECURE_ALLOW_PLAINTEXT`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change <!-- production deployments must set REDIS_TLS=true (or the explicit opt-out) before this image rolls out -->
- [x] Documentation update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed

## Test plan

- [x] `npx vitest run app/.server/db/__tests__/redisOptions.test.ts` — 14 cases cover defaults, dev/test/staging/production NODE_ENV branches, opt-out warning, CA, SNI, TLS-on.
- [x] `npx vitest run` — full suite (146 files, 1378 tests) passes after relaxing the gate to allow `NODE_ENV=test` (two suites transitively import `redis.ts` without mocking it).
- [x] `npm run lint`, `npm run typecheck`, `npm run format:check` clean.
- [ ] Deploy against a TLS-enabled Valkey in the staging cluster (C-212) and confirm the pod logs `Connected to Redis/Valkey at <host>:6379 over TLS`.