### PR TITLE
fix(build): ship build/ in npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "app",
     "bin",
     "bin-src",
+    "build",
     "prisma",
     "public",
     "scripts",
@@ -48,7 +49,7 @@
   },
   "scripts": {
     "prepare": "husky || true",
-    "prepack": "npm run build:server && node scripts/prebuild.mjs",
+    "prepack": "npm run build && npm run build:server",
     "prebuild": "node scripts/prebuild.mjs",
     "build": "node bin/cytario-web.mjs build",
     "build:server": "tsup --config tsup.server.config.ts",


### PR DESCRIPTION
## Summary

- Adds `build` to `package.json#files` and updates `prepack` so `npm run build && npm run build:server` runs before `npm publish`. The published `@cytario/web` tarball now ships the canonical `build/server/` + `build/client/` bundle.
- Eliminates the per-arch `cytario-web build` step that downstream consumers (cytario-ee in particular) were running inside their Docker matrix.

## Why

`build.assets.version` is a content hash over Vite/Rollup output. Rollup's chunk-hash output is not bit-stable across architectures, so running `cytario-web build` separately on amd64 and arm64 produced two different `assets.version` values. Multi-arch images shipped both, the LB round-robined pods of different arches, and React Router v7's `handleManifestRequest` returned `204 + X-Remix-Reload-Document` on every cross-arch version mismatch — triggering an infinite reload loop on splat routes such as `/connections/:name/*`.

Building once at publish time emits one canonical bundle that all consumers reuse.

## Companion PR

cytario-ee drops the corresponding `build` stage from its Dockerfile in <https://github.com/cytario/cytario-ee> (`fix/use-prebuilt-bundle`).

## Test plan

- [ ] CI passes (`qa-checks` + `release` + `container`).
- [ ] Release publishes `@cytario/web@<next>` with `build/server/assets/server-build-*.js` present in the tarball.
- [ ] cytario-ee `bump-web` PR pins the new version; cytario-ee image build succeeds with the simplified Dockerfile.
- [ ] Post-deploy: both arch pods of `cytario-web` in `saas` namespace report identical `assets.version` via `grep -ao 'version":"[a-f0-9]*"' /app/node_modules/@cytario/web/build/server/assets/server-build-*.js`.
- [ ] Splat route `/connections/:name/*` no longer triggers infinite reload.

Refs C-218.