### PR TITLE
feat: plugin registry for SaaS onboarding and subscription gating (C-225)

### DIFF
--- a/__tests__/noopPluginIntegration.test.ts
+++ b/__tests__/noopPluginIntegration.test.ts
@@ -15,6 +15,9 @@ describe("noop-plugin integration", () => {
     assertApiCompatible(noopPlugin, hostApiVersion);
     const ctx = {
       formats: formatRegistry.scopedFor(noopPlugin.name),
+      gates: { register: () => {} },
+      slots: { register: () => {} },
+      env: "server" as const,
       logger: {
         debug: () => {},
         info: () => {},
@@ -39,6 +42,9 @@ describe("noop-plugin integration", () => {
     assertApiCompatible(noopPlugin, hostApiVersion);
     await noopPlugin.register({
       formats: formatRegistry.scopedFor(noopPlugin.name),
+      gates: { register: () => {} },
+      slots: { register: () => {} },
+      env: "server",
       logger: {
         debug: () => {},
         info: () => {},

--- a/app/.server/__tests__/pluginGates.test.ts
+++ b/app/.server/__tests__/pluginGates.test.ts
@@ -1,0 +1,120 @@
+import { gateRegistry, runGates } from "../pluginGates";
+import type { GateRequest, Identity } from "@cytario/plugin-api";
+
+const identity: Identity = {
+  organization: "testcorp",
+  organizationAttributes: {},
+  groups: [],
+  adminScopes: [],
+};
+
+const request = (overrides?: Partial<GateRequest>): GateRequest => ({
+  url: "http://localhost/test",
+  method: "GET",
+  identity,
+  ...overrides,
+});
+
+beforeEach(() => {
+  gateRegistry.__reset();
+});
+
+describe("pluginGates", () => {
+  test("register adds a gate that runGates evaluates", async () => {
+    const gate = vi.fn(() => ({ kind: "continue" }) as const);
+    gateRegistry.register(gate);
+
+    const outcome = await runGates(request());
+
+    expect(gate).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ kind: "continue" });
+  });
+
+  test("returns continue when no gates are registered", async () => {
+    expect(await runGates(request())).toEqual({ kind: "continue" });
+  });
+
+  test("evaluates gates in registration order", async () => {
+    const order: string[] = [];
+    gateRegistry.register(() => {
+      order.push("first");
+      return { kind: "continue" };
+    });
+    gateRegistry.register(() => {
+      order.push("second");
+      return { kind: "continue" };
+    });
+
+    await runGates(request());
+
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  test("returns the first non-continue outcome (redirect) and stops", async () => {
+    const later = vi.fn(() => ({ kind: "continue" }) as const);
+    gateRegistry.register(() => ({ kind: "continue" }));
+    gateRegistry.register(() => ({ kind: "redirect", url: "/onboard" }));
+    gateRegistry.register(later);
+
+    const outcome = await runGates(request());
+
+    expect(outcome).toEqual({ kind: "redirect", url: "/onboard" });
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  test("returns the first non-continue outcome (deny)", async () => {
+    gateRegistry.register(() => ({ kind: "deny", status: 403, message: "read-only" }));
+
+    expect(await runGates(request({ method: "POST" }))).toEqual({
+      kind: "deny",
+      status: 403,
+      message: "read-only",
+    });
+  });
+
+  test("awaits async gates", async () => {
+    gateRegistry.register(async () => ({ kind: "redirect", url: "/async" }));
+
+    expect(await runGates(request())).toEqual({ kind: "redirect", url: "/async" });
+  });
+
+  test("a throwing gate is contained and treated as continue", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const after = vi.fn(() => ({ kind: "redirect", url: "/after" }) as const);
+
+    gateRegistry.register(() => {
+      throw new Error("gate boom");
+    });
+    gateRegistry.register(after);
+
+    const outcome = await runGates(request());
+
+    expect(after).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ kind: "redirect", url: "/after" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("gate threw"),
+      expect.objectContaining({ error: expect.stringContaining("gate boom") }),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  test("a gate returning a malformed outcome is contained and treated as continue", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const after = vi.fn(() => ({ kind: "redirect", url: "/after" }) as const);
+
+    // Garbage returns: undefined, and an object with no recognizable `kind`.
+    gateRegistry.register(() => undefined as never);
+    gateRegistry.register(() => ({ foo: "bar" }) as never);
+    gateRegistry.register(after);
+
+    const outcome = await runGates(request());
+
+    expect(after).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ kind: "redirect", url: "/after" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("malformed outcome"),
+      expect.objectContaining({ outcome: expect.anything() }),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/.server/__tests__/pluginGates.test.ts
+++ b/app/.server/__tests__/pluginGates.test.ts
@@ -117,4 +117,24 @@ describe("pluginGates", () => {
     );
     consoleSpy.mockRestore();
   });
+
+  test("a rejecting async gate is contained and treated as continue", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const after = vi.fn(() => ({ kind: "redirect", url: "/after" }) as const);
+
+    gateRegistry.register(async () => {
+      throw new Error("async boom");
+    });
+    gateRegistry.register(after);
+
+    const outcome = await runGates(request());
+
+    expect(after).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({ kind: "redirect", url: "/after" });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("gate threw"),
+      expect.objectContaining({ error: expect.stringContaining("async boom") }),
+    );
+    consoleSpy.mockRestore();
+  });
 });

--- a/app/.server/__tests__/pluginGates.test.ts
+++ b/app/.server/__tests__/pluginGates.test.ts
@@ -22,7 +22,7 @@ beforeEach(() => {
 describe("pluginGates", () => {
   test("register adds a gate that runGates evaluates", async () => {
     const gate = vi.fn(() => ({ kind: "continue" }) as const);
-    gateRegistry.register(gate);
+    gateRegistry.scopedFor("test-plugin").register(gate);
 
     const outcome = await runGates(request());
 
@@ -36,11 +36,11 @@ describe("pluginGates", () => {
 
   test("evaluates gates in registration order", async () => {
     const order: string[] = [];
-    gateRegistry.register(() => {
+    gateRegistry.scopedFor("test-plugin").register(() => {
       order.push("first");
       return { kind: "continue" };
     });
-    gateRegistry.register(() => {
+    gateRegistry.scopedFor("test-plugin").register(() => {
       order.push("second");
       return { kind: "continue" };
     });
@@ -52,9 +52,9 @@ describe("pluginGates", () => {
 
   test("returns the first non-continue outcome (redirect) and stops", async () => {
     const later = vi.fn(() => ({ kind: "continue" }) as const);
-    gateRegistry.register(() => ({ kind: "continue" }));
-    gateRegistry.register(() => ({ kind: "redirect", url: "/onboard" }));
-    gateRegistry.register(later);
+    gateRegistry.scopedFor("test-plugin").register(() => ({ kind: "continue" }));
+    gateRegistry.scopedFor("test-plugin").register(() => ({ kind: "redirect", url: "/onboard" }));
+    gateRegistry.scopedFor("test-plugin").register(later);
 
     const outcome = await runGates(request());
 
@@ -63,7 +63,9 @@ describe("pluginGates", () => {
   });
 
   test("returns the first non-continue outcome (deny)", async () => {
-    gateRegistry.register(() => ({ kind: "deny", status: 403, message: "read-only" }));
+    gateRegistry
+      .scopedFor("test-plugin")
+      .register(() => ({ kind: "deny", status: 403, message: "read-only" }));
 
     expect(await runGates(request({ method: "POST" }))).toEqual({
       kind: "deny",
@@ -73,7 +75,9 @@ describe("pluginGates", () => {
   });
 
   test("awaits async gates", async () => {
-    gateRegistry.register(async () => ({ kind: "redirect", url: "/async" }));
+    gateRegistry
+      .scopedFor("test-plugin")
+      .register(async () => ({ kind: "redirect", url: "/async" }));
 
     expect(await runGates(request())).toEqual({ kind: "redirect", url: "/async" });
   });
@@ -82,17 +86,17 @@ describe("pluginGates", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const after = vi.fn(() => ({ kind: "redirect", url: "/after" }) as const);
 
-    gateRegistry.register(() => {
+    gateRegistry.scopedFor("test-plugin").register(() => {
       throw new Error("gate boom");
     });
-    gateRegistry.register(after);
+    gateRegistry.scopedFor("test-plugin").register(after);
 
     const outcome = await runGates(request());
 
     expect(after).toHaveBeenCalledTimes(1);
     expect(outcome).toEqual({ kind: "redirect", url: "/after" });
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("gate threw"),
+      expect.stringContaining('"test-plugin" threw'),
       expect.objectContaining({ error: expect.stringContaining("gate boom") }),
     );
     consoleSpy.mockRestore();
@@ -103,9 +107,9 @@ describe("pluginGates", () => {
     const after = vi.fn(() => ({ kind: "redirect", url: "/after" }) as const);
 
     // Garbage returns: undefined, and an object with no recognizable `kind`.
-    gateRegistry.register(() => undefined as never);
-    gateRegistry.register(() => ({ foo: "bar" }) as never);
-    gateRegistry.register(after);
+    gateRegistry.scopedFor("test-plugin").register(() => undefined as never);
+    gateRegistry.scopedFor("test-plugin").register(() => ({ foo: "bar" }) as never);
+    gateRegistry.scopedFor("test-plugin").register(after);
 
     const outcome = await runGates(request());
 
@@ -122,17 +126,17 @@ describe("pluginGates", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const after = vi.fn(() => ({ kind: "redirect", url: "/after" }) as const);
 
-    gateRegistry.register(async () => {
+    gateRegistry.scopedFor("test-plugin").register(async () => {
       throw new Error("async boom");
     });
-    gateRegistry.register(after);
+    gateRegistry.scopedFor("test-plugin").register(after);
 
     const outcome = await runGates(request());
 
     expect(after).toHaveBeenCalledTimes(1);
     expect(outcome).toEqual({ kind: "redirect", url: "/after" });
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("gate threw"),
+      expect.stringContaining('"test-plugin" threw'),
       expect.objectContaining({ error: expect.stringContaining("async boom") }),
     );
     consoleSpy.mockRestore();

--- a/app/.server/auth/__tests__/authMiddleware.test.ts
+++ b/app/.server/auth/__tests__/authMiddleware.test.ts
@@ -7,6 +7,7 @@ import { refreshAccessTokenWithLock } from "../refreshAuthTokens";
 import { sessionContext } from "../sessionMiddleware";
 import { sessionStorage, type SessionData } from "../sessionStorage";
 import { verifyIdToken } from "../verifyIdToken";
+import { runGates } from "~/.server/pluginGates";
 import { listConnections } from "~/routes/connections/connections.server";
 import mock from "~/utils/__tests__/__mocks__";
 
@@ -35,6 +36,10 @@ vi.mock("~/routes/connections/connections.server", () => ({
 
 vi.mock("../verifyIdToken", () => ({
   verifyIdToken: vi.fn(),
+}));
+
+vi.mock("~/.server/pluginGates", () => ({
+  runGates: vi.fn(),
 }));
 
 vi.mock("react-router", async (importOriginal) => {
@@ -87,14 +92,18 @@ describe("authMiddleware", () => {
     notification: undefined,
   } satisfies SessionData;
 
-  const createMiddlewareArgs = (params: Record<string, string> = {}, hasSession = true) => {
+  const createMiddlewareArgs = (
+    params: Record<string, string> = {},
+    hasSession = true,
+    request: Request = new Request("http://localhost/test"),
+  ) => {
     const context = new Map();
     if (hasSession) {
       context.set(sessionContext, mockSession);
     }
 
     return {
-      request: new Request("http://localhost/test"),
+      request,
       params,
       context: {
         get: (key: unknown) => context.get(key),
@@ -121,6 +130,8 @@ describe("authMiddleware", () => {
       idToken: "new-id-token",
       refreshToken: validRefreshToken,
     });
+    // No plugin loaded by default → gates short-circuit to continue.
+    vi.mocked(runGates).mockResolvedValue({ kind: "continue" });
   });
 
   describe("Session Context", () => {
@@ -375,6 +386,155 @@ describe("authMiddleware", () => {
       expect(redirect).toHaveBeenCalledWith("/onboarding");
       expect(listConnections).not.toHaveBeenCalled();
       expect(getAllSessionCredentials).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Plugin Gates", () => {
+    test("gate redirect wins and short-circuits before credential fetch", async () => {
+      vi.mocked(runGates).mockResolvedValue({
+        kind: "redirect",
+        url: "https://admin.cytario.com/onboard?return_to=app",
+      });
+
+      const args = createMiddlewareArgs();
+
+      const result = await authMiddleware(
+        args as unknown as Parameters<typeof authMiddleware>[0],
+        mockNext,
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      expect((result as Response).status).toBe(302);
+      expect(redirect).toHaveBeenCalledWith("https://admin.cytario.com/onboard?return_to=app");
+      expect(listConnections).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    test("passes url, method, and the PII-free identity projection to the gate", async () => {
+      const args = createMiddlewareArgs(
+        {},
+        true,
+        new Request("http://localhost/protected", { method: "POST" }),
+      );
+
+      await authMiddleware(args as unknown as Parameters<typeof authMiddleware>[0], mockNext);
+
+      expect(runGates).toHaveBeenCalledWith({
+        url: "http://localhost/protected",
+        method: "POST",
+        identity: expect.objectContaining({ organization: "org1" }),
+      });
+      const [{ identity }] = vi.mocked(runGates).mock.calls[0];
+      expect(identity).not.toHaveProperty("email");
+      expect(identity).not.toHaveProperty("name");
+    });
+
+    test("deny on POST returns a 403 JSON Response with the gate message", async () => {
+      vi.mocked(runGates).mockResolvedValue({
+        kind: "deny",
+        status: 403,
+        message: "read-only during offboarding",
+      });
+
+      const args = createMiddlewareArgs(
+        {},
+        true,
+        new Request("http://localhost/upload", { method: "POST" }),
+      );
+
+      const result = await authMiddleware(
+        args as unknown as Parameters<typeof authMiddleware>[0],
+        mockNext,
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      const response = result as Response;
+      expect(response.status).toBe(403);
+      expect(response.headers.get("Content-Type")).toBe("application/json");
+      expect(await response.json()).toEqual({ error: "read-only during offboarding" });
+      expect(listConnections).not.toHaveBeenCalled();
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    test("deny defaults to status 403 when none provided", async () => {
+      vi.mocked(runGates).mockResolvedValue({ kind: "deny", message: "blocked" });
+
+      const args = createMiddlewareArgs(
+        {},
+        true,
+        new Request("http://localhost/upload", { method: "DELETE" }),
+      );
+
+      const result = await authMiddleware(
+        args as unknown as Parameters<typeof authMiddleware>[0],
+        mockNext,
+      );
+
+      expect((result as Response).status).toBe(403);
+    });
+
+    test("message-less deny serializes a fallback error body (never empty)", async () => {
+      vi.mocked(runGates).mockResolvedValue({ kind: "deny", status: 403 });
+
+      const args = createMiddlewareArgs(
+        {},
+        true,
+        new Request("http://localhost/upload", { method: "POST" }),
+      );
+
+      const result = await authMiddleware(
+        args as unknown as Parameters<typeof authMiddleware>[0],
+        mockNext,
+      );
+
+      const response = result as Response;
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: "Request denied" });
+    });
+
+    test("the same gate passing on GET proceeds to credential fetch", async () => {
+      // Mirrors a method-aware read-only gate: deny writes, continue on reads.
+      vi.mocked(runGates).mockResolvedValue({ kind: "continue" });
+
+      const args = createMiddlewareArgs(
+        {},
+        true,
+        new Request("http://localhost/slide", { method: "GET" }),
+      );
+
+      await authMiddleware(args as unknown as Parameters<typeof authMiddleware>[0], mockNext);
+
+      expect(listConnections).toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("continue with org present proceeds to credential fetch", async () => {
+      const args = createMiddlewareArgs();
+
+      await authMiddleware(args as unknown as Parameters<typeof authMiddleware>[0], mockNext);
+
+      expect(listConnections).toHaveBeenCalledWith(mockSessionData.user);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    test("continue with no org falls back to the built-in /onboarding redirect", async () => {
+      vi.mocked(runGates).mockResolvedValue({ kind: "continue" });
+      vi.mocked(getSessionData).mockResolvedValue({
+        ...mockSessionData,
+        user: mock.user({ organization: undefined }),
+      });
+
+      const args = createMiddlewareArgs();
+
+      const result = await authMiddleware(
+        args as unknown as Parameters<typeof authMiddleware>[0],
+        mockNext,
+      );
+
+      expect(result).toBeInstanceOf(Response);
+      expect(redirect).toHaveBeenCalledWith("/onboarding");
+      expect(listConnections).not.toHaveBeenCalled();
       expect(mockNext).not.toHaveBeenCalled();
     });
   });

--- a/app/.server/auth/__tests__/authMiddleware.test.ts
+++ b/app/.server/auth/__tests__/authMiddleware.test.ts
@@ -537,6 +537,18 @@ describe("authMiddleware", () => {
       expect(listConnections).not.toHaveBeenCalled();
       expect(mockNext).not.toHaveBeenCalled();
     });
+
+    test("runs gates BEFORE verifyIdToken (H-1 ordering guard)", async () => {
+      // Reordering would let a gate decide on a refreshed token instead of the
+      // current one, and could run a tenant-scoped read before the gate.
+      const args = createMiddlewareArgs();
+
+      await authMiddleware(args as unknown as Parameters<typeof authMiddleware>[0], mockNext);
+
+      const gateOrder = vi.mocked(runGates).mock.invocationCallOrder[0];
+      const verifyOrder = vi.mocked(verifyIdToken).mock.invocationCallOrder[0];
+      expect(gateOrder).toBeLessThan(verifyOrder);
+    });
   });
 
   describe("Logout Flow", () => {

--- a/app/.server/auth/__tests__/getUserInfo.test.ts
+++ b/app/.server/auth/__tests__/getUserInfo.test.ts
@@ -270,6 +270,63 @@ describe("getUserInfo", () => {
       expect(result.organizationAttributes).not.toHaveProperty("groups");
     });
 
+    test("drops email-shaped and oversized attribute values (host-side hygiene)", async () => {
+      const rawProfile = {
+        sub: "user-uuid-hygiene",
+        email: "hygiene@example.com",
+        email_verified: true,
+        name: "Hygiene",
+        preferred_username: "hygiene",
+        given_name: "Hygiene",
+        family_name: "User",
+        policy: [],
+        groups: [],
+        organization: {
+          testcorp: {
+            id: "id",
+            groups: [],
+            subscription_status: ["active"],
+            // Defence-in-depth: a future mapper change leaking PII must not
+            // reach the client bundle.
+            billing_email: ["someone@example.com"],
+            oversized: ["x".repeat(257)],
+          },
+        },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(rawProfile),
+      });
+
+      const result = await getUserInfo("access-token");
+
+      expect(result.organizationAttributes).toEqual({ subscription_status: "active" });
+      expect(result.organizationAttributes).not.toHaveProperty("billing_email");
+      expect(result.organizationAttributes).not.toHaveProperty("oversized");
+    });
+
+    test("freezes the attribute map so a consumer cannot mutate it", async () => {
+      const rawProfile = {
+        sub: "user-uuid-frozen",
+        email: "frozen@example.com",
+        email_verified: true,
+        name: "Frozen",
+        preferred_username: "frozen",
+        given_name: "Frozen",
+        family_name: "User",
+        policy: [],
+        groups: [],
+        organization: { testcorp: { id: "id", groups: [], subscription_status: ["active"] } },
+      };
+
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(rawProfile) });
+
+      const result = await getUserInfo("access-token");
+
+      expect(Object.isFrozen(result.organizationAttributes)).toBe(true);
+    });
+
     test("tolerates scalar, array, and id-shape variants without throwing", async () => {
       const rawProfile = {
         sub: "user-uuid-shapes",

--- a/app/.server/auth/__tests__/getUserInfo.test.ts
+++ b/app/.server/auth/__tests__/getUserInfo.test.ts
@@ -232,7 +232,7 @@ describe("getUserInfo", () => {
       expect(result.groups).toEqual([]);
     });
 
-    test("captures org attributes (excluding id/groups), collapsing multivalued to first value", async () => {
+    test("captures org attributes (excluding id/groups), preserving the multivalued array shape", async () => {
       const rawProfile = {
         sub: "user-uuid-attrs",
         email: "attrs@example.com",
@@ -261,9 +261,10 @@ describe("getUserInfo", () => {
       const result = await getUserInfo("access-token");
 
       expect(result.organization).toBe("testcorp");
+      // Multivalued attrs keep all their values — the host does not collapse.
       expect(result.organizationAttributes).toEqual({
-        subscription_status: "active",
-        subscription_period_end: "2026-12-31",
+        subscription_status: ["active"],
+        subscription_period_end: ["2026-12-31", "ignored"],
       });
       // Host-owned keys never leak into the opaque attribute map.
       expect(result.organizationAttributes).not.toHaveProperty("id");
@@ -301,7 +302,7 @@ describe("getUserInfo", () => {
 
       const result = await getUserInfo("access-token");
 
-      expect(result.organizationAttributes).toEqual({ subscription_status: "active" });
+      expect(result.organizationAttributes).toEqual({ subscription_status: ["active"] });
       expect(result.organizationAttributes).not.toHaveProperty("billing_email");
       expect(result.organizationAttributes).not.toHaveProperty("oversized");
     });
@@ -363,9 +364,11 @@ describe("getUserInfo", () => {
       const result = await getUserInfo("access-token");
 
       expect(result.organization).toBe("testcorp");
+      // Scalar is wrapped to a one-element array; a multivalued attr keeps all
+      // its (string) values; empty and non-string-only attrs are dropped.
       expect(result.organizationAttributes).toEqual({
-        subscription_status: "active",
-        plan: "pro",
+        subscription_status: ["active"],
+        plan: ["pro", "ignored"],
       });
       expect(result.organizationAttributes).not.toHaveProperty("id");
       expect(result.organizationAttributes).not.toHaveProperty("empty_attr");
@@ -478,7 +481,7 @@ describe("getUserInfo", () => {
       email: "alice@example.com",
       policy: ["default-policy"],
       organization: "testcorp",
-      organizationAttributes: { subscription_status: "active" },
+      organizationAttributes: { subscription_status: ["active"] },
       groups: ["lab"],
       adminScopes: ["*"],
     };
@@ -486,7 +489,7 @@ describe("getUserInfo", () => {
     test("projects the tenant-relevant subset", () => {
       expect(toIdentity(fullProfile)).toEqual({
         organization: "testcorp",
-        organizationAttributes: { subscription_status: "active" },
+        organizationAttributes: { subscription_status: ["active"] },
         groups: ["lab"],
         adminScopes: ["*"],
       });

--- a/app/.server/auth/__tests__/getUserInfo.test.ts
+++ b/app/.server/auth/__tests__/getUserInfo.test.ts
@@ -1,4 +1,4 @@
-import { getUserInfo } from "../getUserInfo";
+import { getUserInfo, toIdentity, type UserProfile } from "../getUserInfo";
 import { getWellKnownEndpoints } from "../wellKnownEndpoints";
 
 vi.mock("../wellKnownEndpoints", () => ({
@@ -232,6 +232,112 @@ describe("getUserInfo", () => {
       expect(result.groups).toEqual([]);
     });
 
+    test("captures org attributes (excluding id/groups), collapsing multivalued to first value", async () => {
+      const rawProfile = {
+        sub: "user-uuid-attrs",
+        email: "attrs@example.com",
+        email_verified: true,
+        name: "Attrs",
+        preferred_username: "attrs",
+        given_name: "Attrs",
+        family_name: "User",
+        policy: [],
+        groups: [],
+        organization: {
+          testcorp: {
+            id: "42c3-id",
+            groups: ["/lab"],
+            subscription_status: ["active"],
+            subscription_period_end: ["2026-12-31", "ignored"],
+          },
+        },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(rawProfile),
+      });
+
+      const result = await getUserInfo("access-token");
+
+      expect(result.organization).toBe("testcorp");
+      expect(result.organizationAttributes).toEqual({
+        subscription_status: "active",
+        subscription_period_end: "2026-12-31",
+      });
+      // Host-owned keys never leak into the opaque attribute map.
+      expect(result.organizationAttributes).not.toHaveProperty("id");
+      expect(result.organizationAttributes).not.toHaveProperty("groups");
+    });
+
+    test("tolerates scalar, array, and id-shape variants without throwing", async () => {
+      const rawProfile = {
+        sub: "user-uuid-shapes",
+        email: "shapes@example.com",
+        email_verified: true,
+        name: "Shapes",
+        preferred_username: "shapes",
+        given_name: "Shapes",
+        family_name: "User",
+        policy: [],
+        groups: [],
+        organization: {
+          testcorp: {
+            // `id` can surface array-shaped depending on mapper config.
+            id: ["42c3-id"],
+            groups: ["/lab"],
+            // Single-valued attr emitted as a bare scalar.
+            subscription_status: "active",
+            // Multivalued attr collapses to its first element.
+            plan: ["pro", "ignored"],
+            // Empty array yields no value → dropped.
+            empty_attr: [],
+            // Non-string element → dropped.
+            numeric_attr: [42],
+          },
+        },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(rawProfile),
+      });
+
+      const result = await getUserInfo("access-token");
+
+      expect(result.organization).toBe("testcorp");
+      expect(result.organizationAttributes).toEqual({
+        subscription_status: "active",
+        plan: "pro",
+      });
+      expect(result.organizationAttributes).not.toHaveProperty("id");
+      expect(result.organizationAttributes).not.toHaveProperty("empty_attr");
+      expect(result.organizationAttributes).not.toHaveProperty("numeric_attr");
+    });
+
+    test("defaults org attributes to empty object when claim is absent", async () => {
+      const rawProfile = {
+        sub: "user-uuid-noorg",
+        email: "noorg@example.com",
+        email_verified: true,
+        name: "No Org",
+        preferred_username: "noorg",
+        given_name: "No",
+        family_name: "Org",
+        policy: [],
+        groups: [],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(rawProfile),
+      });
+
+      const result = await getUserInfo("access-token");
+
+      expect(result.organizationAttributes).toEqual({});
+    });
+
     test("nested organization groups take precedence over top-level legacy groups", async () => {
       const rawProfile = {
         sub: "user-uuid-mix",
@@ -301,6 +407,41 @@ describe("getUserInfo", () => {
       expect(result.policy).toEqual([]);
       expect(result.groups).toEqual([]);
       expect(result.adminScopes).toEqual([]);
+    });
+  });
+
+  describe("toIdentity", () => {
+    const fullProfile: UserProfile = {
+      sub: "user-uuid-123",
+      email_verified: true,
+      name: "Alice Doe",
+      preferred_username: "alice",
+      given_name: "Alice",
+      family_name: "Doe",
+      email: "alice@example.com",
+      policy: ["default-policy"],
+      organization: "testcorp",
+      organizationAttributes: { subscription_status: "active" },
+      groups: ["lab"],
+      adminScopes: ["*"],
+    };
+
+    test("projects the tenant-relevant subset", () => {
+      expect(toIdentity(fullProfile)).toEqual({
+        organization: "testcorp",
+        organizationAttributes: { subscription_status: "active" },
+        groups: ["lab"],
+        adminScopes: ["*"],
+      });
+    });
+
+    test("drops PII fields (name, email, preferred_username, policy)", () => {
+      const identity = toIdentity(fullProfile) as unknown as Record<string, unknown>;
+      expect(identity).not.toHaveProperty("name");
+      expect(identity).not.toHaveProperty("email");
+      expect(identity).not.toHaveProperty("preferred_username");
+      expect(identity).not.toHaveProperty("policy");
+      expect(identity).not.toHaveProperty("sub");
     });
   });
 

--- a/app/.server/auth/authMiddleware.ts
+++ b/app/.server/auth/authMiddleware.ts
@@ -91,9 +91,10 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
     }
 
     if (outcome.kind === "deny") {
-      console.info(`${label} Gate denied request with status ${outcome.status ?? 403}`);
+      const status = outcome.status ?? 403;
+      console.info(`${label} Gate denied request with status ${status}`);
       return new Response(JSON.stringify({ error: outcome.message ?? "Request denied" }), {
-        status: outcome.status ?? 403,
+        status,
         headers: { "Content-Type": "application/json" },
       });
     }

--- a/app/.server/auth/authMiddleware.ts
+++ b/app/.server/auth/authMiddleware.ts
@@ -2,12 +2,14 @@ import { createContext, redirect, type MiddlewareFunction } from "react-router";
 
 import { getSessionData } from "./getSession";
 import { getAllSessionCredentials } from "./getSessionCredentials";
+import { toIdentity } from "./getUserInfo";
 import { refreshAccessTokenWithLock } from "./refreshAuthTokens";
 import { sessionContext } from "./sessionMiddleware";
 import { type CytarioSession, type SessionData, sessionStorage } from "./sessionStorage";
 import { verifyIdToken } from "./verifyIdToken";
 import { ConnectionConfig } from "~/.generated/client";
 import { createLabel } from "~/.server/logging";
+import { runGates } from "~/.server/pluginGates";
 import { listConnections } from "~/routes/connections/connections.server";
 
 export interface AuthContextData extends SessionData {
@@ -72,10 +74,30 @@ export const authMiddleware: MiddlewareFunction = async ({ request, context }, n
     let updatedSessionData = sessionData as SessionData;
     const { authTokens, user } = updatedSessionData;
 
-    // A token without an `organization` claim means the user is not a member
-    // of any Keycloak org yet. Short-circuit before any ConnectionConfig
-    // query runs so a zero-org session cannot fall through to an unscoped
-    // tenant read.
+    // Consult plugin session gates before any ConnectionConfig query runs, so
+    // a zero-org or gated session cannot fall through to an unscoped tenant
+    // read. Gates receive only the PII-free identity projection. With no
+    // plugin loaded `runGates` returns `continue` and the built-in no-org
+    // fallback below preserves on-prem behaviour.
+    const outcome = await runGates({
+      url: request.url,
+      method: request.method,
+      identity: toIdentity(user),
+    });
+
+    if (outcome.kind === "redirect") {
+      console.info(`${label} Gate redirect to ${outcome.url}`);
+      return redirect(outcome.url);
+    }
+
+    if (outcome.kind === "deny") {
+      console.info(`${label} Gate denied request with status ${outcome.status ?? 403}`);
+      return new Response(JSON.stringify({ error: outcome.message ?? "Request denied" }), {
+        status: outcome.status ?? 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     if (!user.organization) {
       console.info(`${label} No active organization on session, redirecting to onboarding`);
       return redirect("/onboarding");

--- a/app/.server/auth/getUserInfo.ts
+++ b/app/.server/auth/getUserInfo.ts
@@ -1,14 +1,29 @@
 import { z } from "zod";
 
 import { getWellKnownEndpoints } from "./wellKnownEndpoints";
+import type { Identity } from "@cytario/plugin-api";
 import { ORG_ROOT_SCOPE } from "~/utils/authorization";
 
+// Keycloak nests everything under the org alias key. `id` and `groups` are the
+// host-owned fields; every other key is an opaque, multivalued attribute the
+// host does not interpret (the SaaS plugin narrows them to its own billing
+// types). Pass the attribute bag through unmodelled — bake no billing key
+// names into the schema.
+// Attribute values arrive multivalued (string arrays), but a mapper config can
+// also emit a single-valued attr as a bare scalar, and `id` can surface either
+// shape. Accept any value shape for `id` and the attr bag so a quirk never
+// throws out of the whole parse and breaks login (a logout loop) —
+// `collapseOrganizationAttributes` normalizes and drops non-string values
+// downstream.
 const organizationClaimSchema = z
   .record(
     z.string(),
-    z.object({
-      groups: z.array(z.string()).default([]),
-    }),
+    z
+      .object({
+        id: z.unknown().optional(),
+        groups: z.array(z.string()).default([]),
+      })
+      .catchall(z.unknown()),
   )
   .optional();
 
@@ -30,6 +45,8 @@ type UserProfileRaw = z.infer<typeof userProfileSchema>;
 export interface UserProfile extends Omit<UserProfileRaw, "organization"> {
   /** Active Keycloak organization alias for this session. Undefined for zero-org users. */
   organization?: string;
+  /** Opaque org attributes mirrored into the token, each multivalued attr collapsed to its first value. */
+  organizationAttributes: Record<string, string>;
   groups: string[];
   adminScopes: string[];
 }
@@ -39,13 +56,35 @@ function normalizeGroup(group: string): string {
   return group.replace(/^\//, "");
 }
 
+type OrganizationEntry = NonNullable<UserProfileRaw["organization"]>[string];
+
+/**
+ * Collapses Keycloak attribute values to a single string, dropping host-owned
+ * keys. A scalar collapses to itself; an array to its first element. Empty
+ * arrays and non-string values are dropped.
+ */
+function collapseOrganizationAttributes(entry: OrganizationEntry): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  for (const [key, value] of Object.entries(entry)) {
+    if (key === "id" || key === "groups") continue;
+    if (typeof value === "string") {
+      attributes[key] = value;
+    } else if (Array.isArray(value) && typeof value[0] === "string") {
+      attributes[key] = value[0];
+    }
+  }
+  return attributes;
+}
+
 /** Enriches raw user profile with admin scopes. */
 function enrichUserProfile(raw: UserProfileRaw): UserProfile {
-  // Keycloak Organizations claim is `{ "<alias>": { groups: [...] } }` with
-  // exactly one key. Group membership now arrives nested under that key.
+  // Keycloak Organizations claim is `{ "<alias>": { id, groups, ...attrs } }`
+  // with exactly one key. Group membership and org attributes arrive nested
+  // under that key.
   const orgEntry = raw.organization ? Object.entries(raw.organization)[0] : undefined;
   const organization = orgEntry?.[0];
   const rawGroups = orgEntry ? (orgEntry[1].groups ?? []) : raw.groups;
+  const organizationAttributes = orgEntry ? collapseOrganizationAttributes(orgEntry[1]) : {};
 
   // Root `/admins` becomes the `*` admin scope. `authorization.ts` treats `*`
   // as "admin of every owner scope in this org" — still bounded by the tenant
@@ -66,8 +105,23 @@ function enrichUserProfile(raw: UserProfileRaw): UserProfile {
     family_name: raw.family_name,
     policy: raw.policy,
     organization,
+    organizationAttributes,
     groups,
     adminScopes,
+  };
+}
+
+/**
+ * Projects a `UserProfile` to the contract's `Identity`, dropping PII (`name`,
+ * `email`, `preferred_username`, `policy`). Gates and slots receive this
+ * projection only, so PII never crosses to the client loader payload.
+ */
+export function toIdentity(user: UserProfile): Identity {
+  return {
+    organization: user.organization,
+    organizationAttributes: user.organizationAttributes,
+    groups: user.groups,
+    adminScopes: user.adminScopes,
   };
 }
 

--- a/app/.server/auth/getUserInfo.ts
+++ b/app/.server/auth/getUserInfo.ts
@@ -4,17 +4,9 @@ import { getWellKnownEndpoints } from "./wellKnownEndpoints";
 import type { Identity } from "@cytario/plugin-api";
 import { ORG_ROOT_SCOPE } from "~/utils/authorization";
 
-// Keycloak nests everything under the org alias key. `id` and `groups` are the
-// host-owned fields; every other key is an opaque, multivalued attribute the
-// host does not interpret (the SaaS plugin narrows them to its own billing
-// types). Pass the attribute bag through unmodelled — bake no billing key
-// names into the schema.
-// Attribute values arrive multivalued (string arrays), but a mapper config can
-// also emit a single-valued attr as a bare scalar, and `id` can surface either
-// shape. Accept any value shape for `id` and the attr bag so a quirk never
-// throws out of the whole parse and breaks login (a logout loop) —
-// `collapseOrganizationAttributes` normalizes and drops non-string values
-// downstream.
+// `id`/`groups` are host-owned; other keys are opaque org attributes. Accept any
+// value shape (`unknown`) so a Keycloak mapper quirk can't throw out of the
+// whole parse and break login; normalizeOrganizationAttributes cleans it up.
 const organizationClaimSchema = z
   .record(
     z.string(),
@@ -45,24 +37,14 @@ type UserProfileRaw = z.infer<typeof userProfileSchema>;
 export interface UserProfile extends Omit<UserProfileRaw, "organization"> {
   /** Active Keycloak organization alias for this session. Undefined for zero-org users. */
   organization?: string;
-  /**
-   * Opaque, multivalued org attributes mirrored into the token (Keycloak
-   * attributes are arrays). The host preserves the array shape and assigns no
-   * meaning to keys — a consumer that knows an attribute is single-valued picks
-   * `[0]` itself. Non-string, oversized, and email-shaped values are dropped
-   * (host-side hygiene); a key whose values are all dropped is omitted. Frozen
-   * at runtime.
-   */
+  /** Opaque, multivalued org attributes; frozen. Host assigns no meaning to keys. */
   organizationAttributes: Readonly<Record<string, readonly string[]>>;
   groups: string[];
   adminScopes: string[];
 }
 
-// Defence-in-depth on the opaque attribute mirror: the host stays
-// billing-agnostic, but a future Keycloak mapper change must not silently ship
-// PII or payment identifiers to the browser. Drop email-shaped and oversized
-// values. Vocabulary-free — no attribute key is interpreted. The primary
-// control lives portal-side (which attrs are mirrored at all).
+// Hygiene so a mapper change can't leak PII to the client: drop email-shaped and
+// oversized values. Attributes reach the browser via the Identity projection.
 const EMAIL_SHAPED = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_ATTR_VALUE_BYTES = 256;
 const attrEncoder = new TextEncoder();
@@ -84,13 +66,9 @@ function isAllowedAttrValue(value: unknown): value is string {
 }
 
 /**
- * Normalizes a Keycloak org-attribute entry into a multivalued map, dropping
- * host-owned keys (`id`, `groups`). A scalar is wrapped to a one-element array;
- * an array is filtered to allowed string values. The host preserves the array
- * shape and does not collapse — a consumer that knows an attribute is
- * single-valued picks `[0]`. A key whose values are all dropped is omitted. The
- * map and its arrays are frozen so a misbehaving gate cannot mutate the shared
- * attributes downstream.
+ * Build the opaque attribute map: drop host-owned `id`/`groups`, wrap scalars to
+ * arrays, keep allowed string values, omit now-empty keys. Frozen so a gate
+ * can't mutate the shared attributes.
  */
 function normalizeOrganizationAttributes(
   entry: OrganizationEntry,
@@ -143,13 +121,9 @@ function enrichUserProfile(raw: UserProfileRaw): UserProfile {
   };
 }
 
-/**
- * Projects a `UserProfile` to the contract's `Identity`, dropping PII (`name`,
- * `email`, `preferred_username`, `policy`). Gates and slots receive this
- * projection only, so PII never crosses to the client loader payload.
- */
+/** Projects `UserProfile` to the contract's `Identity`, dropping PII so it never reaches the client. */
 export function toIdentity(user: UserProfile): Identity {
-  // Frozen so a gate cannot mutate the projection shared across the gate chain.
+  // Frozen — gates share this object; none may mutate it.
   return Object.freeze({
     organization: user.organization,
     organizationAttributes: user.organizationAttributes,

--- a/app/.server/auth/getUserInfo.ts
+++ b/app/.server/auth/getUserInfo.ts
@@ -4,15 +4,15 @@ import { getWellKnownEndpoints } from "./wellKnownEndpoints";
 import type { Identity } from "@cytario/plugin-api";
 import { ORG_ROOT_SCOPE } from "~/utils/authorization";
 
-// `id`/`groups` are host-owned; other keys are opaque org attributes. Accept any
-// value shape (`unknown`) so a Keycloak mapper quirk can't throw out of the
-// whole parse and break login; normalizeOrganizationAttributes cleans it up.
+// Only `groups` is consumed; other keys (incl. Keycloak's `id`) are opaque org
+// attributes. Accept any value shape (`unknown`) so a Keycloak mapper quirk
+// can't throw out of the whole parse and break login;
+// normalizeOrganizationAttributes drops `id`/`groups` and cleans the rest.
 const organizationClaimSchema = z
   .record(
     z.string(),
     z
       .object({
-        id: z.unknown().optional(),
         groups: z.array(z.string()).default([]),
       })
       .catchall(z.unknown()),

--- a/app/.server/auth/getUserInfo.ts
+++ b/app/.server/auth/getUserInfo.ts
@@ -45,11 +45,24 @@ type UserProfileRaw = z.infer<typeof userProfileSchema>;
 export interface UserProfile extends Omit<UserProfileRaw, "organization"> {
   /** Active Keycloak organization alias for this session. Undefined for zero-org users. */
   organization?: string;
-  /** Opaque org attributes mirrored into the token, each multivalued attr collapsed to its first value. */
-  organizationAttributes: Record<string, string>;
+  /**
+   * Opaque org attributes mirrored into the token. Each multivalued attr is
+   * collapsed to its first value; empty/non-string, oversized, and email-shaped
+   * values are dropped (host-side hygiene). Frozen at runtime.
+   */
+  organizationAttributes: Readonly<Record<string, string>>;
   groups: string[];
   adminScopes: string[];
 }
+
+// Defence-in-depth on the opaque attribute mirror: the host stays
+// billing-agnostic, but a future Keycloak mapper change must not silently ship
+// PII or payment identifiers to the browser. Drop email-shaped and oversized
+// values. Vocabulary-free — no attribute key is interpreted. The primary
+// control lives portal-side (which attrs are mirrored at all).
+const EMAIL_SHAPED = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_ATTR_VALUE_BYTES = 256;
+const attrEncoder = new TextEncoder();
 
 /** Removes leading slash from group name. */
 function normalizeGroup(group: string): string {
@@ -60,20 +73,29 @@ type OrganizationEntry = NonNullable<UserProfileRaw["organization"]>[string];
 
 /**
  * Collapses Keycloak attribute values to a single string, dropping host-owned
- * keys. A scalar collapses to itself; an array to its first element. Empty
- * arrays and non-string values are dropped.
+ * keys (`id`, `groups`). A scalar collapses to itself; an array to its first
+ * element. Empty/non-string, oversized (>256B), and email-shaped values are
+ * dropped. Returns a frozen map so a misbehaving gate cannot mutate the shared
+ * attributes downstream.
  */
-function collapseOrganizationAttributes(entry: OrganizationEntry): Record<string, string> {
+function collapseOrganizationAttributes(
+  entry: OrganizationEntry,
+): Readonly<Record<string, string>> {
   const attributes: Record<string, string> = {};
   for (const [key, value] of Object.entries(entry)) {
     if (key === "id" || key === "groups") continue;
-    if (typeof value === "string") {
-      attributes[key] = value;
-    } else if (Array.isArray(value) && typeof value[0] === "string") {
-      attributes[key] = value[0];
-    }
+    const collapsed =
+      typeof value === "string"
+        ? value
+        : Array.isArray(value) && typeof value[0] === "string"
+          ? value[0]
+          : undefined;
+    if (collapsed === undefined) continue;
+    if (attrEncoder.encode(collapsed).length > MAX_ATTR_VALUE_BYTES) continue;
+    if (EMAIL_SHAPED.test(collapsed)) continue;
+    attributes[key] = collapsed;
   }
-  return attributes;
+  return Object.freeze(attributes);
 }
 
 /** Enriches raw user profile with admin scopes. */
@@ -84,7 +106,9 @@ function enrichUserProfile(raw: UserProfileRaw): UserProfile {
   const orgEntry = raw.organization ? Object.entries(raw.organization)[0] : undefined;
   const organization = orgEntry?.[0];
   const rawGroups = orgEntry ? (orgEntry[1].groups ?? []) : raw.groups;
-  const organizationAttributes = orgEntry ? collapseOrganizationAttributes(orgEntry[1]) : {};
+  const organizationAttributes = orgEntry
+    ? collapseOrganizationAttributes(orgEntry[1])
+    : Object.freeze({});
 
   // Root `/admins` becomes the `*` admin scope. `authorization.ts` treats `*`
   // as "admin of every owner scope in this org" — still bounded by the tenant
@@ -117,12 +141,13 @@ function enrichUserProfile(raw: UserProfileRaw): UserProfile {
  * projection only, so PII never crosses to the client loader payload.
  */
 export function toIdentity(user: UserProfile): Identity {
-  return {
+  // Frozen so a gate cannot mutate the projection shared across the gate chain.
+  return Object.freeze({
     organization: user.organization,
     organizationAttributes: user.organizationAttributes,
     groups: user.groups,
     adminScopes: user.adminScopes,
-  };
+  });
 }
 
 /** Retrieves and enriches user profile data from Keycloak. */

--- a/app/.server/auth/getUserInfo.ts
+++ b/app/.server/auth/getUserInfo.ts
@@ -46,11 +46,14 @@ export interface UserProfile extends Omit<UserProfileRaw, "organization"> {
   /** Active Keycloak organization alias for this session. Undefined for zero-org users. */
   organization?: string;
   /**
-   * Opaque org attributes mirrored into the token. Each multivalued attr is
-   * collapsed to its first value; empty/non-string, oversized, and email-shaped
-   * values are dropped (host-side hygiene). Frozen at runtime.
+   * Opaque, multivalued org attributes mirrored into the token (Keycloak
+   * attributes are arrays). The host preserves the array shape and assigns no
+   * meaning to keys — a consumer that knows an attribute is single-valued picks
+   * `[0]` itself. Non-string, oversized, and email-shaped values are dropped
+   * (host-side hygiene); a key whose values are all dropped is omitted. Frozen
+   * at runtime.
    */
-  organizationAttributes: Readonly<Record<string, string>>;
+  organizationAttributes: Readonly<Record<string, readonly string[]>>;
   groups: string[];
   adminScopes: string[];
 }
@@ -71,29 +74,34 @@ function normalizeGroup(group: string): string {
 
 type OrganizationEntry = NonNullable<UserProfileRaw["organization"]>[string];
 
+/** Drop non-string, oversized (>256B), and email-shaped values (host hygiene). */
+function isAllowedAttrValue(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    attrEncoder.encode(value).length <= MAX_ATTR_VALUE_BYTES &&
+    !EMAIL_SHAPED.test(value)
+  );
+}
+
 /**
- * Collapses Keycloak attribute values to a single string, dropping host-owned
- * keys (`id`, `groups`). A scalar collapses to itself; an array to its first
- * element. Empty/non-string, oversized (>256B), and email-shaped values are
- * dropped. Returns a frozen map so a misbehaving gate cannot mutate the shared
+ * Normalizes a Keycloak org-attribute entry into a multivalued map, dropping
+ * host-owned keys (`id`, `groups`). A scalar is wrapped to a one-element array;
+ * an array is filtered to allowed string values. The host preserves the array
+ * shape and does not collapse — a consumer that knows an attribute is
+ * single-valued picks `[0]`. A key whose values are all dropped is omitted. The
+ * map and its arrays are frozen so a misbehaving gate cannot mutate the shared
  * attributes downstream.
  */
-function collapseOrganizationAttributes(
+function normalizeOrganizationAttributes(
   entry: OrganizationEntry,
-): Readonly<Record<string, string>> {
-  const attributes: Record<string, string> = {};
+): Readonly<Record<string, readonly string[]>> {
+  const attributes: Record<string, readonly string[]> = {};
   for (const [key, value] of Object.entries(entry)) {
     if (key === "id" || key === "groups") continue;
-    const collapsed =
-      typeof value === "string"
-        ? value
-        : Array.isArray(value) && typeof value[0] === "string"
-          ? value[0]
-          : undefined;
-    if (collapsed === undefined) continue;
-    if (attrEncoder.encode(collapsed).length > MAX_ATTR_VALUE_BYTES) continue;
-    if (EMAIL_SHAPED.test(collapsed)) continue;
-    attributes[key] = collapsed;
+    const raw = Array.isArray(value) ? value : [value];
+    const allowed = raw.filter(isAllowedAttrValue);
+    if (allowed.length === 0) continue;
+    attributes[key] = Object.freeze(allowed);
   }
   return Object.freeze(attributes);
 }
@@ -107,7 +115,7 @@ function enrichUserProfile(raw: UserProfileRaw): UserProfile {
   const organization = orgEntry?.[0];
   const rawGroups = orgEntry ? (orgEntry[1].groups ?? []) : raw.groups;
   const organizationAttributes = orgEntry
-    ? collapseOrganizationAttributes(orgEntry[1])
+    ? normalizeOrganizationAttributes(orgEntry[1])
     : Object.freeze({});
 
   // Root `/admins` becomes the `*` admin scope. `authorization.ts` treats `*`

--- a/app/.server/pluginGates.ts
+++ b/app/.server/pluginGates.ts
@@ -11,46 +11,62 @@ function isGateOutcome(value: unknown): value is GateOutcome {
   );
 }
 
+interface GateEntry {
+  gate: SessionGate;
+  pluginName: string;
+}
+
 /**
  * Server-only session-gate registry. Mirrors the `formatRegistry` singleton
- * pattern: a module-level instance the bootstrap injects into each plugin's
- * `ctx.gates`. Lives under a `.server` path so it never enters the client
- * bundle (gates run in middleware, before render).
+ * pattern: `scopedFor(pluginName)` binds the plugin name at register time (the
+ * public `GateRegistry` surface never accepts it from plugin code), so a gate
+ * throwing at request time can be attributed. Lives under a `.server` path so
+ * it never enters the client bundle.
  */
-class GateRegistryImpl implements GateRegistry {
-  private readonly gates: SessionGate[] = [];
+class GateRegistryImpl {
+  private readonly entries: GateEntry[] = [];
 
-  register(gate: SessionGate): void {
-    this.gates.push(gate);
+  /** Host-internal: a `GateRegistry` adapter bound to a plugin name. */
+  scopedFor(pluginName: string): GateRegistry {
+    return {
+      register: (gate) => this.add(pluginName, gate),
+    };
+  }
+
+  add(pluginName: string, gate: SessionGate): void {
+    this.entries.push({ gate, pluginName });
   }
 
   list(): readonly SessionGate[] {
-    return this.gates;
+    return this.entries.map((e) => e.gate);
   }
 
   /**
    * Runs registered gates in registration order and returns the first
    * non-`continue` outcome (a `redirect` or a `deny`); otherwise `continue`.
    * A throwing gate, or one returning a malformed outcome (missing/unknown
-   * `kind`), is logged and treated as `continue` (fail-open, matching the
-   * format-plugin containment contract).
+   * `kind`), is logged with its plugin name and treated as `continue`
+   * (fail-open, matching the format-plugin containment contract).
    */
   async runGates(req: GateRequest): Promise<GateOutcome> {
     // Snapshot so a gate registering re-entrantly mid-run cannot change the
     // iterated set.
-    for (const gate of [...this.gates]) {
+    for (const { gate, pluginName } of [...this.entries]) {
       let outcome: GateOutcome;
       try {
         outcome = await gate(req);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        console.error("[plugin-gate] gate threw — treating as continue", { error: message });
+        console.error(`[plugin-gate] "${pluginName}" threw — treating as continue`, {
+          error: message,
+        });
         continue;
       }
       if (!isGateOutcome(outcome)) {
-        console.error("[plugin-gate] gate returned a malformed outcome — treating as continue", {
-          outcome,
-        });
+        console.error(
+          `[plugin-gate] "${pluginName}" returned a malformed outcome — treating as continue`,
+          { outcome },
+        );
         continue;
       }
       if (outcome.kind !== "continue") return outcome;
@@ -60,7 +76,7 @@ class GateRegistryImpl implements GateRegistry {
 
   /** Test-only: drop all registrations. */
   __reset(): void {
-    this.gates.length = 0;
+    this.entries.length = 0;
   }
 }
 

--- a/app/.server/pluginGates.ts
+++ b/app/.server/pluginGates.ts
@@ -36,7 +36,9 @@ class GateRegistryImpl implements GateRegistry {
    * format-plugin containment contract).
    */
   async runGates(req: GateRequest): Promise<GateOutcome> {
-    for (const gate of this.gates) {
+    // Snapshot so a gate registering re-entrantly mid-run cannot change the
+    // iterated set.
+    for (const gate of [...this.gates]) {
       let outcome: GateOutcome;
       try {
         outcome = await gate(req);

--- a/app/.server/pluginGates.ts
+++ b/app/.server/pluginGates.ts
@@ -1,0 +1,69 @@
+import type { GateOutcome, GateRegistry, GateRequest, SessionGate } from "@cytario/plugin-api";
+
+const GATE_OUTCOME_KINDS = new Set<GateOutcome["kind"]>(["continue", "redirect", "deny"]);
+
+function isGateOutcome(value: unknown): value is GateOutcome {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "kind" in value &&
+    GATE_OUTCOME_KINDS.has((value as { kind: GateOutcome["kind"] }).kind)
+  );
+}
+
+/**
+ * Server-only session-gate registry. Mirrors the `formatRegistry` singleton
+ * pattern: a module-level instance the bootstrap injects into each plugin's
+ * `ctx.gates`. Lives under a `.server` path so it never enters the client
+ * bundle (gates run in middleware, before render).
+ */
+class GateRegistryImpl implements GateRegistry {
+  private readonly gates: SessionGate[] = [];
+
+  register(gate: SessionGate): void {
+    this.gates.push(gate);
+  }
+
+  list(): readonly SessionGate[] {
+    return this.gates;
+  }
+
+  /**
+   * Runs registered gates in registration order and returns the first
+   * non-`continue` outcome (a `redirect` or a `deny`); otherwise `continue`.
+   * A throwing gate, or one returning a malformed outcome (missing/unknown
+   * `kind`), is logged and treated as `continue` (fail-open, matching the
+   * format-plugin containment contract).
+   */
+  async runGates(req: GateRequest): Promise<GateOutcome> {
+    for (const gate of this.gates) {
+      let outcome: GateOutcome;
+      try {
+        outcome = await gate(req);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error("[plugin-gate] gate threw — treating as continue", { error: message });
+        continue;
+      }
+      if (!isGateOutcome(outcome)) {
+        console.error("[plugin-gate] gate returned a malformed outcome — treating as continue", {
+          outcome,
+        });
+        continue;
+      }
+      if (outcome.kind !== "continue") return outcome;
+    }
+    return { kind: "continue" };
+  }
+
+  /** Test-only: drop all registrations. */
+  __reset(): void {
+    this.gates.length = 0;
+  }
+}
+
+export const gateRegistry = new GateRegistryImpl();
+
+export const runGates = (req: GateRequest): Promise<GateOutcome> => gateRegistry.runGates(req);
+
+export type { GateRegistryImpl };

--- a/app/__tests__/config.test.ts
+++ b/app/__tests__/config.test.ts
@@ -1,0 +1,12 @@
+import { cytarioConfig } from "~/config";
+
+describe("session cookie", () => {
+  // Shared Keycloak realm: cytario-web (app.cytario.com) and the admin portal
+  // (admin.cytario.com) are distinct origins. A `Domain=.cytario.com` cookie
+  // would leak the session across them. The cookie must stay host-scoped, so
+  // there must be no `Domain` attribute.
+  test("has no Domain attribute (host-scoped, no cross-subdomain leak)", () => {
+    expect("domain" in cytarioConfig.cookie).toBe(false);
+    expect((cytarioConfig.cookie as { domain?: unknown }).domain).toBeUndefined();
+  });
+});

--- a/app/components/PluginSlots.tsx
+++ b/app/components/PluginSlots.tsx
@@ -1,0 +1,37 @@
+import { Fragment, useSyncExternalStore, type ComponentType } from "react";
+
+import { slotRegistry } from "./slotRegistry";
+import type { Identity, SlotName, SlotProps } from "@cytario/plugin-api";
+
+// Slots are client-only: the welcome overlay / subscription banner must never
+// enter the SSR HTML (CSP, no flash of plugin UI before hydration). This guard
+// is `false` on the server snapshot and `true` once hydrated on the client.
+const subscribe = () => () => {};
+const useHasMounted = () =>
+  useSyncExternalStore(
+    subscribe,
+    () => true,
+    () => false,
+  );
+
+interface PluginSlotsProps {
+  name: SlotName;
+  identity: Identity;
+}
+
+export function PluginSlots({ name, identity }: PluginSlotsProps) {
+  const hasMounted = useHasMounted();
+  if (!hasMounted) return null;
+
+  const components = slotRegistry.get(name) as ComponentType<SlotProps>[];
+
+  return (
+    <>
+      {components.map((Component, index) => (
+        <Fragment key={index}>
+          <Component identity={identity} />
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/app/components/PluginSlots.tsx
+++ b/app/components/PluginSlots.tsx
@@ -9,17 +9,14 @@ interface PluginSlotsProps {
   identity: Identity;
 }
 
-// Slots are client-only: the welcome overlay / subscription banner must never
-// enter the SSR HTML (CSP, no flash of plugin UI before hydration). `ClientOnly`
-// renders nothing until hydrated.
+// Client-only via ClientOnly: plugin overlay/banner must not enter SSR HTML (CSP).
 export function PluginSlots({ name, identity }: PluginSlotsProps) {
   const components = slotRegistry.get(name) as ComponentType<SlotProps>[];
 
   return (
     <ClientOnly>
       {components.map((Component, index) => (
-        // Index key is stable: the registry is append-only with no `unregister`.
-        // Adding removal/reordering would need a stable per-registration id.
+        // Index key OK: registry is append-only (no unregister/reorder).
         <Fragment key={index}>
           <Component identity={identity} />
         </Fragment>

--- a/app/components/PluginSlots.tsx
+++ b/app/components/PluginSlots.tsx
@@ -1,37 +1,29 @@
-import { Fragment, useSyncExternalStore, type ComponentType } from "react";
+import { Fragment, type ComponentType } from "react";
 
+import { ClientOnly } from "./ClientOnly";
 import { slotRegistry } from "./slotRegistry";
 import type { Identity, SlotName, SlotProps } from "@cytario/plugin-api";
-
-// Slots are client-only: the welcome overlay / subscription banner must never
-// enter the SSR HTML (CSP, no flash of plugin UI before hydration). This guard
-// is `false` on the server snapshot and `true` once hydrated on the client.
-const subscribe = () => () => {};
-const useHasMounted = () =>
-  useSyncExternalStore(
-    subscribe,
-    () => true,
-    () => false,
-  );
 
 interface PluginSlotsProps {
   name: SlotName;
   identity: Identity;
 }
 
+// Slots are client-only: the welcome overlay / subscription banner must never
+// enter the SSR HTML (CSP, no flash of plugin UI before hydration). `ClientOnly`
+// renders nothing until hydrated.
 export function PluginSlots({ name, identity }: PluginSlotsProps) {
-  const hasMounted = useHasMounted();
-  if (!hasMounted) return null;
-
   const components = slotRegistry.get(name) as ComponentType<SlotProps>[];
 
   return (
-    <>
+    <ClientOnly>
       {components.map((Component, index) => (
+        // Index key is stable: the registry is append-only with no `unregister`.
+        // Adding removal/reordering would need a stable per-registration id.
         <Fragment key={index}>
           <Component identity={identity} />
         </Fragment>
       ))}
-    </>
+    </ClientOnly>
   );
 }

--- a/app/components/__tests__/PluginSlots.test.tsx
+++ b/app/components/__tests__/PluginSlots.test.tsx
@@ -7,7 +7,7 @@ import { slotRegistry } from "~/components/slotRegistry";
 
 const identity: Identity = {
   organization: "testcorp",
-  organizationAttributes: { subscription_status: "active" },
+  organizationAttributes: { subscription_status: ["active"] },
   groups: ["lab/team-a"],
   adminScopes: ["*"],
 };

--- a/app/components/__tests__/PluginSlots.test.tsx
+++ b/app/components/__tests__/PluginSlots.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+
+import type { Identity, SlotProps } from "@cytario/plugin-api";
+import { PluginSlots } from "~/components/PluginSlots";
+import { slotRegistry } from "~/components/slotRegistry";
+
+const identity: Identity = {
+  organization: "testcorp",
+  organizationAttributes: { subscription_status: "active" },
+  groups: ["lab/team-a"],
+  adminScopes: ["*"],
+};
+
+describe("PluginSlots", () => {
+  beforeEach(() => {
+    slotRegistry.__reset();
+  });
+
+  test("renders all registered components in order with the identity prop", () => {
+    const First = ({ identity: id }: SlotProps) => <div data-testid="first">{id.organization}</div>;
+    const Second = ({ identity: id }: SlotProps) => (
+      <div data-testid="second">{id.groups.join(",")}</div>
+    );
+    slotRegistry.register("app-banner", First);
+    slotRegistry.register("app-banner", Second);
+
+    render(<PluginSlots name="app-banner" identity={identity} />);
+
+    expect(screen.getByTestId("first")).toHaveTextContent("testcorp");
+    expect(screen.getByTestId("second")).toHaveTextContent("lab/team-a");
+  });
+
+  test("supports multiple components per slot", () => {
+    const A = () => <span data-testid="a" />;
+    const B = () => <span data-testid="b" />;
+    const C = () => <span data-testid="c" />;
+    slotRegistry.register("app-overlay", A);
+    slotRegistry.register("app-overlay", B);
+    slotRegistry.register("app-overlay", C);
+
+    render(<PluginSlots name="app-overlay" identity={identity} />);
+
+    expect(screen.getAllByTestId(/^[abc]$/)).toHaveLength(3);
+  });
+
+  test("renders nothing on the server (SSR-safe)", () => {
+    const Banner = () => <div>banner</div>;
+    slotRegistry.register("app-banner", Banner);
+
+    const html = renderToString(<PluginSlots name="app-banner" identity={identity} />);
+
+    expect(html).toBe("");
+  });
+});

--- a/app/components/__tests__/PluginSlots.test.tsx
+++ b/app/components/__tests__/PluginSlots.test.tsx
@@ -22,8 +22,8 @@ describe("PluginSlots", () => {
     const Second = ({ identity: id }: SlotProps) => (
       <div data-testid="second">{id.groups.join(",")}</div>
     );
-    slotRegistry.register("app-banner", First);
-    slotRegistry.register("app-banner", Second);
+    slotRegistry.scopedFor("test-plugin").register("app-banner", First);
+    slotRegistry.scopedFor("test-plugin").register("app-banner", Second);
 
     render(<PluginSlots name="app-banner" identity={identity} />);
 
@@ -35,9 +35,9 @@ describe("PluginSlots", () => {
     const A = () => <span data-testid="a" />;
     const B = () => <span data-testid="b" />;
     const C = () => <span data-testid="c" />;
-    slotRegistry.register("app-overlay", A);
-    slotRegistry.register("app-overlay", B);
-    slotRegistry.register("app-overlay", C);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", A);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", B);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", C);
 
     render(<PluginSlots name="app-overlay" identity={identity} />);
 
@@ -46,7 +46,7 @@ describe("PluginSlots", () => {
 
   test("renders nothing on the server (SSR-safe)", () => {
     const Banner = () => <div>banner</div>;
-    slotRegistry.register("app-banner", Banner);
+    slotRegistry.scopedFor("test-plugin").register("app-banner", Banner);
 
     const html = renderToString(<PluginSlots name="app-banner" identity={identity} />);
 

--- a/app/components/__tests__/slotRegistry.test.ts
+++ b/app/components/__tests__/slotRegistry.test.ts
@@ -8,16 +8,16 @@ describe("slotRegistry", () => {
   test("appends components in registration order (multi-owner)", () => {
     const a = () => null;
     const b = () => null;
-    slotRegistry.register("app-banner", a);
-    slotRegistry.register("app-banner", b);
+    slotRegistry.scopedFor("test-plugin").register("app-banner", a);
+    slotRegistry.scopedFor("test-plugin").register("app-banner", b);
 
     expect(slotRegistry.get("app-banner")).toEqual([a, b]);
   });
 
   test("never replaces — repeated registers accumulate", () => {
     const a = () => null;
-    slotRegistry.register("app-overlay", a);
-    slotRegistry.register("app-overlay", a);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", a);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", a);
 
     expect(slotRegistry.get("app-overlay")).toHaveLength(2);
   });
@@ -25,15 +25,15 @@ describe("slotRegistry", () => {
   test("keeps slots independent", () => {
     const overlay = () => null;
     const banner = () => null;
-    slotRegistry.register("app-overlay", overlay);
-    slotRegistry.register("app-banner", banner);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", overlay);
+    slotRegistry.scopedFor("test-plugin").register("app-banner", banner);
 
     expect(slotRegistry.get("app-overlay")).toEqual([overlay]);
     expect(slotRegistry.get("app-banner")).toEqual([banner]);
   });
 
   test("__reset drops all registrations", () => {
-    slotRegistry.register("app-overlay", () => null);
+    slotRegistry.scopedFor("test-plugin").register("app-overlay", () => null);
     slotRegistry.__reset();
 
     expect(slotRegistry.get("app-overlay")).toEqual([]);

--- a/app/components/__tests__/slotRegistry.test.ts
+++ b/app/components/__tests__/slotRegistry.test.ts
@@ -1,0 +1,42 @@
+import { slotRegistry } from "~/components/slotRegistry";
+
+describe("slotRegistry", () => {
+  beforeEach(() => {
+    slotRegistry.__reset();
+  });
+
+  test("appends components in registration order (multi-owner)", () => {
+    const a = () => null;
+    const b = () => null;
+    slotRegistry.register("app-banner", a);
+    slotRegistry.register("app-banner", b);
+
+    expect(slotRegistry.get("app-banner")).toEqual([a, b]);
+  });
+
+  test("never replaces — repeated registers accumulate", () => {
+    const a = () => null;
+    slotRegistry.register("app-overlay", a);
+    slotRegistry.register("app-overlay", a);
+
+    expect(slotRegistry.get("app-overlay")).toHaveLength(2);
+  });
+
+  test("keeps slots independent", () => {
+    const overlay = () => null;
+    const banner = () => null;
+    slotRegistry.register("app-overlay", overlay);
+    slotRegistry.register("app-banner", banner);
+
+    expect(slotRegistry.get("app-overlay")).toEqual([overlay]);
+    expect(slotRegistry.get("app-banner")).toEqual([banner]);
+  });
+
+  test("__reset drops all registrations", () => {
+    slotRegistry.register("app-overlay", () => null);
+    slotRegistry.__reset();
+
+    expect(slotRegistry.get("app-overlay")).toEqual([]);
+    expect(slotRegistry.get("app-banner")).toEqual([]);
+  });
+});

--- a/app/components/slotRegistry.ts
+++ b/app/components/slotRegistry.ts
@@ -1,11 +1,8 @@
 import type { SlotName, SlotRegistry } from "@cytario/plugin-api";
 
 /**
- * Client slot registry. Shares the module-singleton + `__reset` shape of
- * `formatRegistry` / `gateRegistry`, but is multi-owner: `register` appends
- * rather than replacing (no scoping, no collision detection), so multiple
- * plugins may mount into the same slot; `get` returns the components in
- * registration order.
+ * Client slot registry: multi-owner module singleton. `register` appends (no
+ * collision detection); `get` returns components in registration order.
  */
 class SlotRegistryImpl implements SlotRegistry {
   private readonly slots: Record<SlotName, unknown[]> = {
@@ -14,8 +11,7 @@ class SlotRegistryImpl implements SlotRegistry {
   };
 
   register(slot: SlotName, component: unknown): void {
-    // Fail at registration, not at render: a non-callable component would
-    // otherwise throw deep inside React when the slot mounts.
+    // Fail here, not at render — a non-callable would throw deep inside React.
     if (typeof component !== "function") {
       throw new TypeError(
         `Slot "${slot}" expects a component function, received ${typeof component}`,

--- a/app/components/slotRegistry.ts
+++ b/app/components/slotRegistry.ts
@@ -1,0 +1,34 @@
+import type { SlotName, SlotRegistry } from "@cytario/plugin-api";
+
+/**
+ * Client slot registry. Mirrors the `formatRegistry` / `gateRegistry`
+ * singleton pattern: a module-level instance the bootstrap injects into each
+ * plugin's `ctx.slots`. Slots are multi-owner — `register` appends rather than
+ * replacing, so multiple plugins may mount into the same slot; `get` returns
+ * the components in registration order.
+ */
+class SlotRegistryImpl implements SlotRegistry {
+  private readonly slots: Record<SlotName, unknown[]> = {
+    "app-overlay": [],
+    "app-banner": [],
+  };
+
+  register(slot: SlotName, component: unknown): void {
+    this.slots[slot].push(component);
+  }
+
+  get(slot: SlotName): unknown[] {
+    return this.slots[slot];
+  }
+
+  /** Test-only: drop all registrations. */
+  __reset(): void {
+    for (const slot of Object.keys(this.slots) as SlotName[]) {
+      this.slots[slot].length = 0;
+    }
+  }
+}
+
+export const slotRegistry = new SlotRegistryImpl();
+
+export type { SlotRegistryImpl };

--- a/app/components/slotRegistry.ts
+++ b/app/components/slotRegistry.ts
@@ -1,11 +1,11 @@
 import type { SlotName, SlotRegistry } from "@cytario/plugin-api";
 
 /**
- * Client slot registry. Mirrors the `formatRegistry` / `gateRegistry`
- * singleton pattern: a module-level instance the bootstrap injects into each
- * plugin's `ctx.slots`. Slots are multi-owner — `register` appends rather than
- * replacing, so multiple plugins may mount into the same slot; `get` returns
- * the components in registration order.
+ * Client slot registry. Shares the module-singleton + `__reset` shape of
+ * `formatRegistry` / `gateRegistry`, but is multi-owner: `register` appends
+ * rather than replacing (no scoping, no collision detection), so multiple
+ * plugins may mount into the same slot; `get` returns the components in
+ * registration order.
  */
 class SlotRegistryImpl implements SlotRegistry {
   private readonly slots: Record<SlotName, unknown[]> = {
@@ -14,6 +14,13 @@ class SlotRegistryImpl implements SlotRegistry {
   };
 
   register(slot: SlotName, component: unknown): void {
+    // Fail at registration, not at render: a non-callable component would
+    // otherwise throw deep inside React when the slot mounts.
+    if (typeof component !== "function") {
+      throw new TypeError(
+        `Slot "${slot}" expects a component function, received ${typeof component}`,
+      );
+    }
     this.slots[slot].push(component);
   }
 

--- a/app/components/slotRegistry.ts
+++ b/app/components/slotRegistry.ts
@@ -1,27 +1,41 @@
 import type { SlotName, SlotRegistry } from "@cytario/plugin-api";
 
+interface SlotEntry {
+  component: unknown;
+  pluginName: string;
+}
+
 /**
- * Client slot registry: multi-owner module singleton. `register` appends (no
- * collision detection); `get` returns components in registration order.
+ * Client slot registry: multi-owner module singleton. `scopedFor(pluginName)`
+ * binds the plugin name at register time (mirrors `formatRegistry`); `register`
+ * appends (no collision detection); `get` returns components in registration
+ * order.
  */
-class SlotRegistryImpl implements SlotRegistry {
-  private readonly slots: Record<SlotName, unknown[]> = {
+class SlotRegistryImpl {
+  private readonly slots: Record<SlotName, SlotEntry[]> = {
     "app-overlay": [],
     "app-banner": [],
   };
 
-  register(slot: SlotName, component: unknown): void {
+  /** Host-internal: a `SlotRegistry` adapter bound to a plugin name. */
+  scopedFor(pluginName: string): SlotRegistry {
+    return {
+      register: (slot, component) => this.add(pluginName, slot, component),
+    };
+  }
+
+  add(pluginName: string, slot: SlotName, component: unknown): void {
     // Fail here, not at render — a non-callable would throw deep inside React.
     if (typeof component !== "function") {
       throw new TypeError(
-        `Slot "${slot}" expects a component function, received ${typeof component}`,
+        `Plugin "${pluginName}" registered a non-component for slot "${slot}" (got ${typeof component})`,
       );
     }
-    this.slots[slot].push(component);
+    this.slots[slot].push({ component, pluginName });
   }
 
   get(slot: SlotName): unknown[] {
-    return this.slots[slot];
+    return this.slots[slot].map((e) => e.component);
   }
 
   /** Test-only: drop all registrations. */

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -2,6 +2,7 @@ import { startTransition } from "react";
 import { hydrateRoot } from "react-dom/client";
 import { HydratedRouter } from "react-router/dom";
 
+import { slotRegistry } from "./components/slotRegistry";
 import { bootstrapPlugins } from "./plugins.generated";
 
 // Await bootstrap before hydrating so registry-derived gates (e.g. the
@@ -10,12 +11,15 @@ import { bootstrapPlugins } from "./plugins.generated";
 // modules are already statically imported above, so this only waits for
 // `register()` to run — it pulls in no extra bundle. (Built-ins still register
 // lazily in ViewerStoreContext to keep viv + geotiff out of the entry chunk.)
-await bootstrapPlugins({
-  debug: (msg, fields) => console.debug("[plugin-bootstrap]", msg, fields ?? {}),
-  info: (msg, fields) => console.info("[plugin-bootstrap]", msg, fields ?? {}),
-  warn: (msg, fields) => console.warn("[plugin-bootstrap]", msg, fields ?? {}),
-  error: (msg, fields) => console.error("[plugin-bootstrap]", msg, fields ?? {}),
-}).catch((err) => {
+await bootstrapPlugins(
+  {
+    debug: (msg, fields) => console.debug("[plugin-bootstrap]", msg, fields ?? {}),
+    info: (msg, fields) => console.info("[plugin-bootstrap]", msg, fields ?? {}),
+    warn: (msg, fields) => console.warn("[plugin-bootstrap]", msg, fields ?? {}),
+    error: (msg, fields) => console.error("[plugin-bootstrap]", msg, fields ?? {}),
+  },
+  { slots: slotRegistry, env: "client" },
+).catch((err) => {
   console.error("[plugin-bootstrap] unexpected bootstrap failure:", err);
 });
 

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,18 +6,22 @@ import type { AppLoadContext, EntryContext } from "react-router";
 import { ServerRouter } from "react-router";
 
 import { buildContentSecurityPolicy } from "./.server/csp";
+import { gateRegistry } from "./.server/pluginGates";
 import { bootstrapPlugins } from "./plugins.generated";
 
 const ABORT_DELAY = 5_000;
 
 // `handleRequest` awaits this so a request cannot resolve the plugin registry
 // before async `register()` calls have completed.
-const bootstrapPromise: Promise<void> = bootstrapPlugins({
-  debug: (msg, fields) => console.debug("[plugin-bootstrap]", msg, fields ?? {}),
-  info: (msg, fields) => console.info("[plugin-bootstrap]", msg, fields ?? {}),
-  warn: (msg, fields) => console.warn("[plugin-bootstrap]", msg, fields ?? {}),
-  error: (msg, fields) => console.error("[plugin-bootstrap]", msg, fields ?? {}),
-}).catch((err: unknown) => {
+const bootstrapPromise: Promise<void> = bootstrapPlugins(
+  {
+    debug: (msg, fields) => console.debug("[plugin-bootstrap]", msg, fields ?? {}),
+    info: (msg, fields) => console.info("[plugin-bootstrap]", msg, fields ?? {}),
+    warn: (msg, fields) => console.warn("[plugin-bootstrap]", msg, fields ?? {}),
+    error: (msg, fields) => console.error("[plugin-bootstrap]", msg, fields ?? {}),
+  },
+  { gates: gateRegistry, env: "server" },
+).catch((err: unknown) => {
   console.error("[plugin-bootstrap] unexpected bootstrap failure:", err);
 });
 

--- a/app/lib/__tests__/bootstrapPluginsCore.test.ts
+++ b/app/lib/__tests__/bootstrapPluginsCore.test.ts
@@ -1,5 +1,11 @@
 import { bootstrapPluginsCore } from "../bootstrapPluginsCore";
-import type { CytarioPlugin, Logger, PluginContext } from "@cytario/plugin-api";
+import type {
+  CytarioPlugin,
+  GateRegistry,
+  Logger,
+  PluginContext,
+  SlotRegistry,
+} from "@cytario/plugin-api";
 import { formatRegistry } from "~/components/ImageViewer/state/formatRegistry";
 
 const noopLogger = (): Logger => ({
@@ -147,5 +153,53 @@ describe("bootstrapPluginsCore (SDS-CY-010403)", () => {
         error: expect.stringContaining("collides"),
       }),
     );
+  });
+
+  describe("registry injection", () => {
+    const captureContext = (sink: { ctx?: PluginContext }): CytarioPlugin => ({
+      name: "capture-plugin",
+      apiVersion: "^2.0.0",
+      register(ctx) {
+        sink.ctx = ctx;
+      },
+    });
+
+    test("injected gates reach ctx and env is server", async () => {
+      const sink: { ctx?: PluginContext } = {};
+      const gates: GateRegistry = { register: vi.fn() };
+
+      await bootstrapPluginsCore([captureContext(sink)], noopLogger(), {
+        gates,
+        env: "server",
+      });
+
+      expect(sink.ctx?.gates).toBe(gates);
+      expect(sink.ctx?.env).toBe("server");
+    });
+
+    test("injected slots reach ctx and env is client", async () => {
+      const sink: { ctx?: PluginContext } = {};
+      const slots: SlotRegistry = { register: vi.fn() };
+
+      await bootstrapPluginsCore([captureContext(sink)], noopLogger(), {
+        slots,
+        env: "client",
+      });
+
+      expect(sink.ctx?.slots).toBe(slots);
+      expect(sink.ctx?.env).toBe("client");
+    });
+
+    test("no-op sinks are supplied when registries are not injected", async () => {
+      const sink: { ctx?: PluginContext } = {};
+
+      await bootstrapPluginsCore([captureContext(sink)], noopLogger());
+
+      // No-op sinks: registering against them is inert and does not throw.
+      expect(() => sink.ctx?.gates.register(() => ({ kind: "continue" }))).not.toThrow();
+      expect(() => sink.ctx?.slots.register("app-overlay", () => null)).not.toThrow();
+      // env defaults to client for backward compatibility.
+      expect(sink.ctx?.env).toBe("client");
+    });
   });
 });

--- a/app/lib/__tests__/bootstrapPluginsCore.test.ts
+++ b/app/lib/__tests__/bootstrapPluginsCore.test.ts
@@ -164,29 +164,33 @@ describe("bootstrapPluginsCore (SDS-CY-010403)", () => {
       },
     });
 
-    test("injected gates reach ctx and env is server", async () => {
+    test("injects the gate registry scoped to the plugin name; env is server", async () => {
       const sink: { ctx?: PluginContext } = {};
-      const gates: GateRegistry = { register: vi.fn() };
+      const scoped: GateRegistry = { register: vi.fn() };
+      const gates = { scopedFor: vi.fn(() => scoped) };
 
       await bootstrapPluginsCore([captureContext(sink)], noopLogger(), {
         gates,
         env: "server",
       });
 
-      expect(sink.ctx?.gates).toBe(gates);
+      expect(gates.scopedFor).toHaveBeenCalledWith("capture-plugin");
+      expect(sink.ctx?.gates).toBe(scoped);
       expect(sink.ctx?.env).toBe("server");
     });
 
-    test("injected slots reach ctx and env is client", async () => {
+    test("injects the slot registry scoped to the plugin name; env is client", async () => {
       const sink: { ctx?: PluginContext } = {};
-      const slots: SlotRegistry = { register: vi.fn() };
+      const scoped: SlotRegistry = { register: vi.fn() };
+      const slots = { scopedFor: vi.fn(() => scoped) };
 
       await bootstrapPluginsCore([captureContext(sink)], noopLogger(), {
         slots,
         env: "client",
       });
 
-      expect(sink.ctx?.slots).toBe(slots);
+      expect(slots.scopedFor).toHaveBeenCalledWith("capture-plugin");
+      expect(sink.ctx?.slots).toBe(scoped);
       expect(sink.ctx?.env).toBe("client");
     });
 

--- a/app/lib/bootstrapPluginsCore.ts
+++ b/app/lib/bootstrapPluginsCore.ts
@@ -17,18 +17,23 @@ import { formatRegistry } from "~/components/ImageViewer/state/formatRegistry";
  * `ctx.env` so a plugin can branch its register() without import-time env
  * sniffing; it defaults to `"client"` for backward compatibility.
  */
+/** A registry the bootstrap binds to a plugin name before handing it to `ctx`. */
+interface Scoped<R> {
+  scopedFor(pluginName: string): R;
+}
+
 export interface BootstrapRegistries {
-  gates?: GateRegistry;
-  slots?: SlotRegistry;
+  gates?: Scoped<GateRegistry>;
+  slots?: Scoped<SlotRegistry>;
   env?: PluginContext["env"];
 }
 
-const noopGateRegistry: GateRegistry = {
-  register: () => {},
+const noopGateRegistry: Scoped<GateRegistry> = {
+  scopedFor: () => ({ register: () => {} }),
 };
 
-const noopSlotRegistry: SlotRegistry = {
-  register: () => {},
+const noopSlotRegistry: Scoped<SlotRegistry> = {
+  scopedFor: () => ({ register: () => {} }),
 };
 
 /**
@@ -77,8 +82,8 @@ export async function bootstrapPluginsCore(
     const ctx: PluginContext = {
       logger,
       formats: formatRegistry.scopedFor(plugin.name),
-      gates,
-      slots,
+      gates: gates.scopedFor(plugin.name),
+      slots: slots.scopedFor(plugin.name),
       env,
     };
 

--- a/app/lib/bootstrapPluginsCore.ts
+++ b/app/lib/bootstrapPluginsCore.ts
@@ -55,6 +55,8 @@ export async function bootstrapPluginsCore(
 ): Promise<void> {
   const gates = registries?.gates ?? noopGateRegistry;
   const slots = registries?.slots ?? noopSlotRegistry;
+  // Both entries set `env` explicitly; the default only covers tests that call
+  // this helper without registries.
   const env: PluginContext["env"] = registries?.env ?? "client";
   for (const plugin of plugins) {
     try {

--- a/app/lib/bootstrapPluginsCore.ts
+++ b/app/lib/bootstrapPluginsCore.ts
@@ -1,6 +1,35 @@
-import type { CytarioPlugin, Logger, PluginContext } from "@cytario/plugin-api";
+import type {
+  CytarioPlugin,
+  GateRegistry,
+  Logger,
+  PluginContext,
+  SlotRegistry,
+} from "@cytario/plugin-api";
 import { IncompatiblePluginError, assertApiCompatible, hostApiVersion } from "@cytario/plugin-api";
 import { formatRegistry } from "~/components/ImageViewer/state/formatRegistry";
+
+/**
+ * Registries each entry can inject. Gates are live server-side, slots are live
+ * client-side; the entry that does not own a registry leaves it undefined and
+ * the bootstrap supplies a no-op sink so a plugin's single `register(ctx)` can
+ * call both without the wrong-env one taking effect. `env` is set by the entry
+ * (`"server"` from entry.server, `"client"` from entry.client) and surfaced on
+ * `ctx.env` so a plugin can branch its register() without import-time env
+ * sniffing; it defaults to `"client"` for backward compatibility.
+ */
+export interface BootstrapRegistries {
+  gates?: GateRegistry;
+  slots?: SlotRegistry;
+  env?: PluginContext["env"];
+}
+
+const noopGateRegistry: GateRegistry = {
+  register: () => {},
+};
+
+const noopSlotRegistry: SlotRegistry = {
+  register: () => {},
+};
 
 /**
  * Iteration body extracted from the generated `plugins.generated.ts`
@@ -17,12 +46,16 @@ import { formatRegistry } from "~/components/ImageViewer/state/formatRegistry";
  *   `FormatRegistry` is scoped to the plugin's name; cross-plugin
  *   registration of the same extension throws DuplicateRegistrationError.
  * - A failing `register()` is caught and logged; subsequent plugins
- *   still run (SDS-CY-010403 error containment).
+ *   still run (error containment).
  */
 export async function bootstrapPluginsCore(
   plugins: ReadonlyArray<CytarioPlugin>,
   logger: Logger,
+  registries?: BootstrapRegistries,
 ): Promise<void> {
+  const gates = registries?.gates ?? noopGateRegistry;
+  const slots = registries?.slots ?? noopSlotRegistry;
+  const env: PluginContext["env"] = registries?.env ?? "client";
   for (const plugin of plugins) {
     try {
       assertApiCompatible(plugin, hostApiVersion);
@@ -42,6 +75,9 @@ export async function bootstrapPluginsCore(
     const ctx: PluginContext = {
       logger,
       formats: formatRegistry.scopedFor(plugin.name),
+      gates,
+      slots,
+      env,
     };
 
     try {

--- a/app/plugins.generated.ts
+++ b/app/plugins.generated.ts
@@ -3,6 +3,7 @@
 // See README.md "Plugin model" for the contract.
 
 import type { CytarioPlugin, Logger } from "@cytario/plugin-api";
+import type { BootstrapRegistries } from "~/lib/bootstrapPluginsCore";
 import { bootstrapPluginsCore } from "~/lib/bootstrapPluginsCore";
 
 
@@ -13,6 +14,9 @@ const plugins: ReadonlyArray<CytarioPlugin> = [
 
 // Built-in formats register inside ViewerStoreContext (client-only).
 // Not imported here — viv/geotiff would break the SSR bundle.
-export function bootstrapPlugins(logger: Logger): Promise<void> {
-  return bootstrapPluginsCore(plugins, logger);
+export function bootstrapPlugins(
+  logger: Logger,
+  registries?: BootstrapRegistries,
+): Promise<void> {
+  return bootstrapPluginsCore(plugins, logger, registries);
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -189,7 +189,21 @@ export function ErrorBoundary() {
 
   if (isRouteErrorResponse(error)) {
     title = `${error.status} ${error.statusText}`;
-    message = error.data ?? "An error occurred while processing your request.";
+    // `error.data` is the parsed response body: a string for a thrown
+    // text/redirect, or an object for a JSON deny (`{ error }`). Render the
+    // string message in both cases — never an object (React would throw).
+    const data: unknown = error.data;
+    if (typeof data === "string") {
+      message = data;
+    } else if (
+      data &&
+      typeof data === "object" &&
+      typeof (data as { error?: unknown }).error === "string"
+    ) {
+      message = (data as { error: string }).error;
+    } else {
+      message = "An error occurred while processing your request.";
+    }
   } else if (error instanceof Error) {
     // Log full error but show only the generic message to avoid leaking
     // session IDs, endpoints, or stack traces to the client.

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -189,9 +189,8 @@ export function ErrorBoundary() {
 
   if (isRouteErrorResponse(error)) {
     title = `${error.status} ${error.statusText}`;
-    // `error.data` is the parsed response body: a string for a thrown
-    // text/redirect, or an object for a JSON deny (`{ error }`). Render the
-    // string message in both cases — never an object (React would throw).
+    // `error.data` may be a string or a JSON object (e.g. a gate deny's
+    // `{ error }`). Extract a string — rendering an object would throw.
     const data: unknown = error.data;
     if (typeof data === "string") {
       message = data;

--- a/app/routes/layouts/__tests__/protected.layout.test.ts
+++ b/app/routes/layouts/__tests__/protected.layout.test.ts
@@ -45,7 +45,7 @@ describe("protected layout loader", () => {
     const data = await runLoader(
       mock.user({
         organization: "testcorp",
-        organizationAttributes: { subscription_status: "active" },
+        organizationAttributes: { subscription_status: ["active"] },
         groups: ["testcorp/lab"],
         adminScopes: ["*"],
       }),
@@ -53,7 +53,7 @@ describe("protected layout loader", () => {
 
     expect(data.identity).toEqual({
       organization: "testcorp",
-      organizationAttributes: { subscription_status: "active" },
+      organizationAttributes: { subscription_status: ["active"] },
       groups: ["testcorp/lab"],
       adminScopes: ["*"],
     });

--- a/app/routes/layouts/__tests__/protected.layout.test.ts
+++ b/app/routes/layouts/__tests__/protected.layout.test.ts
@@ -57,6 +57,14 @@ describe("protected layout loader", () => {
       groups: ["testcorp/lab"],
       adminScopes: ["*"],
     });
+    // Pin the exact key-set so a regressed projection (e.g. a spread of the
+    // full UserProfile) is caught even if the values happen to match.
+    expect(Object.keys(data.identity).sort()).toEqual([
+      "adminScopes",
+      "groups",
+      "organization",
+      "organizationAttributes",
+    ]);
   });
 
   test("does not leak PII or tokens to the client payload", async () => {

--- a/app/routes/layouts/__tests__/protected.layout.test.ts
+++ b/app/routes/layouts/__tests__/protected.layout.test.ts
@@ -1,0 +1,73 @@
+import { createContext } from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { type SessionData } from "~/.server/auth/sessionStorage";
+import mock from "~/utils/__tests__/__mocks__";
+
+vi.mock("~/.server/auth/authMiddleware", () => ({
+  authContext: createContext<Partial<SessionData>>(),
+  authMiddleware: vi.fn(async (_ctx, next) => next()),
+}));
+
+const { authContext } = await import("~/.server/auth/authMiddleware");
+const { loader } = await import("~/routes/layouts/protected.layout");
+
+const buildContext = (user = mock.user()) => ({
+  get: vi.fn((ctx) => {
+    if (ctx === authContext) {
+      return {
+        user,
+        connectionConfigs: [],
+        credentials: { "test-conn": mock.credentials() },
+      };
+    }
+    return undefined;
+  }),
+});
+
+const runLoader = (user = mock.user()) => {
+  const request = new Request("http://localhost/");
+  return loader({
+    request,
+    params: {},
+    context: buildContext(user) as never,
+    unstable_pattern: "",
+    unstable_url: new URL(request.url),
+  });
+};
+
+describe("protected layout loader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns the Identity projection", async () => {
+    const data = await runLoader(
+      mock.user({
+        organization: "testcorp",
+        organizationAttributes: { subscription_status: "active" },
+        groups: ["testcorp/lab"],
+        adminScopes: ["*"],
+      }),
+    );
+
+    expect(data.identity).toEqual({
+      organization: "testcorp",
+      organizationAttributes: { subscription_status: "active" },
+      groups: ["testcorp/lab"],
+      adminScopes: ["*"],
+    });
+  });
+
+  test("does not leak PII or tokens to the client payload", async () => {
+    const data = await runLoader();
+
+    expect(data.identity).not.toHaveProperty("name");
+    expect(data.identity).not.toHaveProperty("email");
+    expect(data.identity).not.toHaveProperty("preferred_username");
+    expect(data.identity).not.toHaveProperty("policy");
+    expect(data.identity).not.toHaveProperty("sub");
+    expect(data).not.toHaveProperty("user");
+    expect(data).not.toHaveProperty("authTokens");
+  });
+});

--- a/app/routes/layouts/protected.layout.tsx
+++ b/app/routes/layouts/protected.layout.tsx
@@ -7,6 +7,8 @@ import {
 
 import { ModalOutlet } from "./ModalOutlet";
 import { authContext, authMiddleware } from "~/.server/auth/authMiddleware";
+import { toIdentity } from "~/.server/auth/getUserInfo";
+import { PluginSlots } from "~/components/PluginSlots";
 import { useInitConnections } from "~/hooks/useInitConnections";
 
 export const middleware = [authMiddleware];
@@ -16,8 +18,10 @@ export const middleware = [authMiddleware];
 export const headers = () => ({ "Cache-Control": "no-store, private" });
 
 export const loader = async ({ context }: LoaderFunctionArgs) => {
-  const { connectionConfigs, credentials } = context.get(authContext);
-  return { connectionConfigs, credentials };
+  const { connectionConfigs, credentials, user } = context.get(authContext);
+  // Projection only — never the raw UserProfile, tokens, or credentials cross
+  // to the client slot props.
+  return { connectionConfigs, credentials, identity: toIdentity(user) };
 };
 
 // Identity clientLoader — see `app/root.tsx`; works around RR's bulk-fetch
@@ -26,15 +30,19 @@ export const clientLoader = ({ serverLoader }: ClientLoaderFunctionArgs) =>
   serverLoader<typeof loader>();
 
 export default function ProtectedLayout() {
-  const { connectionConfigs, credentials } = useLoaderData<typeof loader>();
+  const { connectionConfigs, credentials, identity } = useLoaderData<typeof loader>();
   useInitConnections(connectionConfigs, credentials);
 
   return (
-    <div className="flex h-full">
-      <div className="flex-1 overflow-x-hidden overflow-y-auto">
-        <Outlet />
+    <div className="flex h-full flex-col">
+      <PluginSlots name="app-banner" identity={identity} />
+      <div className="flex flex-1 min-h-0">
+        <div className="flex-1 overflow-x-hidden overflow-y-auto">
+          <Outlet />
+        </div>
+        <ModalOutlet />
       </div>
-      <ModalOutlet />
+      <PluginSlots name="app-overlay" identity={identity} />
     </div>
   );
 }

--- a/app/utils/__tests__/__mocks__.ts
+++ b/app/utils/__tests__/__mocks__.ts
@@ -58,6 +58,7 @@ const mock = {
     email: "string",
     policy: ["default-policy"],
     organization: "org1",
+    organizationAttributes: {},
     groups: ["org1/lab"],
     adminScopes: ["org1/lab"],
     ...overrides,

--- a/bin-src/__tests__/__snapshots__/codegen.test.ts.snap
+++ b/bin-src/__tests__/__snapshots__/codegen.test.ts.snap
@@ -6,6 +6,7 @@ exports[`generatePluginsModule > empty plugin list produces a module with no sta
 // See README.md "Plugin model" for the contract.
 
 import type { CytarioPlugin, Logger } from "@cytario/plugin-api";
+import type { BootstrapRegistries } from "~/lib/bootstrapPluginsCore";
 import { bootstrapPluginsCore } from "~/lib/bootstrapPluginsCore";
 
 
@@ -16,8 +17,11 @@ const plugins: ReadonlyArray<CytarioPlugin> = [
 
 // Built-in formats register inside ViewerStoreContext (client-only).
 // Not imported here — viv/geotiff would break the SSR bundle.
-export function bootstrapPlugins(logger: Logger): Promise<void> {
-  return bootstrapPluginsCore(plugins, logger);
+export function bootstrapPlugins(
+  logger: Logger,
+  registries?: BootstrapRegistries,
+): Promise<void> {
+  return bootstrapPluginsCore(plugins, logger, registries);
 }
 "
 `;
@@ -28,6 +32,7 @@ exports[`generatePluginsModule > single plugin: identifier is index-derived (plu
 // See README.md "Plugin model" for the contract.
 
 import type { CytarioPlugin, Logger } from "@cytario/plugin-api";
+import type { BootstrapRegistries } from "~/lib/bootstrapPluginsCore";
 import { bootstrapPluginsCore } from "~/lib/bootstrapPluginsCore";
 
 import plugin_0 from "@cytario/czi-loader";
@@ -39,8 +44,11 @@ const plugins: ReadonlyArray<CytarioPlugin> = [
 
 // Built-in formats register inside ViewerStoreContext (client-only).
 // Not imported here — viv/geotiff would break the SSR bundle.
-export function bootstrapPlugins(logger: Logger): Promise<void> {
-  return bootstrapPluginsCore(plugins, logger);
+export function bootstrapPlugins(
+  logger: Logger,
+  registries?: BootstrapRegistries,
+): Promise<void> {
+  return bootstrapPluginsCore(plugins, logger, registries);
 }
 "
 `;

--- a/bin-src/__tests__/codegen.test.ts
+++ b/bin-src/__tests__/codegen.test.ts
@@ -76,6 +76,6 @@ describe("generatePluginsModule", () => {
     // bind the static plugin list to that helper.
     const out = generatePluginsModule({ plugins: ["any-plugin"] });
     expect(out).toContain('import { bootstrapPluginsCore } from "~/lib/bootstrapPluginsCore";');
-    expect(out).toMatch(/return bootstrapPluginsCore\(plugins, logger\);/);
+    expect(out).toMatch(/return bootstrapPluginsCore\(plugins, logger, registries\);/);
   });
 });

--- a/bin-src/codegen.ts
+++ b/bin-src/codegen.ts
@@ -44,6 +44,7 @@ export function generatePluginsModule(input: CodegenInput): string {
 // See README.md "Plugin model" for the contract.
 
 import type { CytarioPlugin, Logger } from "@cytario/plugin-api";
+import type { BootstrapRegistries } from "~/lib/bootstrapPluginsCore";
 import { bootstrapPluginsCore } from "~/lib/bootstrapPluginsCore";
 ${imports ? "\n" + imports : ""}
 
@@ -54,8 +55,11 @@ ${list}
 
 // Built-in formats register inside ViewerStoreContext (client-only).
 // Not imported here — viv/geotiff would break the SSR bundle.
-export function bootstrapPlugins(logger: Logger): Promise<void> {
-  return bootstrapPluginsCore(plugins, logger);
+export function bootstrapPlugins(
+  logger: Logger,
+  registries?: BootstrapRegistries,
+): Promise<void> {
+  return bootstrapPluginsCore(plugins, logger, registries);
 }
 `;
 }

--- a/packages/plugin-api/src/__tests__/apiVersion.test.ts
+++ b/packages/plugin-api/src/__tests__/apiVersion.test.ts
@@ -5,6 +5,18 @@ describe("assertApiCompatible", () => {
     expect(() => assertApiCompatible({ name: "ok", apiVersion: "^1.0.0" }, "1.0.0")).not.toThrow();
   });
 
+  test("accepts a plugin targeting the 2.2 gate/slot surface on a 2.2 host", () => {
+    expect(() =>
+      assertApiCompatible({ name: "saas-plugin", apiVersion: "^2.2.0" }, "2.2.0"),
+    ).not.toThrow();
+  });
+
+  test("rejects a 2.2-targeting plugin on a 2.1 host (floor not yet met)", () => {
+    expect(() =>
+      assertApiCompatible({ name: "saas-plugin", apiVersion: "^2.2.0" }, "2.1.0"),
+    ).toThrow(IncompatiblePluginError);
+  });
+
   test("throws IncompatiblePluginError for major mismatch", () => {
     expect(() => assertApiCompatible({ name: "old", apiVersion: "^2.0.0" }, "1.0.0")).toThrow(
       IncompatiblePluginError,

--- a/packages/plugin-api/src/__tests__/gatesSlotsSurface.test.ts
+++ b/packages/plugin-api/src/__tests__/gatesSlotsSurface.test.ts
@@ -1,0 +1,125 @@
+import type {
+  CytarioPlugin,
+  GateOutcome,
+  GateRegistry,
+  GateRequest,
+  Identity,
+  PluginContext,
+  SessionGate,
+  SlotName,
+  SlotProps,
+  SlotRegistry,
+} from "../index";
+
+describe("auth / gates / slots surface", () => {
+  test("Identity carries org alias, opaque attrs, groups and admin scopes", () => {
+    const identity: Identity = {
+      organization: "testcorp",
+      organizationAttributes: { subscription_status: "active" },
+      groups: ["lab/team-a"],
+      adminScopes: ["*"],
+    };
+    expect(identity.organization).toBe("testcorp");
+    expect(identity.organizationAttributes["subscription_status"]).toBe("active");
+    expect(identity.groups).toEqual(["lab/team-a"]);
+    expect(identity.adminScopes).toEqual(["*"]);
+  });
+
+  test("Identity organization is optional for zero-org sessions", () => {
+    const identity: Identity = {
+      organizationAttributes: {},
+      groups: [],
+      adminScopes: [],
+    };
+    expect(identity.organization).toBeUndefined();
+  });
+
+  test("GateRequest threads url, uppercase method and identity", () => {
+    const req: GateRequest = {
+      url: "https://app.cytario.com/images/1",
+      method: "POST",
+      identity: { organizationAttributes: {}, groups: [], adminScopes: [] },
+    };
+    expect(req.method).toBe("POST");
+  });
+
+  test("SessionGate may return a sync or async outcome", async () => {
+    const sync: SessionGate = () => ({ kind: "continue" });
+    const async: SessionGate = async () => ({ kind: "redirect", url: "/onboarding" });
+    const req: GateRequest = {
+      url: "/",
+      method: "GET",
+      identity: { organizationAttributes: {}, groups: [], adminScopes: [] },
+    };
+    expect(sync(req)).toEqual({ kind: "continue" });
+    await expect(async(req)).resolves.toEqual({ kind: "redirect", url: "/onboarding" });
+  });
+
+  test("GateOutcome is exhaustive over kind", () => {
+    const render = (outcome: GateOutcome): string => {
+      switch (outcome.kind) {
+        case "continue":
+          return "continue";
+        case "redirect":
+          return `redirect:${outcome.url}`;
+        case "deny":
+          return `deny:${outcome.status ?? 403}:${outcome.message ?? ""}`;
+        default: {
+          const unreachable: never = outcome;
+          return unreachable;
+        }
+      }
+    };
+    expect(render({ kind: "continue" })).toBe("continue");
+    expect(render({ kind: "redirect", url: "/x" })).toBe("redirect:/x");
+    expect(render({ kind: "deny" })).toBe("deny:403:");
+    expect(render({ kind: "deny", status: 401, message: "nope" })).toBe("deny:401:nope");
+  });
+
+  test("a GateRegistry accepts a SessionGate", () => {
+    const registered: SessionGate[] = [];
+    const registry: GateRegistry = {
+      register(gate) {
+        registered.push(gate);
+      },
+    };
+    registry.register(() => ({ kind: "continue" }));
+    expect(registered).toHaveLength(1);
+  });
+
+  test("SlotRegistry appends components for the known slot names", () => {
+    const calls: Array<{ slot: SlotName; component: unknown }> = [];
+    const registry: SlotRegistry = {
+      register(slot, component) {
+        calls.push({ slot, component });
+      },
+    };
+    const Overlay = () => null;
+    const Banner = () => null;
+    registry.register("app-overlay", Overlay);
+    registry.register("app-banner", Banner);
+    expect(calls.map((c) => c.slot)).toEqual(["app-overlay", "app-banner"]);
+  });
+
+  test("SlotProps carries the Identity projection", () => {
+    const props: SlotProps = {
+      identity: { organizationAttributes: {}, groups: [], adminScopes: [] },
+    };
+    expect(props.identity.groups).toEqual([]);
+  });
+
+  test("a CytarioPlugin can register a gate and slots via PluginContext", () => {
+    const plugin = {
+      name: "surface-probe",
+      apiVersion: "^2.2.0",
+      register(ctx: PluginContext) {
+        if (ctx.env === "server") {
+          ctx.gates.register(() => ({ kind: "continue" }));
+        } else {
+          ctx.slots.register("app-banner", () => null);
+        }
+      },
+    } satisfies CytarioPlugin;
+    expect(plugin.name).toBe("surface-probe");
+  });
+});

--- a/packages/plugin-api/src/__tests__/gatesSlotsSurface.test.ts
+++ b/packages/plugin-api/src/__tests__/gatesSlotsSurface.test.ts
@@ -15,12 +15,12 @@ describe("auth / gates / slots surface", () => {
   test("Identity carries org alias, opaque attrs, groups and admin scopes", () => {
     const identity: Identity = {
       organization: "testcorp",
-      organizationAttributes: { subscription_status: "active" },
+      organizationAttributes: { subscription_status: ["active"] },
       groups: ["lab/team-a"],
       adminScopes: ["*"],
     };
     expect(identity.organization).toBe("testcorp");
-    expect(identity.organizationAttributes["subscription_status"]).toBe("active");
+    expect(identity.organizationAttributes["subscription_status"]).toEqual(["active"]);
     expect(identity.groups).toEqual(["lab/team-a"]);
     expect(identity.adminScopes).toEqual(["*"]);
   });

--- a/packages/plugin-api/src/auth.ts
+++ b/packages/plugin-api/src/auth.ts
@@ -1,0 +1,23 @@
+// Read-only identity projection — host-independent. Carries the tenant-relevant
+// subset of the host's user profile and deliberately omits raw PII (name, email,
+// preferred_username, policy): the client slot path ships Identity to the
+// browser on every protected navigation, and nothing in the overlay/banner needs
+// PII. The host treats organizationAttributes as an opaque string map and assigns
+// no meaning to its keys; the consuming plugin owns that vocabulary.
+
+/** Read-only identity view derived from the verified token. */
+export interface Identity {
+  /** Active Keycloak organization alias. Undefined ⇒ zero-org session. */
+  organization?: string;
+  /**
+   * Keycloak Organization attributes mirrored into the token, as an opaque
+   * string map. A generic Keycloak Organizations primitive — the host does not
+   * interpret keys. The consuming plugin reads its own keys out of this map and
+   * narrows them to its own types; the host assigns no meaning to them.
+   */
+  organizationAttributes: Readonly<Record<string, string>>;
+  /** Tenant group paths the user belongs to (admin subgroups excluded). */
+  groups: readonly string[];
+  /** Scopes the user administers, incl. the `*` (`ORG_ROOT_SCOPE`) sentinel. */
+  adminScopes: readonly string[];
+}

--- a/packages/plugin-api/src/auth.ts
+++ b/packages/plugin-api/src/auth.ts
@@ -11,12 +11,14 @@ export interface Identity {
   organization?: string;
   /**
    * Keycloak Organization attributes mirrored into the token, as an opaque
-   * string map. A generic Keycloak Organizations primitive — the host does not
-   * interpret keys. The consuming plugin reads its own keys out of this map and
-   * narrows them to its own types; the host assigns no meaning to them.
-   * `Readonly` at the type level; the host also freezes the map at runtime.
+   * multivalued map (Keycloak attributes are arrays). A generic Keycloak
+   * Organizations primitive — the host does not interpret keys and does not
+   * collapse values. The consuming plugin reads its own keys out of this map
+   * and narrows them to its own types; a single-valued attribute is read as
+   * `[0]`. `Readonly` at the type level; the host also freezes the map and its
+   * arrays at runtime.
    */
-  organizationAttributes: Readonly<Record<string, string>>;
+  organizationAttributes: Readonly<Record<string, readonly string[]>>;
   /** Tenant group paths the user belongs to (admin subgroups excluded). */
   groups: readonly string[];
   /** Scopes the user administers, incl. the `*` (`ORG_ROOT_SCOPE`) sentinel. */

--- a/packages/plugin-api/src/auth.ts
+++ b/packages/plugin-api/src/auth.ts
@@ -14,6 +14,7 @@ export interface Identity {
    * string map. A generic Keycloak Organizations primitive — the host does not
    * interpret keys. The consuming plugin reads its own keys out of this map and
    * narrows them to its own types; the host assigns no meaning to them.
+   * `Readonly` at the type level; the host also freezes the map at runtime.
    */
   organizationAttributes: Readonly<Record<string, string>>;
   /** Tenant group paths the user belongs to (admin subgroups excluded). */

--- a/packages/plugin-api/src/auth.ts
+++ b/packages/plugin-api/src/auth.ts
@@ -1,22 +1,15 @@
-// Read-only identity projection — host-independent. Carries the tenant-relevant
-// subset of the host's user profile and deliberately omits raw PII (name, email,
-// preferred_username, policy): the client slot path ships Identity to the
-// browser on every protected navigation, and nothing in the overlay/banner needs
-// PII. The host treats organizationAttributes as an opaque string map and assigns
-// no meaning to its keys; the consuming plugin owns that vocabulary.
+// Read-only identity projection handed to plugins. Omits PII (name/email/etc.)
+// because it crosses to the browser via slot props. organizationAttributes is
+// opaque: the host assigns no meaning to keys; the plugin owns that vocabulary.
 
 /** Read-only identity view derived from the verified token. */
 export interface Identity {
   /** Active Keycloak organization alias. Undefined ⇒ zero-org session. */
   organization?: string;
   /**
-   * Keycloak Organization attributes mirrored into the token, as an opaque
-   * multivalued map (Keycloak attributes are arrays). A generic Keycloak
-   * Organizations primitive — the host does not interpret keys and does not
-   * collapse values. The consuming plugin reads its own keys out of this map
-   * and narrows them to its own types; a single-valued attribute is read as
-   * `[0]`. `Readonly` at the type level; the host also freezes the map and its
-   * arrays at runtime.
+   * Opaque, multivalued Keycloak org attributes (Keycloak attrs are arrays).
+   * The host neither interprets keys nor collapses values; read `[0]` for a
+   * single-valued attribute. Frozen at runtime.
    */
   organizationAttributes: Readonly<Record<string, readonly string[]>>;
   /** Tenant group paths the user belongs to (admin subgroups excluded). */

--- a/packages/plugin-api/src/gates.ts
+++ b/packages/plugin-api/src/gates.ts
@@ -3,7 +3,9 @@ import type { Identity } from "./auth";
 export type GateOutcome =
   | { kind: "continue" }
   // For navigations — e.g. no-org onboarding or a plugin-defined hard-stop.
-  // Absolute or app-relative; host trusts plugin code.
+  // Absolute or app-relative. The host does NOT validate this URL — gate
+  // authors must not interpolate user-controlled input here without their own
+  // validation (open-redirect risk).
   | { kind: "redirect"; url: string }
   // For blocking a single request without navigating — e.g. making a workspace
   // read-only by denying unsafe methods. Host returns a Response with

--- a/packages/plugin-api/src/gates.ts
+++ b/packages/plugin-api/src/gates.ts
@@ -1,0 +1,25 @@
+import type { Identity } from "./auth";
+
+export type GateOutcome =
+  | { kind: "continue" }
+  // For navigations — e.g. no-org onboarding or a plugin-defined hard-stop.
+  // Absolute or app-relative; host trusts plugin code.
+  | { kind: "redirect"; url: string }
+  // For blocking a single request without navigating — e.g. making a workspace
+  // read-only by denying unsafe methods. Host returns a Response with
+  // this status (default 403) and a JSON `{ error: message }` body the UI
+  // surfaces as a toast. Intended for unsafe methods; denying a GET yields an
+  // error page (the ErrorBoundary), so gates should branch on `method`.
+  | { kind: "deny"; status?: number; message?: string };
+
+export interface GateRequest {
+  url: string; // request URL
+  method: string; // HTTP method, uppercase — lets a gate treat writes differently from reads
+  identity: Identity; // org, attrs, groups, scopes (plugin interprets the attrs itself)
+}
+
+export type SessionGate = (req: GateRequest) => GateOutcome | Promise<GateOutcome>;
+
+export interface GateRegistry {
+  register(gate: SessionGate): void;
+}

--- a/packages/plugin-api/src/gates.ts
+++ b/packages/plugin-api/src/gates.ts
@@ -2,10 +2,8 @@ import type { Identity } from "./auth";
 
 export type GateOutcome =
   | { kind: "continue" }
-  // For navigations — e.g. no-org onboarding or a plugin-defined hard-stop.
-  // Absolute or app-relative. The host does NOT validate this URL — gate
-  // authors must not interpolate user-controlled input here without their own
-  // validation (open-redirect risk).
+  // Navigation redirect (absolute or app-relative). Host does NOT validate the
+  // URL — don't interpolate user input here (open-redirect risk).
   | { kind: "redirect"; url: string }
   // For blocking a single request without navigating — e.g. making a workspace
   // read-only by denying unsafe methods. Host returns a Response with

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -24,6 +24,9 @@ export type {
   TileSelection,
 } from "./image";
 export { normalizePixelType } from "./image";
+export type { Identity } from "./auth";
+export type { GateOutcome, GateRequest, SessionGate, GateRegistry } from "./gates";
+export type { SlotName, SlotProps, SlotRegistry } from "./slots";
 
 export { assertApiCompatible, IncompatiblePluginError } from "./apiVersion";
 export { sanitizeHeaders } from "./headers";

--- a/packages/plugin-api/src/plugin.ts
+++ b/packages/plugin-api/src/plugin.ts
@@ -1,4 +1,6 @@
 import type { FormatRegistry } from "./format";
+import type { GateRegistry } from "./gates";
+import type { SlotRegistry } from "./slots";
 
 export interface Logger {
   debug(msg: string, fields?: Record<string, unknown>): void;
@@ -9,7 +11,11 @@ export interface Logger {
 
 export interface PluginContext {
   formats: FormatRegistry;
+  gates: GateRegistry; // live server-side; no-op sink client-side
+  slots: SlotRegistry; // live client-side; no-op sink server-side
   logger: Logger;
+  /** Lets a plugin branch its register() without import-time env sniffing. */
+  env: "server" | "client";
 }
 
 export interface CytarioPlugin {

--- a/packages/plugin-api/src/slots.ts
+++ b/packages/plugin-api/src/slots.ts
@@ -1,0 +1,21 @@
+import type { Identity } from "./auth";
+
+/** Host-defined mount points. v1 surface. */
+export type SlotName = "app-overlay" | "app-banner";
+
+/** Props the host passes to every slot component (client-only). */
+export interface SlotProps {
+  identity: Identity;
+}
+
+export interface SlotRegistry {
+  // `component` is a React component type; typed as unknown here to keep
+  // plugin-api React-free at the type level (matches the framework-agnostic
+  // image.ts surface). Host casts to ComponentType<SlotProps>.
+  //
+  // Slots are multi-owner: `register` appends rather than replacing, so
+  // multiple plugins may mount into the same slot. The host renders all
+  // registered components in registration order. The registry implementation
+  // lives in the host; this is the contract type only.
+  register(slot: SlotName, component: unknown): void;
+}


### PR DESCRIPTION
## Summary

Adds the **plugin-registry extension points** in `@cytario/plugin-api` (2.1.0 → 2.2.0, additive) plus the cytario-web host wiring that lets a closed-source SaaS plugin drive onboarding redirect, a welcome overlay, and subscription gating — without any billing vocabulary entering the public, AGPL host.

> **`C-225` is referenced bare (not bracketed) on purpose.** This PR ships the host-side extension surface only. The feature is not delivered until `@cytario/saas-plugin` is built and wired into the cytario-ee build, so merging this must **not** transition the Plane work item. The bracket belongs on the cytario-ee PR that completes the flow.

## What's in this PR

**`@cytario/plugin-api` (minor, additive):**
- `Identity` — billing-agnostic identity view: `organization`, opaque `organizationAttributes`, `groups`, `adminScopes`. No PII, no subscription vocabulary.
- `GateRegistry` / `SessionGate` / `GateOutcome` (`continue` / `redirect` / `deny{status,message}`), `GateRequest` (`url`, `method`, `identity`).
- `SlotRegistry` / `SlotName` / `SlotProps` — React-free at the type level (`component: unknown`; host owns the cast).
- `PluginContext` extended with `gates`, `slots`, `env` — existing format plugins are unaffected.

**Host wiring (cytario-web):**
- `getUserInfo` parses Keycloak org attributes into an opaque, frozen `organizationAttributes` map (drops `id`/`groups`, collapses multivalued to first value, drops email-shaped + oversized values — defence-in-depth); `toIdentity` projects to the PII-free `Identity`.
- Server-only `pluginGates` registry + `runGates` (first non-`continue` wins; throwing/malformed/rejecting gate → fail-open `continue`).
- `authMiddleware` consults the gate before any tenant-scoped query; `redirect` → redirect, `deny` → JSON 403, `continue` + no-org → built-in `/onboarding` fallback (on-prem behaviour preserved).
- Client multi-owner `slotRegistry` + SSR-safe `PluginSlots` (via `ClientOnly`); `protected.layout` returns the `Identity` projection and mounts the `app-overlay` / `app-banner` slots.
- Bootstrap injects the gate registry server-side and the slot registry client-side (no-op sink for the absent env); codegen forwards the optional `registries` arg.

## Security boundary

- Host stays **billing-agnostic** — zero `subscription`/`stripe`/`past_due` vocabulary in `app/` or `packages/`. The plugin owns all policy.
- PII never crosses to the client: `toIdentity` drops `name`/`email`/`preferred_username`/`policy`; raw `UserProfile`/tokens/credentials never enter gate input or slot props.
- Fail-open subscription gate is deliberately asymmetric with the fail-closed tenant boundary; the no-org short-circuit still runs before any tenant read.
- Slots render client-only (no plugin markup in SSR HTML, CSP unchanged). Session cookie stays host-scoped (no `Domain`) — guards shared-realm isolation with `admin.cytario.com`.

## Not in this PR (separate repos / follow-ups)

- `@cytario/saas-plugin` (closed-source, its own repo) and its cytario-ee wiring — the bracketed, ticket-closing change.
- Portal-side requirement forbidding PII/payment-identifier attributes on Keycloak org attrs (primary control for the host-side hygiene here).
- `version.ts` stays `2.1.0` in-tree; semantic-release emits `2.2.0` + the `plugin-api-v2.2.0` tag from the `feat(plugin-api)` commit.

## Testing

- `npm run typecheck`: clean.
- Full vitest suite green (the only failures are an environment sandbox restriction on a subprocess-spawning codegen test, which passes locally).
- New coverage: gate ordering/containment, org-attr hygiene + frozen map, PII-free projection + exact key-set, multi-owner slots, SSR-null, deny-on-POST vs GET-pass, `^2.2.0` apiVersion floor, session-cookie host-scoping.

Every commit passes the full pre-commit hook (lint + typecheck + format).
