### PR TITLE
fix(viewer): retry tile fetch with cache bypass on browser cache-op failure [C-237]

### DIFF
--- a/app/utils/__tests__/signedFetch.test.ts
+++ b/app/utils/__tests__/signedFetch.test.ts
@@ -276,7 +276,8 @@ describe("createSignedFetch", () => {
   });
 
   test("throws CorsLikelyError on Chrome-style 'Failed to fetch' TypeError", async () => {
-    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    // Genuine CORS failures reject the retry too — both attempts fail.
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
     const sf = createSignedFetch(() => mockCredentials, mockConfig);
     await expect(sf("https://bucket.s3.eu-central-1.amazonaws.com/key")).rejects.toBeInstanceOf(
       CorsLikelyError,
@@ -284,7 +285,7 @@ describe("createSignedFetch", () => {
   });
 
   test("throws CorsLikelyError on WebKit-style 'Load failed' TypeError", async () => {
-    mockFetch.mockRejectedValueOnce(new TypeError("Load failed"));
+    mockFetch.mockRejectedValue(new TypeError("Load failed"));
     const sf = createSignedFetch(() => mockCredentials, mockConfig);
     await expect(sf("https://bucket.s3.eu-central-1.amazonaws.com/key")).rejects.toBeInstanceOf(
       CorsLikelyError,
@@ -292,24 +293,67 @@ describe("createSignedFetch", () => {
   });
 
   test("throws CorsLikelyError on Firefox-style NetworkError TypeError", async () => {
-    mockFetch.mockRejectedValueOnce(
-      new TypeError("NetworkError when attempting to fetch resource."),
-    );
+    mockFetch.mockRejectedValue(new TypeError("NetworkError when attempting to fetch resource."));
     const sf = createSignedFetch(() => mockCredentials, mockConfig);
     await expect(sf("https://bucket.s3.eu-central-1.amazonaws.com/key")).rejects.toBeInstanceOf(
       CorsLikelyError,
     );
   });
 
-  test("passes through non-CORS errors unchanged", async () => {
+  test("passes through non-CORS errors unchanged without retrying", async () => {
     const original = new Error("some other failure");
     mockFetch.mockRejectedValueOnce(original);
     const sf = createSignedFetch(() => mockCredentials, mockConfig);
     await expect(sf("https://bucket.s3.eu-central-1.amazonaws.com/key")).rejects.toBe(original);
+    // A non-TypeError is not a cache-op candidate — no retry.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("recovers from ERR_CACHE_OPERATION_NOT_SUPPORTED by retrying with cache: no-store", async () => {
+    // Chrome surfaces the cache-op failure as a generic "Failed to fetch"
+    // TypeError — indistinguishable from CORS until the retry succeeds.
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    mockFetch.mockResolvedValueOnce(new Response("tile-bytes"));
+    const sf = createSignedFetch(() => mockCredentials, mockConfig);
+
+    const res = await sf("https://bucket.s3.eu-central-1.amazonaws.com/image.ome.tif", {
+      headers: { Range: "bytes=0-1024" },
+    });
+    expect(await res.text()).toBe("tile-bytes");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Retry bypasses the browser disk cache but keeps the signed URL
+    // (response-cache-control intact for CDN/SW).
+    const [retryUrl, retryInit] = mockFetch.mock.calls[1];
+    expect(retryInit.cache).toBe("no-store");
+    expect(retryUrl).toContain("response-cache-control=private%2C%20max-age%3D604800");
+    expect(retryInit.headers).toHaveProperty("Range", "bytes=0-1024");
+
+    // First attempt used the normal (cacheable) fetch.
+    const [, firstInit] = mockFetch.mock.calls[0];
+    expect(firstInit.cache).toBeUndefined();
+  });
+
+  test("retries the cache-bypass GET at most once", async () => {
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+    const sf = createSignedFetch(() => mockCredentials, mockConfig);
+    await expect(sf("https://bucket.s3.eu-central-1.amazonaws.com/key")).rejects.toBeInstanceOf(
+      CorsLikelyError,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not cache-retry non-idempotent methods", async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const sf = createSignedFetch(() => mockCredentials, mockConfig);
+    await expect(
+      sf("https://bucket.s3.eu-central-1.amazonaws.com/key", { method: "POST" }),
+    ).rejects.toBeInstanceOf(CorsLikelyError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   test("CorsLikelyError carries the bucket host", async () => {
-    mockFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
     const sf = createSignedFetch(() => mockCredentials, mockConfig);
     const err = await sf("https://bucket.s3.eu-central-1.amazonaws.com/key").catch((e) => e);
     expect(err).toBeInstanceOf(CorsLikelyError);

--- a/app/utils/signedFetch.ts
+++ b/app/utils/signedFetch.ts
@@ -53,6 +53,11 @@ function isLikelyCorsFailure(error: unknown): boolean {
   );
 }
 
+function isRetriableGet(init: RequestInit): boolean {
+  const method = (init.method ?? "GET").toUpperCase();
+  return (method === "GET" || method === "HEAD") && init.cache !== "no-store";
+}
+
 async function fetchWithCorsDetection(
   url: string,
   init: RequestInit,
@@ -62,6 +67,23 @@ async function fetchWithCorsDetection(
   try {
     return await fetch(url, init);
   } catch (error) {
+    // A fetch TypeError is ambiguous: a genuine CORS/network failure and
+    // Chrome's ERR_CACHE_OPERATION_NOT_SUPPORTED (it cannot store the 206
+    // range responses our tile reads produce) both surface as "Failed to
+    // fetch". Retry the idempotent GET once bypassing the browser disk
+    // cache — the `response-cache-control` param stays on the URL, so
+    // CDN/SW caching is untouched. A cache-op failure now succeeds; a real
+    // CORS failure throws again and is reported as such.
+    if (isLikelyCorsFailure(error) && isRetriableGet(init)) {
+      try {
+        return await fetch(url, { ...init, cache: "no-store" });
+      } catch (retryError) {
+        if (isLikelyCorsFailure(retryError)) {
+          throw new CorsLikelyError(host, origin, retryError);
+        }
+        throw retryError;
+      }
+    }
     if (isLikelyCorsFailure(error)) {
       throw new CorsLikelyError(host, origin, error);
     }


### PR DESCRIPTION
## Background

In the OME-TIFF viewer, regions intermittently fail to render and paint as a solid block — reported as "bleaching" (a flat magenta fill, sometimes a stale blue square). DAPI renders fine above the failed region, so the image loads but individual tiles drop out. Reproduced on Ultivue demo deliverables (`ULT-2020-92-008-1.ome.tif`, `USL-2023-52702-10.ome.tif`).

## Diagnosis

Byte-range tile reads fail at the browser with `net::ERR_CACHE_OPERATION_NOT_SUPPORTED`. The rejected `fetch` propagates up the viv/geotiff.js stack (`fetch` → `getSlice` → `parseFileDirectoryAt` → `getTile`) as `AggregateError: Request failed` in `onTileError`. The tile never receives bytes, so deck.gl samples a stale/zeroed GPU texture through the channel LUT → the magenta block.

Root cause: `signedFetch.ts` injects `response-cache-control=private, max-age=604800` on every image GET. Chrome then tries to **store the 206 partial responses** from the `Range` reads; its disk cache has only partial support for sparse entries and rejects the whole request under certain cache states (hence intermittent). The HTTP cache sits in the request path — a cache-write failure *is* the request failure, no automatic network fallback.

## Fix

`ERR_CACHE_OPERATION_NOT_SUPPORTED` and a genuine CORS failure **both** surface as a `TypeError: Failed to fetch` — indistinguishable by message. So in `fetchWithCorsDetection`, retry the idempotent GET once with `cache: "no-store"` before classifying:

- cache-op failure → retry succeeds, tile renders
- real CORS failure → retry throws again → `CorsLikelyError` as before

The `response-cache-control` param stays on the URL, so CDN / service-worker caching is unaffected — only Chrome's broken local-store path is bypassed. Reactive (not proactive `no-store`), so the happy path keeps browser-disk caching.

## Tests

`signedFetch.test.ts` — 34 pass:
- Existing CORS tests switched to persistent reject (a real CORS error fails the retry too).
- New: cache-op recovery (asserts retry uses `cache: "no-store"`, keeps `response-cache-control` + `Range`), retry-at-most-once, no-retry on non-idempotent `POST`, no-retry on non-`TypeError`.

lint + typecheck + format:check clean.

Closes [C-237].