### PR TITLE
fix(search): surface deeply nested files via ?suffix= [C-203]

### DIFF
--- a/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/AddOverlay.tsx
@@ -17,7 +17,7 @@ interface AddOverlayProps {
 export function AddOverlay({ callback, query, onOverlayAdd }: AddOverlayProps) {
   const { toast } = useToast();
 
-  const searchString = `/search?query=${query}`;
+  const searchString = `/search?suffix=${encodeURIComponent(query)}`;
 
   // Fetch available files on mount
   const objectsFetcher = useFetcher<SearchRouteLoaderResponse>();

--- a/app/components/.client/ImageViewer/components/OverlaysController/__tests__/AddOverlay.test.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/__tests__/AddOverlay.test.tsx
@@ -87,7 +87,7 @@ describe("AddOverlay", () => {
 
     render(<AddOverlay query="parquet" />);
 
-    expect(mockUseFetcherLoad).toHaveBeenCalledWith("/search?query=parquet");
+    expect(mockUseFetcherLoad).toHaveBeenCalledWith("/search?suffix=parquet");
   });
 
   test("fetches files on mount with correct search query for csv", () => {
@@ -95,7 +95,7 @@ describe("AddOverlay", () => {
 
     render(<AddOverlay query="csv" />);
 
-    expect(mockUseFetcherLoad).toHaveBeenCalledWith("/search?query=csv");
+    expect(mockUseFetcherLoad).toHaveBeenCalledWith("/search?suffix=csv");
   });
 
   test("shows loading state while fetcher is loading", () => {

--- a/app/routes/__tests__/search.route.test.tsx
+++ b/app/routes/__tests__/search.route.test.tsx
@@ -265,6 +265,64 @@ describe("SearchRoute", () => {
     expect(result.notification?.message).not.toMatch(/Small Bucket/);
   });
 
+  test("?suffix= pushes a keyFilter into listObjectsClient and skips the substring query", async () => {
+    const config = mock.connectionConfig({ name: "c", prefix: "" });
+    listObjectsClient.mockResolvedValue({ contents: [], commonPrefixes: [], isCapped: false });
+
+    seedConnectionsStore([config]);
+
+    const request = new Request("http://localhost/search?suffix=parquet");
+    await clientLoader({ request, params: {}, serverLoader: vi.fn() } as never);
+
+    expect(listObjectsClient).toHaveBeenCalledWith(
+      config,
+      expect.anything(),
+      expect.objectContaining({
+        query: null,
+        recursive: true,
+        keyFilter: expect.any(Function),
+      }),
+    );
+
+    const passedFilter = listObjectsClient.mock.calls[0][2].keyFilter as (k: string) => boolean;
+    expect(passedFilter("a/b/c.parquet")).toBe(true);
+    expect(passedFilter("a/b/c.PARQUET")).toBe(true);
+    expect(passedFilter("a/b/c.tif")).toBe(false);
+    expect(passedFilter("parquet")).toBe(false);
+  });
+
+  test("?suffix= is case-insensitive on the suffix itself", async () => {
+    const config = mock.connectionConfig({ name: "c", prefix: "" });
+    listObjectsClient.mockResolvedValue({ contents: [], commonPrefixes: [], isCapped: false });
+
+    seedConnectionsStore([config]);
+
+    const request = new Request("http://localhost/search?suffix=Parquet");
+    await clientLoader({ request, params: {}, serverLoader: vi.fn() } as never);
+
+    const passedFilter = listObjectsClient.mock.calls[0][2].keyFilter as (k: string) => boolean;
+    expect(passedFilter("foo/bar.parquet")).toBe(true);
+  });
+
+  test("?query= alone (no suffix) still uses the substring filter and no keyFilter", async () => {
+    const config = mock.connectionConfig({ name: "c", prefix: "" });
+    listObjectsClient.mockResolvedValue({ contents: [], commonPrefixes: [], isCapped: false });
+
+    seedConnectionsStore([config]);
+
+    const request = new Request("http://localhost/search?query=match");
+    await clientLoader({ request, params: {}, serverLoader: vi.fn() } as never);
+
+    expect(listObjectsClient).toHaveBeenCalledWith(
+      config,
+      expect.anything(),
+      expect.objectContaining({
+        query: "match",
+        keyFilter: undefined,
+      }),
+    );
+  });
+
   test("clientLoader omits the notification when nothing was capped", async () => {
     const config = mock.connectionConfig();
 

--- a/app/routes/search.route.tsx
+++ b/app/routes/search.route.tsx
@@ -39,7 +39,15 @@ export const handle = {
 export const clientLoader = async ({
   request,
 }: ClientLoaderFunctionArgs): Promise<SearchRouteLoaderResponse> => {
-  const searchQuery = new URL(request.url).searchParams.get("query") ?? "";
+  const url = new URL(request.url);
+  const searchQuery = url.searchParams.get("query") ?? "";
+  const suffix = url.searchParams.get("suffix");
+  const keyFilter = suffix
+    ? (() => {
+        const needle = `.${suffix.toLowerCase()}`;
+        return (key: string) => key.toLowerCase().endsWith(needle);
+      })()
+    : undefined;
   const connections = useConnectionsStore.getState().connections;
   const signal = request.signal;
 
@@ -50,7 +58,8 @@ export const clientLoader = async ({
       const prefix = getPrefix(config.prefix);
       try {
         const { contents, isCapped } = await listObjectsClient(config, credentials, {
-          query: searchQuery,
+          query: keyFilter ? null : searchQuery,
+          keyFilter,
           prefix,
           recursive: true,
           signal,

--- a/app/utils/__tests__/listObjectsClient.test.ts
+++ b/app/utils/__tests__/listObjectsClient.test.ts
@@ -230,6 +230,84 @@ describe("listObjectsClient", () => {
     expect(result.contents.map((o) => o.Key)).toEqual(["needle.tif"]);
   });
 
+  test("keyFilter drops non-matching keys per page before the maxTotal cap", async () => {
+    // Page 1: only non-matches → contents stays empty, loop continues past
+    // maxTotal because the cap is on filtered length, not raw scan.
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        xml(
+          `<IsTruncated>true</IsTruncated><NextContinuationToken>p2</NextContinuationToken>${contentsXml(["a.tif", "b.tif", "c.tif"])}`,
+        ),
+        { status: 200 },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(xml(`<IsTruncated>false</IsTruncated>${contentsXml(["deep/d.parquet"])}`), {
+        status: 200,
+      }),
+    );
+
+    const result = await listObjectsClient(mock.connectionConfig(), mock.credentials(), {
+      recursive: true,
+      keyFilter: (key) => key.endsWith(".parquet"),
+      maxTotal: 3,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.contents.map((o) => o.Key)).toEqual(["deep/d.parquet"]);
+    expect(result.isCapped).toBe(false);
+  });
+
+  test("maxScanned caps work on giant buckets even when keyFilter finds no matches", async () => {
+    // Page 1 alone exceeds maxScanned → break with isCapped=true reflecting
+    // S3's IsTruncated, never reaching page 2 where a match would have lived.
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        xml(
+          `<IsTruncated>true</IsTruncated><NextContinuationToken>p2</NextContinuationToken>${contentsXml(["a.tif", "b.tif", "c.tif"])}`,
+        ),
+        { status: 200 },
+      ),
+    );
+    fetchMock.mockResolvedValueOnce(
+      new Response(xml(`<IsTruncated>false</IsTruncated>${contentsXml(["late.parquet"])}`), {
+        status: 200,
+      }),
+    );
+
+    const result = await listObjectsClient(mock.connectionConfig(), mock.credentials(), {
+      recursive: true,
+      keyFilter: (key) => key.endsWith(".parquet"),
+      maxScanned: 2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.contents).toEqual([]);
+    expect(result.isCapped).toBe(true);
+  });
+
+  test("keyFilter cap counts matches, not raw entries", async () => {
+    // 3 raw entries, 2 matches. maxTotal=2 must stop once 2 parquets accrue.
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        xml(
+          `<IsTruncated>true</IsTruncated><NextContinuationToken>p2</NextContinuationToken>${contentsXml(["a.parquet", "b.tif", "c.parquet"])}`,
+        ),
+        { status: 200 },
+      ),
+    );
+
+    const result = await listObjectsClient(mock.connectionConfig(), mock.credentials(), {
+      recursive: true,
+      keyFilter: (key) => key.endsWith(".parquet"),
+      maxTotal: 2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.contents.map((o) => o.Key)).toEqual(["a.parquet", "c.parquet"]);
+    expect(result.isCapped).toBe(true);
+  });
+
   test("encodes wire query with RFC-3986 strict (matches SigV4 canonical form)", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(xml(`<IsTruncated>false</IsTruncated>`), { status: 200 }),

--- a/app/utils/listObjectsClient.ts
+++ b/app/utils/listObjectsClient.ts
@@ -5,7 +5,7 @@ import { SignatureV4 } from "@smithy/signature-v4";
 
 import { ExpiredCredentialsError, requestCredentialsRefresh } from "./credentialsRefresh";
 import { filterObjects } from "./filterObjects";
-import { DEFAULT_MAX_TOTAL } from "./listingLimits";
+import { DEFAULT_MAX_SCANNED, DEFAULT_MAX_TOTAL } from "./listingLimits";
 import { constructS3Url } from "./resourceId";
 import { CorsLikelyError } from "./signedFetch";
 import type { ConnectionConfig } from "~/.generated/client";
@@ -41,8 +41,16 @@ export interface ListObjectsClientOptions {
   recursive?: boolean;
   /** S3 page size. Default: 1000 (S3 max). */
   maxKeys?: number;
-  /** Hard cap on total entries (contents + commonPrefixes) collected across pages. Default: 10000. */
+  /** Hard cap on matched entries (contents + commonPrefixes) kept across pages. Default: 10000. */
   maxTotal?: number;
+  /** Hard cap on raw entries scanned across pages before `keyFilter`. Default: 100000. */
+  maxScanned?: number;
+  /**
+   * Applied per page before the `maxTotal` cap, so the cap bounds matches
+   * rather than raw scans. S3 has no server-side suffix filter, so
+   * suffix-restricted listings (e.g. `*.parquet`) must filter here.
+   */
+  keyFilter?: (key: string) => boolean;
   /**
    * Short-circuits pagination as soon as any object in a fetched page
    * satisfies the predicate. Useful for "first match wins" scans.
@@ -222,6 +230,8 @@ export async function listObjectsClient(
     recursive = false,
     maxKeys = DEFAULT_PAGE_SIZE,
     maxTotal = DEFAULT_MAX_TOTAL,
+    maxScanned = DEFAULT_MAX_SCANNED,
+    keyFilter,
     findFirst,
     signal,
   } = options;
@@ -237,6 +247,7 @@ export async function listObjectsClient(
   let continuationToken: string | undefined;
   let isCapped = false;
   let pageCount = 0;
+  let scannedCount = 0;
 
   do {
     const queryParams: Record<string, string> = {
@@ -296,13 +307,22 @@ export async function listObjectsClient(
     }
 
     pageCount++;
+    scannedCount += parsed.contents.length;
 
-    for (const obj of parsed.contents) contents.push(obj);
+    for (const obj of parsed.contents) {
+      if (keyFilter && (!obj.Key || !keyFilter(obj.Key))) continue;
+      contents.push(obj);
+    }
     for (const cp of parsed.commonPrefixes) commonPrefixes.push(cp);
 
     if (findFirst && contents.some(findFirst)) break;
 
     if (contents.length + commonPrefixes.length >= maxTotal) {
+      isCapped = parsed.isTruncated;
+      break;
+    }
+
+    if (scannedCount >= maxScanned) {
       isCapped = parsed.isTruncated;
       break;
     }

--- a/app/utils/listingLimits.ts
+++ b/app/utils/listingLimits.ts
@@ -1,5 +1,8 @@
-/** Hard cap on total entries collected across paginated `ListObjectsV2` calls. */
+/** Hard cap on matched entries collected across paginated `ListObjectsV2` calls. */
 export const DEFAULT_MAX_TOTAL = 10_000;
+
+/** Hard cap on raw entries scanned across pages, regardless of `keyFilter` matches. */
+export const DEFAULT_MAX_SCANNED = 100_000;
 
 /** Shared truncation message so the cap value stays in sync with `DEFAULT_MAX_TOTAL`. */
 export function formatTruncationMessage(name: string): string {


### PR DESCRIPTION
## Summary

- `listObjectsClient` now accepts a `keyFilter` applied per page before the `maxTotal` cap, so the cap bounds matches rather than raw scans. A new `maxScanned` ceiling (default 100k) keeps unbounded scans on huge buckets terminating when no matches are found.
- `/search` accepts an explicit `?suffix=<ext>` param. When set, it pushes a `key.toLowerCase().endsWith(".<ext>")` filter into the listing; `?query=` keeps its substring semantics for global search.
- `AddOverlay` (overlay picker) calls `/search?suffix=${query}` instead of `/search?query=${query}`. Deep `.parquet` / `.csv` files now surface even when the connection has >10k non-matching keys sorted before them.

Closes C-203.

## Test plan

- [x] `app/utils/__tests__/listObjectsClient.test.ts` — `keyFilter` drops non-matching keys per page before `maxTotal`; cap counts matches not raw scans; `maxScanned` ceiling halts scan even when no matches are found.
- [x] `app/routes/__tests__/search.route.test.tsx` — `?suffix=` builds a case-insensitive endsWith filter and sets `query: null`; `?query=` alone keeps substring filter and omits `keyFilter`.
- [x] `app/components/.client/ImageViewer/components/OverlaysController/__tests__/AddOverlay.test.tsx` — picker fetches `/search?suffix=parquet` and `/search?suffix=csv`.
- [x] `npm run lint` clean.
- [x] `npm run typecheck` clean.
- [x] `npm run format:check` clean.
- [ ] Manual: open overlay picker on a connection where `.parquet` files live under a deeply nested prefix sorted late alphabetically; confirm files surface in the tree.

## Follow-up

Picker still renders a flat pre-built tree (no lazy expansion). For buckets where >10k matches exist or >100k keys precede the first match, the picker should fall back to lazy directory navigation like `DirectoryViewTree`. Track as a separate ticket.