### PR TITLE
Resolve org by alias + handle STS denial gracefully [C-223] [C-224]

### DIFF
--- a/app/.server/auth/__tests__/authMiddleware.test.ts
+++ b/app/.server/auth/__tests__/authMiddleware.test.ts
@@ -112,9 +112,10 @@ describe("authMiddleware", () => {
     vi.mocked(sessionStorage.destroySession).mockResolvedValue("destroy-cookie");
     vi.mocked(listConnections).mockResolvedValue(mockConnectionConfigs);
     // Return the same credentials by default (no change = no session commit)
-    vi.mocked(getAllSessionCredentials).mockImplementation(
-      async (sessionData) => sessionData.credentials,
-    );
+    vi.mocked(getAllSessionCredentials).mockImplementation(async (sessionData) => ({
+      credentials: sessionData.credentials,
+      errors: {},
+    }));
     vi.mocked(refreshAccessTokenWithLock).mockResolvedValue({
       accessToken: "new-access-token",
       idToken: "new-id-token",
@@ -198,7 +199,10 @@ describe("authMiddleware", () => {
 
     test("commits session when credentials changed", async () => {
       const newCredentials = { "new-bucket": mock.credentials() };
-      vi.mocked(getAllSessionCredentials).mockResolvedValue(newCredentials);
+      vi.mocked(getAllSessionCredentials).mockResolvedValue({
+        credentials: newCredentials,
+        errors: {},
+      });
 
       const args = createMiddlewareArgs();
 

--- a/app/.server/auth/__tests__/getSessionCredentials.test.ts
+++ b/app/.server/auth/__tests__/getSessionCredentials.test.ts
@@ -122,7 +122,8 @@ describe("getAllSessionCredentials", () => {
       mock.connectionConfig({ name: "conn-a" }),
     ]);
 
-    expect(result).toBe(validCredentials);
+    expect(result.credentials).toBe(validCredentials);
+    expect(result.errors).toEqual({});
     expect(mockSend).not.toHaveBeenCalled();
   });
 
@@ -131,7 +132,7 @@ describe("getAllSessionCredentials", () => {
       mock.connectionConfig({ name: "new-conn" }),
     ]);
 
-    expect(result).toEqual({ "new-conn": mockCredentials });
+    expect(result.credentials).toEqual({ "new-conn": mockCredentials });
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
@@ -149,7 +150,7 @@ describe("getAllSessionCredentials", () => {
       mock.connectionConfig({ name: "expired-conn" }),
     ]);
 
-    expect(result).toEqual({ "expired-conn": mockCredentials });
+    expect(result.credentials).toEqual({ "expired-conn": mockCredentials });
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
@@ -171,8 +172,8 @@ describe("getAllSessionCredentials", () => {
 
     // No bucket dedup — each connection gets its own STS mint.
     expect(mockSend).toHaveBeenCalledTimes(2);
-    expect(result["internal"]).toEqual(mockCredentials);
-    expect(result["external"]).toEqual(mockCredentials);
+    expect(result.credentials["internal"]).toEqual(mockCredentials);
+    expect(result.credentials["external"]).toEqual(mockCredentials);
   });
 
   test("fetches multiple connections in parallel", async () => {
@@ -184,10 +185,11 @@ describe("getAllSessionCredentials", () => {
     const result = await getAllSessionCredentials(mockSessionData, configs);
 
     expect(mockSend).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({
+    expect(result.credentials).toEqual({
       "conn-a": mockCredentials,
       "conn-b": mockCredentials,
     });
+    expect(result.errors).toEqual({});
   });
 
   test("preserves existing valid credentials when fetching new ones", async () => {
@@ -202,8 +204,8 @@ describe("getAllSessionCredentials", () => {
       mock.connectionConfig({ name: "new-conn" }),
     ]);
 
-    expect(result["existing-conn"]).toBe(existingCredentials);
-    expect(result["new-conn"]).toEqual(mockCredentials);
+    expect(result.credentials["existing-conn"]).toBe(existingCredentials);
+    expect(result.credentials["new-conn"]).toEqual(mockCredentials);
     // Only fetched for new-conn, not existing-conn
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
@@ -220,9 +222,27 @@ describe("getAllSessionCredentials", () => {
 
     const result = await getAllSessionCredentials(mockSessionData, configs);
 
-    // conn-a succeeds, conn-b fails silently
-    expect(result["conn-a"]).toEqual(mockCredentials);
-    expect(result["conn-b"]).toBeUndefined();
+    // conn-a succeeds, conn-b fails — reason recorded in errors map
+    expect(result.credentials["conn-a"]).toEqual(mockCredentials);
+    expect(result.credentials["conn-b"]).toBeUndefined();
+    expect(result.errors["conn-b"]).toBe("STS service unavailable");
+  });
+
+  test("classifies STS AccessDenied as a role-trust-policy hint", async () => {
+    const denied = Object.assign(
+      new Error("Not authorized to perform sts:AssumeRoleWithWebIdentity"),
+      {
+        name: "AccessDenied",
+      },
+    );
+    mockSend.mockRejectedValueOnce(denied);
+
+    const result = await getAllSessionCredentials(mockSessionData, [
+      mock.connectionConfig({ name: "blocked" }),
+    ]);
+
+    expect(result.credentials["blocked"]).toBeUndefined();
+    expect(result.errors["blocked"]).toMatch(/AWS STS denied AssumeRoleWithWebIdentity/);
   });
 
   test("calls STS with correct configuration", async () => {
@@ -312,7 +332,8 @@ describe("getAllSessionCredentials", () => {
   test("returns empty credentials when no bucket configs provided", async () => {
     const result = await getAllSessionCredentials(mockSessionData, []);
 
-    expect(result).toBe(mockSessionData.credentials);
+    expect(result.credentials).toBe(mockSessionData.credentials);
+    expect(result.errors).toEqual({});
     expect(mockSend).not.toHaveBeenCalled();
   });
 });

--- a/app/.server/auth/authMiddleware.ts
+++ b/app/.server/auth/authMiddleware.ts
@@ -12,6 +12,8 @@ import { listConnections } from "~/routes/connections/connections.server";
 
 export interface AuthContextData extends SessionData {
   connectionConfigs: ConnectionConfig[];
+  /** Per-connection reason for connections whose STS mint failed this request. */
+  credentialErrors: Record<string, string>;
 }
 
 export const authContext = createContext<AuthContextData>();
@@ -36,17 +38,22 @@ const label = createLabel("authorize", "green");
 
 const fetchAllCredentials = async (
   sessionData: SessionData,
-): Promise<{ sessionData: SessionData; connectionConfigs: ConnectionConfig[] }> => {
+): Promise<{
+  sessionData: SessionData;
+  connectionConfigs: ConnectionConfig[];
+  credentialErrors: Record<string, string>;
+}> => {
   const connectionConfigs = await listConnections(sessionData.user);
 
-  const newCredentials = await getAllSessionCredentials(sessionData, connectionConfigs);
+  const { credentials, errors } = await getAllSessionCredentials(sessionData, connectionConfigs);
 
   return {
     sessionData: {
       ...sessionData,
-      credentials: newCredentials,
+      credentials,
     },
     connectionConfigs,
+    credentialErrors: errors,
   };
 };
 
@@ -77,8 +84,11 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
     const idTokenPayload = await verifyIdToken(authTokens.idToken);
 
     if (idTokenPayload) {
-      const { sessionData: withCredentials, connectionConfigs } =
-        await fetchAllCredentials(updatedSessionData);
+      const {
+        sessionData: withCredentials,
+        connectionConfigs,
+        credentialErrors,
+      } = await fetchAllCredentials(updatedSessionData);
       updatedSessionData = withCredentials;
 
       if (updatedSessionData.credentials !== sessionData.credentials) {
@@ -86,7 +96,7 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
         await sessionStorage.commitSession(session);
       }
 
-      context.set(authContext, { ...updatedSessionData, connectionConfigs });
+      context.set(authContext, { ...updatedSessionData, connectionConfigs, credentialErrors });
       return next();
     }
 
@@ -103,7 +113,11 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
       if (newAuthTokens) {
         session.set("authTokens", newAuthTokens);
 
-        const { sessionData: withCredentials, connectionConfigs } = await fetchAllCredentials({
+        const {
+          sessionData: withCredentials,
+          connectionConfigs,
+          credentialErrors,
+        } = await fetchAllCredentials({
           ...updatedSessionData,
           authTokens: newAuthTokens,
         });
@@ -112,7 +126,7 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
         session.set("credentials", updatedSessionData.credentials);
         await sessionStorage.commitSession(session);
 
-        context.set(authContext, { ...updatedSessionData, connectionConfigs });
+        context.set(authContext, { ...updatedSessionData, connectionConfigs, credentialErrors });
         return next();
       }
     }

--- a/app/.server/auth/getSessionCredentials.ts
+++ b/app/.server/auth/getSessionCredentials.ts
@@ -41,41 +41,57 @@ const fetchTemporaryCredentials = async (
   const actualRegion = region ?? "eu-central-1";
   const providerConfig = getS3ProviderConfig(endpoint, actualRegion);
 
-  try {
-    const stsClient = new STSClient({
-      endpoint: providerConfig.stsEndpoint,
-      region: actualRegion,
-    });
+  const stsClient = new STSClient({
+    endpoint: providerConfig.stsEndpoint,
+    region: actualRegion,
+  });
 
-    // Inline session policy is an AWS-specific STS feature: STS intersects it
-    // with the role's attached policy, so the minted credential cannot exceed
-    // the configured prefix scope even if the role itself is broader.
-    // Non-AWS providers (e.g. MinIO) may ignore or reject the `Policy` field,
-    // so we omit it there — the role's intrinsic scope is the only bound.
-    const sessionPolicy =
-      provider === "aws"
-        ? buildSessionPolicy({ organization, bucketName, prefix, region: actualRegion })
-        : undefined;
+  // Inline session policy is an AWS-specific STS feature: STS intersects it
+  // with the role's attached policy, so the minted credential cannot exceed
+  // the configured prefix scope even if the role itself is broader.
+  // Non-AWS providers (e.g. MinIO) may ignore or reject the `Policy` field,
+  // so we omit it there — the role's intrinsic scope is the only bound.
+  const sessionPolicy =
+    provider === "aws"
+      ? buildSessionPolicy({ organization, bucketName, prefix, region: actualRegion })
+      : undefined;
 
-    const command = new AssumeRoleWithWebIdentityCommand({
-      RoleArn: roleArn ?? undefined,
-      RoleSessionName: roleSessionName,
-      WebIdentityToken: idToken,
-      DurationSeconds: 60 * 60 * 1, // 1 hour
-      ...(sessionPolicy ? { Policy: sessionPolicy } : {}),
-    });
+  const command = new AssumeRoleWithWebIdentityCommand({
+    RoleArn: roleArn ?? undefined,
+    RoleSessionName: roleSessionName,
+    WebIdentityToken: idToken,
+    DurationSeconds: 60 * 60 * 1, // 1 hour
+    ...(sessionPolicy ? { Policy: sessionPolicy } : {}),
+  });
 
-    const { Credentials } = await stsClient.send(command);
+  const { Credentials } = await stsClient.send(command);
 
-    if (!Credentials) {
-      throw new Error("No credentials returned from STS");
-    }
-    return Credentials;
-  } catch (error) {
-    console.error("STS fetchTemporaryCredentials failed:", error);
-    throw error;
+  if (!Credentials) {
+    throw new Error("No credentials returned from STS");
   }
+  return Credentials;
 };
+
+/** Map an STS error to a single-line human-readable reason. */
+const describeCredentialError = (error: unknown): string => {
+  if (error && typeof error === "object" && "name" in error) {
+    const name = String((error as { name?: string }).name ?? "");
+    if (name === "AccessDenied") {
+      return "AWS STS denied AssumeRoleWithWebIdentity. Verify the role's trust policy allows this user / organization.";
+    }
+    if (name === "ExpiredTokenException" || name === "InvalidIdentityToken") {
+      return "The identity token was rejected by AWS STS. Try signing in again.";
+    }
+  }
+  if (error instanceof Error) return error.message;
+  return "Failed to fetch temporary credentials.";
+};
+
+export interface SessionCredentialsResult {
+  credentials: ConnectionsCredentials;
+  /** Reason string per connection name for connections whose STS mint failed. */
+  errors: Record<string, string>;
+}
 
 /**
  * Fetches credentials for all connection configs in parallel.
@@ -86,13 +102,13 @@ const fetchTemporaryCredentials = async (
 export const getAllSessionCredentials = async (
   sessionData: SessionData,
   connectionConfigs: ConnectionConfig[],
-): Promise<ConnectionsCredentials> => {
+): Promise<SessionCredentialsResult> => {
   const stale = connectionConfigs.filter(
     (config) => !isValidCredentials(sessionData.credentials[config.name]),
   );
 
   if (stale.length === 0) {
-    return sessionData.credentials;
+    return { credentials: sessionData.credentials, errors: {} };
   }
 
   console.info(`${label} Fetching credentials for ${stale.length} connection(s)`);
@@ -112,13 +128,17 @@ export const getAllSessionCredentials = async (
   );
 
   const newCredentials = { ...sessionData.credentials };
-  for (const result of results) {
+  const errors: Record<string, string> = {};
+  results.forEach((result, i) => {
     if (result.status === "fulfilled") {
       newCredentials[result.value.name] = result.value.credentials;
     } else {
-      console.warn(`${label} Failed to fetch credentials for a connection:`, result.reason);
+      const name = stale[i].name;
+      const reason = describeCredentialError(result.reason);
+      errors[name] = reason;
+      console.warn(`${label} Failed to fetch credentials for ${name}: ${reason}`);
     }
-  }
+  });
 
-  return newCredentials;
+  return { credentials: newCredentials, errors };
 };

--- a/app/.server/auth/keycloakAdmin/organizations.ts
+++ b/app/.server/auth/keycloakAdmin/organizations.ts
@@ -18,8 +18,11 @@ export interface KeycloakOrganization {
 export async function findOrganizationByAlias(
   alias: string,
 ): Promise<KeycloakOrganization | undefined> {
-  const params = new URLSearchParams({ search: alias, exact: "true" });
-  const orgs = await adminFetch<KeycloakOrganization[]>(`/organizations?${params}`);
+  // KC 26.6's `/organizations?search=…` filters on `name` (and `domains`),
+  // never on `alias` — when the alias differs from the name, that endpoint
+  // returns an empty set even with `exact=true`. Page through every org and
+  // filter client-side instead.
+  const orgs = await adminFetchAll<KeycloakOrganization>((params) => `/organizations?${params}`);
   return orgs.find((o) => o.alias === alias);
 }
 

--- a/app/routes/objects/objects.clientLoader.ts
+++ b/app/routes/objects/objects.clientLoader.ts
@@ -17,6 +17,13 @@ export const clientLoader = async ({
 
   const resolved = { ...serverData, pendingClientLoad: false };
 
+  // Server already flagged this connection as unreachable (e.g. STS denied
+  // AssumeRoleWithWebIdentity). Skip the S3 listing — the route renders the
+  // connectionError banner instead.
+  if (resolved.connectionError || !resolved.credentials) {
+    return { ...resolved, nodes: [] };
+  }
+
   if (resolved.serverDeterminedSingleFile) {
     return { ...resolved, nodes: [], isSingleFile: true };
   }

--- a/app/routes/objects/objects.loader.ts
+++ b/app/routes/objects/objects.loader.ts
@@ -27,13 +27,19 @@ export interface BucketRouteServerLoaderResponse {
   /** Full S3 key (connection prefix + urlPath). */
   pathName: string;
   name: string;
-  credentials: Credentials;
+  credentials: Credentials | null;
   connectionConfig: ConnectionConfig;
   isPinned: boolean;
   /** Set when the URL points at a Zarr directory; the chunk listing is skipped. */
   serverDeterminedSingleFile: boolean;
   /** `true` during SSR; `clientLoader` flips it once the listing resolves. */
   pendingClientLoad: boolean;
+  /**
+   * Populated when the STS mint for this connection failed (e.g. the role's
+   * trust policy denied AssumeRoleWithWebIdentity). The route renders an
+   * error banner instead of the directory listing / viewer.
+   */
+  connectionError: string | null;
 }
 
 export interface BucketRouteLoaderResponse extends BucketRouteServerLoaderResponse {
@@ -44,7 +50,7 @@ export interface BucketRouteLoaderResponse extends BucketRouteServerLoaderRespon
 }
 
 export const loader = async ({ params, context }: LoaderFunctionArgs) => {
-  const { user, credentials: connectionsCredentials } = context.get(authContext);
+  const { user, credentials: connectionsCredentials, credentialErrors } = context.get(authContext);
   const { name: connectionName } = params;
 
   if (!connectionName) throw new Error("Connection name is required");
@@ -56,8 +62,11 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
 
   const { bucketName } = connectionConfig;
 
-  const credentials = connectionsCredentials[connectionName];
-  if (!credentials) throw new Error(`No credentials for connection: ${connectionName}`);
+  const credentials = connectionsCredentials[connectionName] ?? null;
+  const connectionError = credentials
+    ? null
+    : (credentialErrors[connectionName] ??
+      "No credentials available for this connection. Verify the connection's role configuration.");
 
   const rawUrlPath = params["*"] ?? "";
 
@@ -92,9 +101,10 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
     connectionConfig,
     isPinned,
     serverDeterminedSingleFile,
-    pendingClientLoad: true,
+    pendingClientLoad: connectionError ? false : true,
     nodes: [],
     isSingleFile: serverDeterminedSingleFile,
+    connectionError,
   };
 
   return payload;

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -1,5 +1,5 @@
 import { Button, EmptyState } from "@cytario/design";
-import { Ban, Bookmark, BookmarkCheck, Download } from "lucide-react";
+import { AlertTriangle, Ban, Bookmark, BookmarkCheck, Download } from "lucide-react";
 import { lazy, Suspense, useCallback, useEffect, useRef } from "react";
 import {
   type MetaFunction,
@@ -91,6 +91,7 @@ export default function ObjectsRoute() {
     isSingleFile,
     notification,
     pendingClientLoad,
+    connectionError,
   } = useLoaderData<typeof clientLoader>();
 
   const viewMode = useLayoutStore((state) => state.viewMode);
@@ -163,6 +164,24 @@ export default function ObjectsRoute() {
       );
     }
   }, [connectionName, urlPath, isPinned, nodes, pinFetcher]);
+
+  if (connectionError) {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Connection unavailable"
+        description={connectionError}
+        action={
+          <Button
+            onPress={() => openModal("edit-connection", { nodeName: connectionName })}
+            variant="secondary"
+          >
+            Edit connection
+          </Button>
+        }
+      />
+    );
+  }
 
   if (nodes.length > 0) {
     return (


### PR DESCRIPTION
## Summary

- [C-223] `findOrganizationByAlias` now pages through `/admin/realms/{realm}/organizations` and matches the requested alias in-process. KC 26.6's `?search=…&exact=true` filters on `name`/`domains` only, so realms whose organization `alias` diverged from `name` 404'd `/admin/users?scope=*` with no server-side log. KC's Java SPI has a direct `getByAlias` but it is not exposed via Admin REST.
- [C-224] STS `AssumeRoleWithWebIdentity` denial no longer 500s the connection view. `getAllSessionCredentials` classifies the failure (`AccessDenied`, `ExpiredTokenException`, …) and returns `{ credentials, errors }`; `authMiddleware` threads the per-connection error map into `authContext.credentialErrors`; `objects.loader.ts` returns a `connectionError` payload instead of throwing; `objects.route.tsx` renders an "Edit connection" `EmptyState` with the AWS-specific reason. Redundant inner `console.error` in `fetchTemporaryCredentials` is dropped — the outer collector's one-line warn carries the classified reason.

## Test plan

- [ ] Configure a Keycloak organization with `alias != name`, assign an org-root admin to it, open `/admin/users?scope=*` and confirm the page renders with the org name in the heading.
- [ ] Confirm orgs whose `alias == name` still resolve unchanged.
- [ ] Create a connection whose role's trust policy denies the current user, open the connection, and confirm the "Connection unavailable" empty state appears with the AWS reason and an "Edit connection" action.
- [ ] Confirm only the failing connection surfaces the banner; other connections on the same session continue to list normally.
- [ ] Tail `kubectl logs -l app.kubernetes.io/name=cytario-web` during the failure: only the `[CREDENTIAL] Failed to fetch credentials for …` warn appears — no SDK stack traces.
- [ ] `npm run lint && npm run typecheck && npx vitest run` all pass.
