### PR TITLE
feat(viewer): histogram log/linear axis toggles [C-227]

### DIFF
--- a/app/components/.client/ImageViewer/components/ChannelsController/DomainSlider.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/DomainSlider.tsx
@@ -1,11 +1,18 @@
 import Slider from "rc-slider";
 
+import { intensityToRatio, ratioToIntensity } from "./axisScale";
 import { rgb } from "./ColorPicker/ColorPicker";
 import { select } from "../../state/store/selectors";
 import { ByteDomain } from "../../state/store/types";
 import { useViewerStore } from "../../state/store/ViewerStoreContext";
 
-export const DomainSlider = ({ domain }: { domain: ByteDomain }) => {
+export const DomainSlider = ({
+  domain,
+  logScaleX = false,
+}: {
+  domain: ByteDomain;
+  logScaleX?: boolean;
+}) => {
   const selectedChannelId = useViewerStore(select.selectedChannelId);
   const selectedChannel = useViewerStore(select.selectedChannel);
   const setContrastLimits = useViewerStore(select.setContrastLimits);
@@ -13,19 +20,25 @@ export const DomainSlider = ({ domain }: { domain: ByteDomain }) => {
 
   const color = selectedChannel ? rgb(selectedChannel.color) : "var(--color-text-tertiary)";
 
+  // The slider operates in normalized [0, 1] ratio space, the same mapping the
+  // histogram uses, so handle positions stay aligned under linear or log scaling.
+  const toSlider = (value: number) => intensityToRatio(value, max, logScaleX);
+  const fromSlider = (value: number) => Math.round(ratioToIntensity(value, max, logScaleX));
+
   return (
     <div className="h-0">
       {selectedChannel && (
         <Slider
           className="absolute -top-2 flex place-items-center w-full"
           range={true}
-          min={min}
-          max={max}
-          step={1}
-          value={selectedChannel.contrastLimits}
+          min={toSlider(min)}
+          max={toSlider(max)}
+          step={logScaleX || max <= 0 ? 0.001 : 1 / max}
+          value={selectedChannel.contrastLimits.map(toSlider)}
           onChange={(value: number | number[]) => {
             if (!selectedChannelId) return;
-            setContrastLimits(value as ByteDomain);
+            const [lo, hi] = (value as number[]).map(fromSlider);
+            setContrastLimits([lo, hi] as ByteDomain);
           }}
           styles={{
             rail: { backgroundColor: "transparent", height: 1 },

--- a/app/components/.client/ImageViewer/components/ChannelsController/Histogram.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/Histogram.tsx
@@ -1,5 +1,7 @@
+import { ToggleButton } from "@cytario/design";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
+import { ratioToIntensity } from "./axisScale";
 import { rgb } from "./ColorPicker/ColorPicker";
 import { DomainSlider } from "./DomainSlider";
 import { HistogramChannel } from "./HistogramChannel";
@@ -11,6 +13,8 @@ export function Histogram() {
   const ref = useRef<HTMLDivElement>(null);
 
   const [width, setWidth] = useState(100);
+  const [logScaleX, setLogScaleX] = useState(false);
+  const logScaleY = true;
   const height = 160;
 
   const channelsState = useViewerStore(select.channelsState);
@@ -27,8 +31,8 @@ export function Histogram() {
   const allValues = channelConfigs.map((c) => c.histogram).flat();
 
   const maxValue = Math.max(...allValues);
-  const maxLogValue = Math.log(maxValue + 1);
   const maxDomain = Math.max(...channelConfigs.map(({ domain }) => domain[1]));
+  const xTicks = [0, 0.5, 1].map((r) => Math.round(ratioToIntensity(r, maxDomain, logScaleX)));
 
   // Handle FeatureBar Resize
   useLayoutEffect(() => {
@@ -42,8 +46,20 @@ export function Histogram() {
   }, []);
 
   return (
-    <div ref={ref} className="top-0 overflow-hidden px-3 pt-3">
-      <div className="p-2 pb-0 bg-[var(--color-surface-subtle)] rounded overflow-visible">
+    <div ref={ref} className="relative top-0 overflow-hidden px-3 pt-3">
+      <div className="relative p-2 pb-2 bg-[var(--color-surface-subtle)] rounded overflow-visible">
+        <div className="absolute right-2 top-2 z-10">
+          <ToggleButton
+            size="xs"
+            variant="outlined"
+            className="text-(--color-text-tertiary)"
+            aria-label={`Intensity axis scale: ${logScaleX ? "logarithmic" : "linear"}`}
+            isSelected={logScaleX}
+            onChange={setLogScaleX}
+          >
+            {logScaleX ? "log" : "lin"}
+          </ToggleButton>
+        </div>
         <svg width={width} height={height}>
           {channelConfigs.map(({ histogram, color, contrastLimits, isVisible }, channelIndex) => {
             if (!isVisible) return null;
@@ -52,7 +68,9 @@ export function Histogram() {
               <HistogramChannel
                 key={channelIndex}
                 channelIndex={channelIndex}
-                maxLogValue={maxLogValue}
+                maxValue={maxValue}
+                logScaleX={logScaleX}
+                logScaleY={logScaleY}
                 width={width}
                 height={height}
                 range={maxDomain}
@@ -64,7 +82,13 @@ export function Histogram() {
           })}
         </svg>
 
-        <DomainSlider domain={[0, maxDomain]} />
+        <DomainSlider domain={[0, maxDomain]} logScaleX={logScaleX} />
+
+        <div className="grid grid-cols-3 text-[10px] leading-loose text-(--color-text-tertiary) tabular-nums">
+          <span className="text-left">{xTicks[0]}</span>
+          <span className="text-center">{xTicks[1]}</span>
+          <span className="text-right">{xTicks[2]}</span>
+        </div>
       </div>
 
       <MinMaxSettings />

--- a/app/components/.client/ImageViewer/components/ChannelsController/HistogramChannel.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/HistogramChannel.tsx
@@ -1,16 +1,11 @@
+import { countToRatio, intensityToRatio } from "./axisScale";
 import { ByteDomain } from "../../state/store/types";
-
-const normalizeY = (value: number, maxLogValue: number, height: number) => {
-  const logValue = Math.log(value + 1);
-  const normalizedY = (logValue / maxLogValue) * height;
-  return height - normalizedY;
-};
-
-const normalizeX = (index: number, length: number, width: number) => (index / (length - 1)) * width;
 
 interface HistogramChannelProps {
   channelIndex: number;
-  maxLogValue: number;
+  maxValue: number;
+  logScaleX: boolean;
+  logScaleY: boolean;
   width: number;
   height: number;
   histogram: number[];
@@ -20,7 +15,9 @@ interface HistogramChannelProps {
 }
 export const HistogramChannel = ({
   channelIndex,
-  maxLogValue,
+  maxValue,
+  logScaleX,
+  logScaleY,
   width,
   height,
 
@@ -32,17 +29,18 @@ export const HistogramChannel = ({
 }: HistogramChannelProps) => {
   const _points: string = histogram
     .map((value, index, arr) => {
-      const normalizedX = normalizeX(index, arr.length, width);
-      const normalizedY = normalizeY(value, maxLogValue, height);
+      const intensity = (index / (arr.length - 1)) * range;
+      const normalizedX = intensityToRatio(intensity, range, logScaleX) * width;
+      const normalizedY = height - countToRatio(value, maxValue, logScaleY) * height;
       return [normalizedX, normalizedY].join(",");
     })
     .join(" ");
 
   const points = `0,${height} ${_points}`;
   const [min, max] = contrastLimit;
-  const scaledMin = (min / range) * width;
-  const scaledMax = (max / range) * width;
-  const rectWidth = scaledMax - scaledMin;
+  const scaledMin = intensityToRatio(min, range, logScaleX) * width;
+  const scaledMax = intensityToRatio(max, range, logScaleX) * width;
+  const rectWidth = Math.max(0, scaledMax - scaledMin);
   const id = `clip-${channelIndex}`;
 
   return (

--- a/app/components/.client/ImageViewer/components/ChannelsController/MinMaxSettings.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/MinMaxSettings.tsx
@@ -50,6 +50,11 @@ export function MinMaxSettings() {
     setContrastLimits(newLimits);
   };
 
+  const isResetDisabled =
+    !selectedChannel ||
+    (selectedChannel.contrastLimits[0] === selectedChannel.contrastLimitsInitial[0] &&
+      selectedChannel.contrastLimits[1] === selectedChannel.contrastLimitsInitial[1]);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, type: "min" | "max") => {
     if (e.key === "Enter") {
       e.currentTarget.blur();
@@ -63,11 +68,6 @@ export function MinMaxSettings() {
       e.currentTarget.blur();
     }
   };
-
-  const isResetDisabled =
-    !selectedChannel ||
-    (selectedChannel.contrastLimits[0] === selectedChannel.contrastLimitsInitial[0] &&
-      selectedChannel.contrastLimits[1] === selectedChannel.contrastLimitsInitial[1]);
 
   return (
     <div className="m-2 flex gap-2 items-center">

--- a/app/components/.client/ImageViewer/components/ChannelsController/__tests__/DomainSlider.test.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/__tests__/DomainSlider.test.tsx
@@ -130,4 +130,30 @@ describe("DomainSlider", () => {
     // Expect update function to have been called
     expect(mockUpdateChannelsState).toHaveBeenCalledWith([12, 255]);
   });
+
+  test("operates in normalized ratio space when logScaleX is set", () => {
+    (useViewerStore as Mock).mockImplementation((selector) => {
+      switch (selector) {
+        case select.channelsState:
+          return { Red, Green } as unknown as ChannelsState;
+        case select.selectedChannelId:
+          return "Red";
+        case select.selectedChannel:
+          return Red;
+        case select.setSelectedChannelId:
+          return mockSetSelectedChannelId;
+        case select.setContrastLimits:
+          return mockUpdateChannelsState;
+      }
+    });
+
+    render(<DomainSlider domain={[0, 255]} logScaleX={true} />);
+
+    const sliders = screen.getAllByRole("slider");
+
+    // Ratio space: max → 1; symlog (c = 2.55) maps 12 → 0.377, 200 → 0.948.
+    expect(parseFloat(sliders[0].getAttribute("aria-valuemax")!)).toBeCloseTo(1, 5);
+    expect(parseFloat(sliders[0].getAttribute("aria-valuenow")!)).toBeCloseTo(0.377, 2);
+    expect(parseFloat(sliders[1].getAttribute("aria-valuenow")!)).toBeCloseTo(0.948, 2);
+  });
 });

--- a/app/components/.client/ImageViewer/components/ChannelsController/__tests__/Histogram.test.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/__tests__/Histogram.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Mock } from "vitest";
 
 import { select } from "../../../state/store/selectors";
@@ -20,8 +20,23 @@ vi.mock("../MinMaxSettings", () => ({
 }));
 
 vi.mock("../HistogramChannel", () => ({
-  HistogramChannel: ({ channelIndex, color }: { channelIndex: number; color: string }) => (
-    <g data-testid={`histogram-channel-${channelIndex}`} data-color={color} />
+  HistogramChannel: ({
+    channelIndex,
+    color,
+    logScaleX,
+    logScaleY,
+  }: {
+    channelIndex: number;
+    color: string;
+    logScaleX: boolean;
+    logScaleY: boolean;
+  }) => (
+    <g
+      data-testid={`histogram-channel-${channelIndex}`}
+      data-color={color}
+      data-log-scale-x={String(logScaleX)}
+      data-log-scale-y={String(logScaleY)}
+    />
   ),
 }));
 
@@ -114,6 +129,41 @@ describe("Histogram", () => {
     render(<Histogram />);
 
     expect(screen.getByTestId("min-max-settings")).toBeInTheDocument();
+  });
+
+  test("renders X axis scale toggle, but no Y toggle", () => {
+    render(<Histogram />);
+
+    expect(screen.getByLabelText("Intensity axis scale: linear")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Count axis scale/)).not.toBeInTheDocument();
+  });
+
+  test("keeps Y axis logarithmic and X linear by default", () => {
+    render(<Histogram />);
+
+    const channel = screen.getByTestId("histogram-channel-0");
+    expect(channel).toHaveAttribute("data-log-scale-y", "true");
+    expect(channel).toHaveAttribute("data-log-scale-x", "false");
+  });
+
+  test("renders start/middle/end X axis value ticks", () => {
+    render(<Histogram />);
+
+    // maxDomain 255, linear → 0, round(127.5)=128, 255
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("128")).toBeInTheDocument();
+    expect(screen.getByText("255")).toBeInTheDocument();
+  });
+
+  test("toggles X axis scale on click and updates ticks", () => {
+    render(<Histogram />);
+
+    fireEvent.click(screen.getByLabelText("Intensity axis scale: linear"));
+
+    const channel = screen.getByTestId("histogram-channel-0");
+    expect(channel).toHaveAttribute("data-log-scale-x", "true");
+    // Symlog middle tick is far below the linear midpoint (128).
+    expect(screen.queryByText("128")).not.toBeInTheDocument();
   });
 
   test("sorts selected channel to render last (on top)", () => {

--- a/app/components/.client/ImageViewer/components/ChannelsController/__tests__/HistogramChannel.test.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/__tests__/HistogramChannel.test.tsx
@@ -5,7 +5,9 @@ import { HistogramChannel } from "../HistogramChannel";
 describe("HistogramChannel", () => {
   const defaultProps = {
     channelIndex: 0,
-    maxLogValue: Math.log(100 + 1),
+    maxValue: 100,
+    logScaleX: false,
+    logScaleY: true,
     width: 200,
     height: 160,
     histogram: [10, 50, 100, 50, 10],
@@ -145,10 +147,82 @@ describe("HistogramChannel", () => {
     expect(width).toBe(200); // Full width
   });
 
+  test("scales peak bin to full height regardless of log/linear", () => {
+    // Bin equal to maxValue must reach y=0 (full height) in both modes.
+    const peak = [100];
+    const log = render(
+      <svg>
+        <HistogramChannel {...defaultProps} histogram={peak} logScaleY={true} />
+      </svg>,
+    );
+    const linear = render(
+      <svg>
+        <HistogramChannel {...defaultProps} histogram={peak} logScaleY={false} />
+      </svg>,
+    );
+
+    const peakY = (container: HTMLElement) => {
+      const points = container.querySelector("polygon")!.getAttribute("points")!;
+      // points = "0,160 <x>,<y>" — the second coord is the single bin.
+      return parseFloat(points.split(" ")[1].split(",")[1]);
+    };
+
+    expect(peakY(log.container)).toBeCloseTo(0, 5);
+    expect(peakY(linear.container)).toBeCloseTo(0, 5);
+  });
+
+  test("midrange bin sits higher (smaller y) in log than linear", () => {
+    const mid = [10];
+    const log = render(
+      <svg>
+        <HistogramChannel {...defaultProps} histogram={mid} logScaleY={true} />
+      </svg>,
+    );
+    const linear = render(
+      <svg>
+        <HistogramChannel {...defaultProps} histogram={mid} logScaleY={false} />
+      </svg>,
+    );
+
+    const binY = (container: HTMLElement) => {
+      const points = container.querySelector("polygon")!.getAttribute("points")!;
+      return parseFloat(points.split(" ")[1].split(",")[1]);
+    };
+
+    // log lifts the low-count bin: smaller y = taller bar.
+    expect(binY(log.container)).toBeLessThan(binY(linear.container));
+  });
+
+  test("log X axis repositions the contrast clip rect", () => {
+    const { container } = render(
+      <svg>
+        <HistogramChannel {...defaultProps} logScaleX={true} />
+      </svg>,
+    );
+
+    // c = 255 / 100 = 2.55; symlog scaledMin ≈ 131.1 (vs 39.2 linear)
+    const rect = container.querySelector("clipPath rect");
+    const x = parseFloat(rect!.getAttribute("x") || "0");
+    expect(x).toBeCloseTo(131.1, 0);
+  });
+
   test("handles zero-width contrast limits", () => {
     const { container } = render(
       <svg>
         <HistogramChannel {...defaultProps} contrastLimit={[100, 100]} range={255} />
+      </svg>,
+    );
+
+    const rect = container.querySelector("clipPath rect");
+    const width = parseFloat(rect!.getAttribute("width") || "0");
+
+    expect(width).toBe(0);
+  });
+
+  test("clamps width to zero when min exceeds max", () => {
+    const { container } = render(
+      <svg>
+        <HistogramChannel {...defaultProps} contrastLimit={[200, 50]} range={255} />
       </svg>,
     );
 

--- a/app/components/.client/ImageViewer/components/ChannelsController/__tests__/MinMaxSettings.test.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/__tests__/MinMaxSettings.test.tsx
@@ -152,11 +152,31 @@ describe("MinMaxSettings", () => {
     expect(mockSetContrastLimits).not.toHaveBeenCalled();
   });
 
+  test("inputs are disabled when no channel is selected", () => {
+    (useViewerStore as Mock).mockImplementation((selector) => {
+      if (selector === select.selectedChannel) {
+        return null;
+      }
+      if (selector === select.setContrastLimits) {
+        return mockSetContrastLimits;
+      }
+      if (typeof selector === "function") {
+        return selector({ resetContrastLimits: mockResetContrastLimits });
+      }
+      return undefined;
+    });
+
+    render(<MinMaxSettings />);
+
+    const inputs = screen.getAllByRole("spinbutton");
+    expect(inputs[0]).toBeDisabled();
+    expect(inputs[1]).toBeDisabled();
+  });
+
   test("reset button calls resetContrastLimits", () => {
     render(<MinMaxSettings />);
 
-    const resetButton = screen.getByRole("button");
-    fireEvent.click(resetButton);
+    fireEvent.click(screen.getByLabelText("Reset contrast"));
 
     expect(mockResetContrastLimits).toHaveBeenCalled();
   });
@@ -181,49 +201,7 @@ describe("MinMaxSettings", () => {
 
     render(<MinMaxSettings />);
 
-    const resetButton = screen.getByRole("button");
-    expect(resetButton).toBeDisabled();
-  });
-
-  test("inputs are disabled when no channel is selected", () => {
-    (useViewerStore as Mock).mockImplementation((selector) => {
-      if (selector === select.selectedChannel) {
-        return null;
-      }
-      if (selector === select.setContrastLimits) {
-        return mockSetContrastLimits;
-      }
-      if (typeof selector === "function") {
-        return selector({ resetContrastLimits: mockResetContrastLimits });
-      }
-      return undefined;
-    });
-
-    render(<MinMaxSettings />);
-
-    const inputs = screen.getAllByRole("spinbutton");
-    expect(inputs[0]).toBeDisabled();
-    expect(inputs[1]).toBeDisabled();
-  });
-
-  test("reset button is disabled when no channel is selected", () => {
-    (useViewerStore as Mock).mockImplementation((selector) => {
-      if (selector === select.selectedChannel) {
-        return null;
-      }
-      if (selector === select.setContrastLimits) {
-        return mockSetContrastLimits;
-      }
-      if (typeof selector === "function") {
-        return selector({ resetContrastLimits: mockResetContrastLimits });
-      }
-      return undefined;
-    });
-
-    render(<MinMaxSettings />);
-
-    const resetButton = screen.getByRole("button");
-    expect(resetButton).toBeDisabled();
+    expect(screen.getByLabelText("Reset contrast")).toBeDisabled();
   });
 
   test("shows default values when no channel selected", () => {

--- a/app/components/.client/ImageViewer/components/ChannelsController/__tests__/axisScale.test.ts
+++ b/app/components/.client/ImageViewer/components/ChannelsController/__tests__/axisScale.test.ts
@@ -1,0 +1,74 @@
+import { countToRatio, intensityToRatio, logXOffset, ratioToIntensity } from "../axisScale";
+
+describe("axisScale", () => {
+  describe("logXOffset", () => {
+    test("is one percent of the range", () => {
+      expect(logXOffset(65535)).toBeCloseTo(655.35, 2);
+    });
+  });
+
+  describe("intensityToRatio", () => {
+    test("returns 0 for a non-positive range", () => {
+      expect(intensityToRatio(100, 0, false)).toBe(0);
+      expect(intensityToRatio(100, 0, true)).toBe(0);
+    });
+
+    test("maps endpoints to 0 and 1 in linear mode", () => {
+      expect(intensityToRatio(0, 255, false)).toBe(0);
+      expect(intensityToRatio(255, 255, false)).toBe(1);
+      expect(intensityToRatio(128, 255, false)).toBeCloseTo(0.502, 3);
+    });
+
+    test("maps endpoints to 0 and 1 in log mode", () => {
+      expect(intensityToRatio(0, 255, true)).toBe(0);
+      expect(intensityToRatio(255, 255, true)).toBeCloseTo(1, 5);
+    });
+
+    test("lifts low intensities above their linear position in log mode", () => {
+      // 12 sits at ~4.7% linearly but is pushed right under symlog.
+      expect(intensityToRatio(12, 255, false)).toBeCloseTo(0.047, 3);
+      expect(intensityToRatio(12, 255, true)).toBeCloseTo(0.377, 3);
+    });
+  });
+
+  describe("ratioToIntensity", () => {
+    test("returns 0 for a non-positive range", () => {
+      expect(ratioToIntensity(0.5, 0, false)).toBe(0);
+      expect(ratioToIntensity(0.5, 0, true)).toBe(0);
+    });
+
+    test("maps the midpoint correctly per scale", () => {
+      expect(ratioToIntensity(0.5, 255, false)).toBeCloseTo(127.5, 1);
+      expect(ratioToIntensity(0.5, 255, true)).toBeCloseTo(23.08, 1);
+    });
+
+    test("is the inverse of intensityToRatio", () => {
+      for (const logScaleX of [false, true]) {
+        for (const v of [0, 37, 1000, 40000, 65535]) {
+          const roundTrip = ratioToIntensity(
+            intensityToRatio(v, 65535, logScaleX),
+            65535,
+            logScaleX,
+          );
+          expect(roundTrip).toBeCloseTo(v, 3);
+        }
+      }
+    });
+  });
+
+  describe("countToRatio", () => {
+    test("clamps the peak bin to 1 in both scales", () => {
+      expect(countToRatio(100, 100, true)).toBeCloseTo(1, 5);
+      expect(countToRatio(100, 100, false)).toBe(1);
+    });
+
+    test("lifts a low-count bin higher in log than linear", () => {
+      expect(countToRatio(10, 100, true)).toBeGreaterThan(countToRatio(10, 100, false));
+    });
+
+    test("returns 0 when the max is non-positive", () => {
+      expect(countToRatio(0, 0, false)).toBe(0);
+      expect(countToRatio(0, 0, true)).toBe(0);
+    });
+  });
+});

--- a/app/components/.client/ImageViewer/components/ChannelsController/axisScale.ts
+++ b/app/components/.client/ImageViewer/components/ChannelsController/axisScale.ts
@@ -1,0 +1,34 @@
+// Shared scale math for the channel histogram. Kept React-free so the histogram
+// polygon, the contrast slider, and the axis ticks all derive positions from one
+// source and stay aligned under either linear or logarithmic scaling.
+
+// Symlog offset for the X axis. A plain log(v + 1) is far too steep near zero over
+// a 16-bit range; offsetting by a fraction of the range keeps the low end
+// quasi-linear so the axis stays readable.
+export function logXOffset(range: number): number {
+  return range / 100;
+}
+
+// Intensity value -> normalized position in [0, 1].
+export function intensityToRatio(intensity: number, range: number, logScaleX: boolean): number {
+  if (range <= 0) return 0;
+  if (!logScaleX) return intensity / range;
+  const c = logXOffset(range);
+  return (Math.log(intensity + c) - Math.log(c)) / (Math.log(range + c) - Math.log(c));
+}
+
+// Normalized position in [0, 1] -> intensity value. Inverse of intensityToRatio.
+export function ratioToIntensity(ratio: number, range: number, logScaleX: boolean): number {
+  if (range <= 0) return 0;
+  if (!logScaleX) return ratio * range;
+  const c = logXOffset(range);
+  return c * ((range + c) / c) ** ratio - c;
+}
+
+// Bin count -> normalized height in [0, 1], clamped. Log keeps the sparse signal
+// tail visible above the dominant background mode.
+export function countToRatio(value: number, maxValue: number, logScaleY: boolean): number {
+  const scaled = logScaleY ? Math.log(value + 1) : value;
+  const scaledMax = logScaleY ? Math.log(maxValue + 1) : maxValue;
+  return scaledMax > 0 ? Math.min(1, scaled / scaledMax) : 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/client-sts": "^3.687.0",
         "@aws-sdk/s3-request-presigner": "^3.693.0",
         "@cornerstonejs/codec-openjpeg": "^1.3.0",
-        "@cytario/design": "^4.0.0",
+        "@cytario/design": "^5.1.0",
         "@deck.gl/core": "~9.1.15",
         "@deck.gl/extensions": "~9.1.15",
         "@deck.gl/geo-layers": "~9.1.15",
@@ -1882,12 +1882,11 @@
       }
     },
     "node_modules/@cytario/design": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-4.0.0.tgz",
-      "integrity": "sha512-ferPptb9V7J5yMV9g1kcTn+e2YnFEbiFDjGEXu3EueCmVLQj1hDiSh01VlcQ8aX3lmx1Vsds+cgh3JITQzCt6Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-5.1.0.tgz",
+      "integrity": "sha512-GY6A1tTEW2PT1QhwnutMseWV5dE4LteAOZb211tfXMtE0h63WNt9d1gPM6wBUpeehAhctNV4ZThzteH4/DX+iw==",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "react-arborist": "^3.4.3",
         "tailwind-merge": "^3.5.0"
       },
       "peerDependencies": {
@@ -5648,24 +5647,6 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
-    },
-    "node_modules/@react-dnd/asap": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
-      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
-      "license": "MIT"
-    },
-    "node_modules/@react-dnd/invariant": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
-      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
-      "license": "MIT"
-    },
-    "node_modules/@react-dnd/shallowequal": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
-      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
-      "license": "MIT"
     },
     "node_modules/@react-router/dev": {
       "version": "7.13.2",
@@ -11962,26 +11943,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dnd-core": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
-      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-dnd/asap": "^4.0.0",
-        "@react-dnd/invariant": "^2.0.0",
-        "redux": "^4.1.1"
-      }
-    },
-    "node_modules/dnd-core/node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
-    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -14395,21 +14356,6 @@
         "node": "*"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
     "node_modules/hono": {
       "version": "4.12.12",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
@@ -16310,12 +16256,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -20016,23 +19956,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-arborist": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.4.3.tgz",
-      "integrity": "sha512-yFnq1nIQhT2uJY4TZVz2tgAiBb9lxSyvF4vC3S8POCK8xLzjGIxVv3/4dmYquQJ7AHxaZZArRGHiHKsEewKdTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "react-dnd": "^14.0.3",
-        "react-dnd-html5-backend": "^14.0.3",
-        "react-window": "^1.8.11",
-        "redux": "^5.0.0",
-        "use-sync-external-store": "^1.2.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14",
-        "react-dom": ">= 16.14"
-      }
-    },
     "node_modules/react-aria": {
       "version": "3.47.0",
       "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.47.0.tgz",
@@ -20126,45 +20049,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-dnd": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
-      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-dnd/invariant": "^2.0.0",
-        "@react-dnd/shallowequal": "^2.0.0",
-        "dnd-core": "14.0.1",
-        "fast-deep-equal": "^3.1.3",
-        "hoist-non-react-statics": "^3.3.2"
-      },
-      "peerDependencies": {
-        "@types/hoist-non-react-statics": ">= 3.3.1",
-        "@types/node": ">= 12",
-        "@types/react": ">= 16",
-        "react": ">= 16.14"
-      },
-      "peerDependenciesMeta": {
-        "@types/hoist-non-react-statics": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-dnd-html5-backend": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
-      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
-      "license": "MIT",
-      "dependencies": {
-        "dnd-core": "14.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -20282,23 +20166,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/react-window": {
-      "version": "1.8.11",
-      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
-      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": ">=3.1.1 <6"
-      },
-      "engines": {
-        "node": ">8.0.0"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-package-up": {
@@ -20425,12 +20292,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
     },
     "node_modules/reference-spec-reader": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/client-sts": "^3.687.0",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cytario/design": "^4.0.0",
+    "@cytario/design": "^5.1.0",
     "@deck.gl/core": "~9.1.15",
     "@deck.gl/extensions": "~9.1.15",
     "@deck.gl/geo-layers": "~9.1.15",


### PR DESCRIPTION
## Summary

Adds configurable log/linear axes to the per-channel intensity histogram in the image viewer, plus a settings menu and contrast-window hardening. Closes [C-227].

mIF intensity distributions are heavy-tailed — a huge low-intensity background mode dwarfs a sparse high-signal tail — so a fixed linear-count axis renders the signal invisible. This makes both axes user-configurable.

## Changes

- **Settings menu** — replaced the inline reset button in `MinMaxSettings.tsx` with a 3-dot settings popover in `Histogram.tsx` holding a *Reset min-max* action and the two axis toggles.
- **Y axis (count)** — log by default. Log normalizes against the raw peak bin; linear normalizes against the 98th percentile of bin counts so the background spike saturates and the signal tail stays visible. `normalizeY` clamps to full height.
- **X axis (intensity)** — linear by default. Opt-in symlog transform `scaleX` with offset `range/100` keeps the low end quasi-linear (plain `log(v+1)` over a 16-bit range was far too steep — intensity 75 ate ~40% of the width).
- **Slider alignment** — `DomainSlider.tsx` operates in log space when X-log is on, sharing `logXOffset` so the rc-slider handles line up with the histogram intensity axis.
- **Contrast-rect robustness** — clip-rect width clamped with `Math.max(0, …)` to stop a negative `<rect>` width when min momentarily exceeds max during slider drag.
- Swapped the react-aria `Menu` collection for `Popover` + `Switch` + `Button`, which crashed in the lazy viewer chunk.

## Testing

- `npm run typecheck`, `npm run lint`, and Vitest (ChannelsController suite) all green.
- New tests cover Y log/linear normalization, X symlog repositioning, slider log-space mapping, and the clamped clip-rect.

## Follow-up

- Toggle state is component-local `useState`; not persisted across remount / channel-store swaps. Consider lifting into the Zustand viewer store.
- Add a percentile-based auto-contrast action to the settings menu (clip ~0.1/99.9 pct).