### PR TITLE
fix(connections): broken-connection robustness — graceful detail view, create-time role check, list refresh [C-229] [C-231]

### DIFF
--- a/app/routes/connections/connections.route.tsx
+++ b/app/routes/connections/connections.route.tsx
@@ -42,11 +42,19 @@ const title = "Storage Connections";
 
 export const meta: MetaFunction = () => [{ title: `${title} — Cytario` }];
 
+// The client loader runs an expensive per-bucket probe, so we don't want to
+// re-run it on incidental same-path navigations (opening the add-connection
+// modal, changing the search query). But we MUST revalidate after a mutation
+// and when the user (re-)enters the list — otherwise a connection created on
+// another route never appears until a hard reload.
 export const shouldRevalidate: ShouldRevalidateFunction = ({
+  currentUrl,
+  nextUrl,
   formAction,
   defaultShouldRevalidate,
 }) => {
   if (formAction) return defaultShouldRevalidate;
+  if (currentUrl.pathname !== nextUrl.pathname) return true;
   return false;
 };
 

--- a/app/routes/connections/createConnection.action.ts
+++ b/app/routes/connections/createConnection.action.ts
@@ -1,8 +1,9 @@
 import { type ActionFunctionArgs, redirect } from "react-router";
 
 import { connectionSchema, parseS3Uri } from "./connection.schema";
-import { Prisma } from "~/.generated/client";
-import { authContext } from "~/.server/auth/authMiddleware";
+import { Prisma, type ConnectionConfig } from "~/.generated/client";
+import { authContext, type AuthContextData } from "~/.server/auth/authMiddleware";
+import { getAllSessionCredentials } from "~/.server/auth/getSessionCredentials";
 import { sessionContext } from "~/.server/auth/sessionMiddleware";
 import { sessionStorage } from "~/.server/auth/sessionStorage";
 import { describeCorsFailure, describeCorsWarning, probeBucketCors } from "~/.server/corsPreflight";
@@ -46,8 +47,54 @@ export async function createConnection(
   });
 }
 
+/**
+ * Soft post-create check: attempt to mint STS credentials for the new config
+ * so an un-assumable role surfaces immediately as a warning. Reuses the same
+ * mint path as the per-request credential fetch. Never throws — returns a
+ * user-facing warning string, or `undefined` when the role assumed cleanly.
+ */
+async function probeRoleAssumable(
+  auth: AuthContextData,
+  organization: string,
+  ownerScope: string,
+  createdBy: string,
+  config: {
+    name: string;
+    bucketName: string;
+    provider: string;
+    roleArn: string | null;
+    region: string | null;
+    endpoint: string;
+    prefix?: string;
+  },
+): Promise<string | undefined> {
+  const probeConfig: ConnectionConfig = {
+    id: 0,
+    name: config.name,
+    organization,
+    ownerScope,
+    createdBy,
+    bucketName: config.bucketName,
+    provider: config.provider,
+    endpoint: config.endpoint,
+    roleArn: config.roleArn,
+    region: config.region,
+    prefix: config.prefix ?? "",
+  };
+
+  try {
+    const { errors } = await getAllSessionCredentials(auth, [probeConfig]);
+    const reason = errors[config.name];
+    if (!reason) return undefined;
+    return `The IAM role could not be assumed yet (${reason}) — the connection was saved but may not work until the role and its trust policy are correct.`;
+  } catch {
+    return "The IAM role could not be verified yet — the connection was saved but may not work until the role is reachable.";
+  }
+}
+
 export const createAction = async ({ request, context }: ActionFunctionArgs) => {
-  const { user } = context.get(authContext);
+  const auth = context.get(authContext);
+  const { user } = auth;
   if (!user.organization) {
     throw new Error("Active organization missing from session");
   }
@@ -121,19 +168,30 @@ export const createAction = async ({ request, context }: ActionFunctionArgs) => 
 
     await createConnection(user.organization, data.ownerScope, user.sub, newConfig);
 
-    if (corsResult.warnings.length > 0) {
-      session.set("notification", {
-        status: "warning",
-        message: `Connection added. ${corsResult.warnings
-          .map((w) => describeCorsWarning(w, cytarioOrigin))
-          .join(" ")}`,
-      });
-    } else {
-      session.set("notification", {
-        status: "success",
-        message: "Storage connection added successfully.",
-      });
-    }
+    // Verify the IAM role can actually be assumed. This is a soft check, not a
+    // gate: a freshly-created role/trust-policy can take seconds to propagate
+    // in STS, so a failure here is surfaced as a warning rather than blocking
+    // the (already-persisted) connection. The per-request credential mint will
+    // retry on every page load.
+    const roleWarning = await probeRoleAssumable(
+      auth,
+      user.organization,
+      data.ownerScope,
+      user.sub,
+      newConfig,
+    );
+
+    const warnings = [
+      ...corsResult.warnings.map((w) => describeCorsWarning(w, cytarioOrigin)),
+      ...(roleWarning ? [roleWarning] : []),
+    ];
+
+    session.set(
+      "notification",
+      warnings.length > 0
+        ? { status: "warning", message: `Connection added. ${warnings.join(" ")}` }
+        : { status: "success", message: "Storage connection added successfully." },
+    );
 
     return redirect(`/connections/${encodeURIComponent(data.name)}`, {
       headers: { "Set-Cookie": await sessionStorage.commitSession(session) },

--- a/app/routes/objects/objects.loader.ts
+++ b/app/routes/objects/objects.loader.ts
@@ -57,7 +57,13 @@ export const loader = async ({ params, context }: LoaderFunctionArgs) => {
 
   const connectionConfig = await getConnection(user, connectionName);
   if (!connectionConfig) {
-    throw new Error("Connection configuration not found");
+    // Unknown name, or a connection the user can't see. A bare Error surfaces
+    // as an unhandled 500; throw a 404 so the root ErrorBoundary renders a
+    // proper "Not Found" page instead.
+    throw new Response("Connection not found, or you don't have access to it.", {
+      status: 404,
+      statusText: "Not Found",
+    });
   }
 
   const { bucketName } = connectionConfig;


### PR DESCRIPTION
Follow-ups to the connection-status work (#119). Three independent robustness fixes for connections that exist but can't be used or aren't reflected in the UI.

## 1. Detail view no longer 500s for missing/inaccessible connections [C-229]

`objects.loader` threw a bare `Error("Connection configuration not found")` when `getConnection` returned null (unknown name, or a connection the user can't see). That surfaced as an unhandled **500 "An unexpected error occurred"**.

Now throws a **404 Response**, so the root `ErrorBoundary` renders a proper "Not Found" page with a helpful message.

## 2. Create-time IAM role check [C-229]

Connection create only probed bucket CORS — never that the role could be assumed. A connection with a bad/un-assumable Role ARN persisted silently and only failed later.

The create action now mints STS credentials for the new config (reusing the per-request mint path) and surfaces a failure as a **non-blocking warning** in the success notification. It is **not** a gate: a freshly-created role/trust-policy can take seconds to propagate in STS, so the connection is still saved and the per-request mint retries on every load.

## 3. Connections list refreshes after a mutation [C-231]

The route's `shouldRevalidate` returned `false` for every non-form navigation (to avoid re-running the expensive per-bucket probe on incidental param changes). That also suppressed revalidation when re-entering the list after creating a connection elsewhere — so the new connection never appeared until a hard reload.

Now revalidates on a genuine **pathname change** (re-entering the list) while still skipping same-path search-param toggles (modal/query) and keeping post-mutation revalidation.

## Testing

- `typecheck`, `lint`, `prettier` clean (pre-commit hooks pass).
- Connections + objects unit suites green (120 passed, incl. `objects.loader`).
- Not yet eyeballed live (same tenant-mismatch constraint as #119): the 404 page, the create-time role warning, and the post-create list refresh want a manual pass in a tenant with a working connection.

## Relation

Builds on #119 (connection status single source of truth). Independent files; both branch off `main`. Closes the remaining C-229 follow-ups and C-231.