### PR TITLE
fix(viewer): await plugin bootstrap before hydration [C-228]

### DIFF
--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -4,19 +4,21 @@ import { HydratedRouter } from "react-router/dom";
 
 import { bootstrapPlugins } from "./plugins.generated";
 
-startTransition(() => {
-  hydrateRoot(document, <HydratedRouter />);
-});
-
-// Built-ins register lazily when ViewerStoreContext mounts — importing them
-// here would pull viv + geotiff (multi-MB) into the entry bundle and delay
-// hydration on non-viewer routes. Plugin bootstrap runs after hydrateRoot
-// for the same reason.
-void bootstrapPlugins({
+// Await bootstrap before hydrating so registry-derived gates (e.g. the
+// `isImageFile` viewer gate) see plugin-contributed formats on the first
+// client render, matching the server which also awaits before SSR. Plugin
+// modules are already statically imported above, so this only waits for
+// `register()` to run — it pulls in no extra bundle. (Built-ins still register
+// lazily in ViewerStoreContext to keep viv + geotiff out of the entry chunk.)
+await bootstrapPlugins({
   debug: (msg, fields) => console.debug("[plugin-bootstrap]", msg, fields ?? {}),
   info: (msg, fields) => console.info("[plugin-bootstrap]", msg, fields ?? {}),
   warn: (msg, fields) => console.warn("[plugin-bootstrap]", msg, fields ?? {}),
   error: (msg, fields) => console.error("[plugin-bootstrap]", msg, fields ?? {}),
 }).catch((err) => {
   console.error("[plugin-bootstrap] unexpected bootstrap failure:", err);
+});
+
+startTransition(() => {
+  hydrateRoot(document, <HydratedRouter />);
 });


### PR DESCRIPTION
## Summary

Plugin-contributed image formats (e.g. `.ndpi` from `@cytario/ndpi-loader`) rendered the **"Unsupported file format."** empty state instead of the viewer on direct-load / reload, even when the plugin was built, registered, and API-compatible. Built-in formats were unaffected (hardcoded in `STATIC_FILE_TYPES`).

## Root cause

The objects route gates `<Viewer>` on `isImageFile(resourceId)`, which derives plugin formats from the registry **at call time**. `entry.server.tsx` awaits `bootstrapPlugins` before SSR, but `entry.client.tsx` ran it fire-and-forget **after** `hydrateRoot`. The client gate re-evaluated before async/dynamically-loaded plugins had registered → returned `false` → stuck on the empty state, and the non-reactive registry never triggered a re-render.

`czi` works in the cytario-ee prod build because codegen statically imports the plugin and its `register()` populates the registry synchronously, completing before the deferred hydration commit. The race only bites plugins whose registration is async or dynamically loaded.

Introduced by `87ecc64` (route gated on registry-derived `isImageFile`) on top of the deferred client bootstrap from `b285e3d`.

## Fix

`entry.client.tsx` now `await`s `bootstrapPlugins` before `hydrateRoot`, mirroring the server. Plugin modules are already statically imported, so this waits only for `register()` and pulls in **no** extra bundle; built-ins still register lazily in `ViewerStoreContext` to keep viv + geotiff out of the entry chunk.

## Tradeoff

Hydration now waits on `register()`. Sync-register plugins ≈ 0 cost; async-register (e.g. wasm init) delays hydration by that init time across all routes. Right contract: plugins keep `register()` cheap and push heavy init into `load()`.

## Test plan

- [x] `typecheck` / `lint` / `format:check` pass (pre-commit + manual)
- [x] Existing `objects.route.test.tsx` green (route untouched)
- [ ] Direct-load an objects route at a plugin-contributed extension → renders viewer, not empty state
- [ ] Built-in `.ome.tif` still renders with no added hydration delay

Closes C-228.