### PR TITLE
fix(c-242): renew STS credentials and keep Keycloak session alive

### DIFF
--- a/app/.server/auth/getSessionCredentials.ts
+++ b/app/.server/auth/getSessionCredentials.ts
@@ -4,6 +4,7 @@ import { buildSessionPolicy } from "./sessionPolicy";
 import { type ConnectionsCredentials, type SessionData } from "./sessionStorage";
 import { ConnectionConfig } from "~/.generated/client";
 import { createLabel } from "~/.server/logging";
+import { STS_STALENESS_BUFFER_MS } from "~/utils/credentialsRefresh";
 import { getS3ProviderConfig } from "~/utils/s3Provider";
 
 const label = createLabel("credentials", "cyan");
@@ -11,9 +12,7 @@ const label = createLabel("credentials", "cyan");
 export const isValidCredentials = (credentials?: { Expiration?: Date }): boolean => {
   if (!credentials?.Expiration) return false;
 
-  // Check if credentials are expired (with 5 minute buffer)
-  const bufferMs = 5 * 60 * 1000; // 5 minutes
-  return Date.now() < new Date(credentials.Expiration).getTime() - bufferMs;
+  return Date.now() < new Date(credentials.Expiration).getTime() - STS_STALENESS_BUFFER_MS;
 };
 
 /**

--- a/app/components/DirectoryView/DirectoryViewGrid.tsx
+++ b/app/components/DirectoryView/DirectoryViewGrid.tsx
@@ -8,7 +8,7 @@ import { ClientOnly } from "~/components/ClientOnly";
 import { GridItem } from "~/components/DirectoryView/GridItem";
 import { ProviderPill } from "~/components/Pills/ProviderPill";
 import { ScopePill } from "~/components/Pills/ScopePill";
-import { select, selectHttpsUrl } from "~/utils/connectionsStore/selectors";
+import { liveCredentials, select, selectHttpsUrl } from "~/utils/connectionsStore/selectors";
 import { useConnectionsStore } from "~/utils/connectionsStore/useConnectionsStore";
 import { isImageFile } from "~/utils/fileType";
 import { constructS3Url } from "~/utils/resourceId";
@@ -34,11 +34,7 @@ function useSignedFetch(connectionName: string) {
 
   const signedFetch = useMemo(() => {
     if (!connectionConfig) return null;
-    return createSignedFetch(
-      () => useConnectionsStore.getState().connections[connectionName]?.credentials,
-      connectionConfig,
-      connectionName,
-    );
+    return createSignedFetch(liveCredentials(connectionName), connectionConfig, connectionName);
   }, [connectionName, connectionConfig]);
 
   return { connectionConfig, signedFetch };

--- a/app/components/DirectoryView/DirectoryViewGrid.tsx
+++ b/app/components/DirectoryView/DirectoryViewGrid.tsx
@@ -37,6 +37,7 @@ function useSignedFetch(connectionName: string) {
     return createSignedFetch(
       () => useConnectionsStore.getState().connections[connectionName]?.credentials,
       connectionConfig,
+      connectionName,
     );
   }, [connectionName, connectionConfig]);
 

--- a/app/hooks/useCredentialsKeepAlive.ts
+++ b/app/hooks/useCredentialsKeepAlive.ts
@@ -1,0 +1,140 @@
+import { Credentials } from "@aws-sdk/client-sts";
+import { useEffect, useRef } from "react";
+import { useRevalidator } from "react-router";
+
+import { useConnectionsStore } from "~/utils/connectionsStore/useConnectionsStore";
+import { setCredentialsRefresher } from "~/utils/credentialsRefresh";
+
+/**
+ * Revalidate slightly inside the server's 5-minute STS staleness buffer
+ * (`isValidCredentials`) so credentials rotate before they expire, and well
+ * inside Keycloak's SSO idle timeout so the session survives long viewer
+ * stretches that produce no other server traffic (reads are browser→S3).
+ */
+const KEEP_ALIVE_INTERVAL_MS = 4 * 60 * 1000;
+
+/** How long to wait for a revalidation to land rotated credentials in the store. */
+const STORE_UPDATE_TIMEOUT_MS = 5_000;
+
+/**
+ * Resolves once the store holds credentials for `connectionName` with a
+ * different `AccessKeyId` than `previousKeyId`; `null` on timeout. The store
+ * is written by `useInitConnections` in an effect, so the update can land
+ * after the revalidation promise settles.
+ */
+const waitForRotatedCredentials = (
+  connectionName: string,
+  previousKeyId: string | undefined,
+  timeoutMs: number,
+): Promise<Credentials | null> =>
+  new Promise((resolve) => {
+    const read = () => {
+      const credentials = useConnectionsStore.getState().connections[connectionName]?.credentials;
+      return credentials && credentials.AccessKeyId !== previousKeyId ? credentials : null;
+    };
+
+    const immediate = read();
+    if (immediate) {
+      resolve(immediate);
+      return;
+    }
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      unsubscribe();
+    };
+    const unsubscribe = useConnectionsStore.subscribe(() => {
+      const rotated = read();
+      if (rotated) {
+        cleanup();
+        resolve(rotated);
+      }
+    });
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(null);
+    }, timeoutMs);
+  });
+
+/**
+ * Keeps STS credentials and the Keycloak session alive (C-242).
+ *
+ * Installs the `credentialsRefresh` refresher so the `signedFetch` /
+ * `listObjectsClient` ExpiredToken retry path can re-mint credentials: a
+ * revalidation re-runs the protected-layout loader, the auth middleware
+ * refreshes stale STS credentials (and Keycloak tokens), and
+ * `useInitConnections` lands them in the connections store.
+ *
+ * Additionally revalidates on an interval so rotation happens proactively —
+ * consumers without a retry path (DuckDB-WASM reads) never see expired
+ * credentials, and the Keycloak session never idles out mid-use.
+ */
+export function useCredentialsKeepAlive() {
+  const revalidator = useRevalidator();
+  // Latest-ref so the once-installed refresher/interval never call a stale
+  // `revalidate` from a previous render.
+  const revalidateRef = useRef(revalidator.revalidate);
+  useEffect(() => {
+    revalidateRef.current = revalidator.revalidate;
+  });
+
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const lastRunRef = useRef(0);
+
+  useEffect(() => {
+    // Loader data is fresh at mount — don't let the visibility handler fire early.
+    lastRunRef.current = Date.now();
+
+    // Single-flight: a burst of expired tile reads triggers one revalidation.
+    const revalidateOnce = () => {
+      if (!inFlightRef.current) {
+        lastRunRef.current = Date.now();
+        inFlightRef.current = Promise.resolve(revalidateRef.current()).finally(() => {
+          inFlightRef.current = null;
+        });
+      }
+      return inFlightRef.current;
+    };
+
+    const uninstall = setCredentialsRefresher(async (connectionName) => {
+      const previousKeyId =
+        useConnectionsStore.getState().connections[connectionName]?.credentials?.AccessKeyId;
+
+      await revalidateOnce();
+
+      const rotated = await waitForRotatedCredentials(
+        connectionName,
+        previousKeyId,
+        STORE_UPDATE_TIMEOUT_MS,
+      );
+      if (rotated) return rotated;
+
+      // No rotation observed — return what the store holds; the caller's
+      // retry surfaces ExpiredCredentialsError if it is still stale.
+      const current = useConnectionsStore.getState().connections[connectionName]?.credentials;
+      if (!current) {
+        throw new Error(`No credentials for connection "${connectionName}" after refresh.`);
+      }
+      return current;
+    });
+
+    const interval = setInterval(revalidateOnce, KEEP_ALIVE_INTERVAL_MS);
+
+    // Browsers throttle interval timers in hidden tabs — catch up on return.
+    const onVisibilityChange = () => {
+      if (
+        document.visibilityState === "visible" &&
+        Date.now() - lastRunRef.current > KEEP_ALIVE_INTERVAL_MS
+      ) {
+        revalidateOnce();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      uninstall();
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+}

--- a/app/hooks/useCredentialsKeepAlive.ts
+++ b/app/hooks/useCredentialsKeepAlive.ts
@@ -2,16 +2,18 @@ import { Credentials } from "@aws-sdk/client-sts";
 import { useEffect, useRef } from "react";
 import { useRevalidator } from "react-router";
 
+import { liveCredentials } from "~/utils/connectionsStore/selectors";
 import { useConnectionsStore } from "~/utils/connectionsStore/useConnectionsStore";
-import { setCredentialsRefresher } from "~/utils/credentialsRefresh";
+import { setCredentialsRefresher, STS_STALENESS_BUFFER_MS } from "~/utils/credentialsRefresh";
 
 /**
- * Revalidate slightly inside the server's 5-minute STS staleness buffer
- * (`isValidCredentials`) so credentials rotate before they expire, and well
- * inside Keycloak's SSO idle timeout so the session survives long viewer
- * stretches that produce no other server traffic (reads are browser→S3).
+ * Revalidate inside the server's STS staleness buffer (`isValidCredentials`)
+ * so one tick always lands in the window where the loader re-mints — rotation
+ * happens before expiry. Each tick also keeps the Keycloak session inside its
+ * idle timeout: viewer stretches produce no other server traffic (reads are
+ * browser→S3).
  */
-const KEEP_ALIVE_INTERVAL_MS = 4 * 60 * 1000;
+const KEEP_ALIVE_INTERVAL_MS = STS_STALENESS_BUFFER_MS - 60 * 1000;
 
 /** How long to wait for a revalidation to land rotated credentials in the store. */
 const STORE_UPDATE_TIMEOUT_MS = 5_000;
@@ -29,7 +31,7 @@ const waitForRotatedCredentials = (
 ): Promise<Credentials | null> =>
   new Promise((resolve) => {
     const read = () => {
-      const credentials = useConnectionsStore.getState().connections[connectionName]?.credentials;
+      const credentials = liveCredentials(connectionName)();
       return credentials && credentials.AccessKeyId !== previousKeyId ? credentials : null;
     };
 
@@ -97,8 +99,7 @@ export function useCredentialsKeepAlive() {
     };
 
     const uninstall = setCredentialsRefresher(async (connectionName) => {
-      const previousKeyId =
-        useConnectionsStore.getState().connections[connectionName]?.credentials?.AccessKeyId;
+      const previousKeyId = liveCredentials(connectionName)()?.AccessKeyId;
 
       await revalidateOnce();
 
@@ -111,7 +112,7 @@ export function useCredentialsKeepAlive() {
 
       // No rotation observed — return what the store holds; the caller's
       // retry surfaces ExpiredCredentialsError if it is still stale.
-      const current = useConnectionsStore.getState().connections[connectionName]?.credentials;
+      const current = liveCredentials(connectionName)();
       if (!current) {
         throw new Error(`No credentials for connection "${connectionName}" after refresh.`);
       }

--- a/app/routes/layouts/protected.layout.tsx
+++ b/app/routes/layouts/protected.layout.tsx
@@ -13,6 +13,7 @@ import { ExplorerTab } from "~/components/Sidebar/Explorer/ExplorerTab";
 import { SIDEBAR_SEARCH_INPUT_ID } from "~/components/Sidebar/Explorer/SidebarSearchInput";
 import { Sidebar, SIDEBAR } from "~/components/Sidebar/Sidebar";
 import { useNavSidebarStore } from "~/components/Sidebar/sidebarStores";
+import { useCredentialsKeepAlive } from "~/hooks/useCredentialsKeepAlive";
 import { useInitConnections } from "~/hooks/useInitConnections";
 import { useConnectionHealthProbe } from "~/utils/connectionsStore/useConnectionHealthProbe";
 
@@ -38,6 +39,7 @@ export default function ProtectedLayout() {
   const { connectionConfigs, credentials, credentialErrors, identity } =
     useLoaderData<typeof loader>();
   useInitConnections(connectionConfigs, credentials, credentialErrors);
+  useCredentialsKeepAlive();
   useConnectionHealthProbe();
 
   return (

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -26,7 +26,7 @@ import { useLayoutStore } from "~/components/DirectoryView/useLayoutStore";
 import { ViewModeToggle } from "~/components/DirectoryView/ViewModeToggle";
 import { useModal } from "~/hooks/useModal";
 import { toastBridge, toToastVariant } from "~/toast-bridge";
-import { useConnectionsStore } from "~/utils/connectionsStore/useConnectionsStore";
+import { liveCredentials } from "~/utils/connectionsStore/selectors";
 import { getFileType, isImageFile } from "~/utils/fileType";
 import { getName } from "~/utils/pathUtils";
 import { constructS3Url } from "~/utils/resourceId";
@@ -243,7 +243,7 @@ export default function ObjectsRoute() {
       // `pathName` already includes the connection prefix.
       const s3Url = constructS3Url(connectionConfig, pathName);
       const signedFetch = createSignedFetch(
-        () => useConnectionsStore.getState().connections[connectionName]?.credentials,
+        liveCredentials(connectionName),
         connectionConfig,
         connectionName,
       );

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -245,6 +245,7 @@ export default function ObjectsRoute() {
       const signedFetch = createSignedFetch(
         () => useConnectionsStore.getState().connections[connectionName]?.credentials,
         connectionConfig,
+        connectionName,
       );
       return (
         <ClientOnly>

--- a/app/utils/connectionsStore/selectors.ts
+++ b/app/utils/connectionsStore/selectors.ts
@@ -16,6 +16,14 @@ export interface ResolvedResource {
   httpsUrl: string;
 }
 
+/**
+ * Live, non-reactive credentials getter — the contract `createSignedFetch`
+ * needs for its lazy resolve: a fresh store read per call (never a captured
+ * snapshot), so retries after an STS rotation pick up the new credentials.
+ */
+export const liveCredentials = (connectionName: string) => (): Credentials | null =>
+  useConnectionsStore.getState().connections[connectionName]?.credentials ?? null;
+
 export const select = {
   connection: (connectionName: string) => (state: ConnectionsStore) =>
     state.connections[connectionName],

--- a/app/utils/credentialsRefresh.ts
+++ b/app/utils/credentialsRefresh.ts
@@ -6,6 +6,13 @@
 
 import type { Credentials } from "@aws-sdk/client-sts";
 
+/**
+ * How long before STS expiry the server treats credentials as stale and
+ * re-mints them (`isValidCredentials`). The client keep-alive interval must
+ * stay below this so one revalidation always lands inside the window.
+ */
+export const STS_STALENESS_BUFFER_MS = 5 * 60 * 1000;
+
 /** Thrown when no refresher is installed or the refresh+retry still fails. */
 export class ExpiredCredentialsError extends Error {
   public readonly connectionName?: string;

--- a/app/utils/db/__tests__/createDatabase.test.ts
+++ b/app/utils/db/__tests__/createDatabase.test.ts
@@ -26,7 +26,9 @@ describe("createDatabase", () => {
   const mockConnect = vi.fn();
   const mockInstantiate = vi.fn();
   const mockOpen = vi.fn();
-  const mockConnection = { query: mockQuery };
+  // Fresh per test: `appliedKeyIds` is keyed by connection identity, and a
+  // shared mock object would carry "credentials already applied" across tests.
+  let mockConnection: { query: typeof mockQuery };
   const credentials = mock.credentials();
 
   beforeEach(() => {
@@ -49,6 +51,7 @@ describe("createDatabase", () => {
           connect: mockConnect,
         }) as never,
     );
+    mockConnection = { query: mockQuery };
     mockConnect.mockResolvedValue(mockConnection);
     mockQuery.mockResolvedValue({});
 

--- a/app/utils/db/convertCsvToParquet.ts
+++ b/app/utils/db/convertCsvToParquet.ts
@@ -1,5 +1,6 @@
 import { selectBundle, createWorker, AsyncDuckDB, ConsoleLogger } from "@duckdb/duckdb-wasm";
 
+import { applyS3Credentials } from "./createDatabase";
 import { getLocalDuckDbBundles } from "./duckdbBundles";
 import { escapeSqlString } from "./escapeSqlString";
 import { getUint8ArrayForResourceId } from "./getBlobFromObjectNode";
@@ -46,15 +47,7 @@ export async function convertCsvToParquet(resourceId: string) {
 
     const { credentials, connectionConfig, s3Uri } = resolveResourceId(resourceId);
 
-    // Single-quote-escape every interpolated value — credentials, region,
-    // and S3 keys can carry `'` on non-AWS providers.
-    await conn.query(`SET s3_access_key_id='${escapeSqlString(credentials.AccessKeyId ?? "")}'`);
-    await conn.query(
-      `SET s3_secret_access_key='${escapeSqlString(credentials.SecretAccessKey ?? "")}'`,
-    );
-    if (credentials.SessionToken) {
-      await conn.query(`SET s3_session_token='${escapeSqlString(credentials.SessionToken)}'`);
-    }
+    await applyS3Credentials(conn, credentials);
     await conn.query(
       `SET s3_region='${escapeSqlString(connectionConfig.region ?? "eu-central-1")}'`,
     );

--- a/app/utils/db/createDatabase.ts
+++ b/app/utils/db/createDatabase.ts
@@ -10,7 +10,6 @@ import { ConnectionConfig } from "~/.generated/client";
 /** Initialize a DuckDB WASM connection with S3 support (singleton per resourceId). */
 const createDatabaseInternal = async (
   resourceId: string,
-  credentials: Credentials,
   connectionConfig?: ConnectionConfig | null,
 ) => {
   console.info("[getTileDataWasm] Initializing DuckDB WASM with S3 support...");
@@ -46,12 +45,6 @@ const createDatabaseInternal = async (
   await connection.query("SET enable_object_cache = true;");
   await connection.query("SET http_keep_alive = true;");
 
-  // Single-quote-escape every interpolated value — non-AWS providers may carry `'`.
-  const { AccessKeyId, SecretAccessKey, SessionToken } = credentials;
-  await connection.query(`SET s3_access_key_id='${escapeSqlString(AccessKeyId ?? "")}'`);
-  await connection.query(`SET s3_secret_access_key='${escapeSqlString(SecretAccessKey ?? "")}'`);
-  await connection.query(`SET s3_session_token='${escapeSqlString(SessionToken ?? "")}'`);
-
   // Always path-style: dotted bucket names break the vhost wildcard cert.
   const endpoint = connectionConfig?.endpoint;
   const region = connectionConfig?.region ?? "eu-central-1";
@@ -68,4 +61,35 @@ const createDatabaseInternal = async (
   return connection;
 };
 
-export const createDatabase = createSingleton(createDatabaseInternal);
+type DuckDbConnection = Awaited<ReturnType<typeof createDatabaseInternal>>;
+
+// Single-quote-escape every interpolated value — non-AWS providers may carry `'`.
+const applyS3Credentials = async (connection: DuckDbConnection, credentials: Credentials) => {
+  const { AccessKeyId, SecretAccessKey, SessionToken } = credentials;
+  await connection.query(`SET s3_access_key_id='${escapeSqlString(AccessKeyId ?? "")}'`);
+  await connection.query(`SET s3_secret_access_key='${escapeSqlString(SecretAccessKey ?? "")}'`);
+  await connection.query(`SET s3_session_token='${escapeSqlString(SessionToken ?? "")}'`);
+};
+
+const getConnection = createSingleton(createDatabaseInternal);
+
+/** `AccessKeyId` last applied via `SET s3_*`, per resourceId. */
+const appliedKeyIds = new Map<string, string | undefined>();
+
+/**
+ * STS credentials rotate (~hourly, C-242) while the cached connection lives for
+ * the whole viewer session — re-apply the `SET s3_*` trio whenever the caller
+ * resolves a different `AccessKeyId` than the connection last saw.
+ */
+export const createDatabase = async (
+  resourceId: string,
+  credentials: Credentials,
+  connectionConfig?: ConnectionConfig | null,
+) => {
+  const connection = await getConnection(resourceId, connectionConfig);
+  if (appliedKeyIds.get(resourceId) !== credentials.AccessKeyId) {
+    await applyS3Credentials(connection, credentials);
+    appliedKeyIds.set(resourceId, credentials.AccessKeyId);
+  }
+  return connection;
+};

--- a/app/utils/db/createDatabase.ts
+++ b/app/utils/db/createDatabase.ts
@@ -64,7 +64,11 @@ const createDatabaseInternal = async (
 type DuckDbConnection = Awaited<ReturnType<typeof createDatabaseInternal>>;
 
 // Single-quote-escape every interpolated value — non-AWS providers may carry `'`.
-const applyS3Credentials = async (connection: DuckDbConnection, credentials: Credentials) => {
+// Shared with `convertCsvToParquet`, which bootstraps its own WASM instance.
+export const applyS3Credentials = async (
+  connection: Pick<DuckDbConnection, "query">,
+  credentials: Credentials,
+) => {
   const { AccessKeyId, SecretAccessKey, SessionToken } = credentials;
   await connection.query(`SET s3_access_key_id='${escapeSqlString(AccessKeyId ?? "")}'`);
   await connection.query(`SET s3_secret_access_key='${escapeSqlString(SecretAccessKey ?? "")}'`);
@@ -73,8 +77,14 @@ const applyS3Credentials = async (connection: DuckDbConnection, credentials: Cre
 
 const getConnection = createSingleton(createDatabaseInternal);
 
-/** `AccessKeyId` last applied via `SET s3_*`, per resourceId. */
-const appliedKeyIds = new Map<string, string | undefined>();
+// Keyed by the connection itself so a rebuilt connection (singleton retries
+// after a failed init) can never inherit a stale "already applied" verdict.
+const appliedKeyIds = new WeakMap<DuckDbConnection, string | undefined>();
+
+// Serialize `SET s3_*` per resourceId: two concurrent reads straddling a
+// rotation would otherwise interleave their SET trios on the shared
+// connection and leave a mismatched key/secret pair behind.
+const pendingApplications = new Map<string, Promise<void>>();
 
 /**
  * STS credentials rotate (~hourly, C-242) while the cached connection lives for
@@ -87,9 +97,20 @@ export const createDatabase = async (
   connectionConfig?: ConnectionConfig | null,
 ) => {
   const connection = await getConnection(resourceId, connectionConfig);
-  if (appliedKeyIds.get(resourceId) !== credentials.AccessKeyId) {
-    await applyS3Credentials(connection, credentials);
-    appliedKeyIds.set(resourceId, credentials.AccessKeyId);
-  }
+
+  const previous = pendingApplications.get(resourceId) ?? Promise.resolve();
+  const application = previous.then(async () => {
+    if (appliedKeyIds.get(connection) !== credentials.AccessKeyId) {
+      await applyS3Credentials(connection, credentials);
+      appliedKeyIds.set(connection, credentials.AccessKeyId);
+    }
+  });
+  // Keep the chain alive past a failed application so the next caller retries.
+  pendingApplications.set(
+    resourceId,
+    application.catch(() => {}),
+  );
+  await application;
+
   return connection;
 };

--- a/app/utils/db/getBlobFromObjectNode.ts
+++ b/app/utils/db/getBlobFromObjectNode.ts
@@ -1,4 +1,5 @@
 import { resolveResourceId } from "../connectionsStore/selectors";
+import { useConnectionsStore } from "../connectionsStore/useConnectionsStore";
 import { useFileStore, type DownloadProgress } from "../localFilesStore/useFileStore";
 import { createSignedFetch } from "../signedFetch";
 
@@ -58,8 +59,14 @@ export const getUint8ArrayForResourceId = async (resourceId: string): Promise<Ui
   const cachedData = await getFile(resourceId);
   if (cachedData) return cachedData;
 
-  const { connectionConfig, credentials, httpsUrl } = resolveResourceId(resourceId);
-  const signedFetch = createSignedFetch(() => credentials, connectionConfig);
+  const { connectionConfig, connectionName, httpsUrl } = resolveResourceId(resourceId);
+  // Live getter + connectionName: a download outliving the STS credentials can
+  // refresh and retry instead of failing on ExpiredToken (C-242).
+  const signedFetch = createSignedFetch(
+    () => useConnectionsStore.getState().connections[connectionName]?.credentials,
+    connectionConfig,
+    connectionName,
+  );
 
   const response = await signedFetch(httpsUrl);
   const data = await readStreamWithProgress(response, (progress) => {

--- a/app/utils/db/getBlobFromObjectNode.ts
+++ b/app/utils/db/getBlobFromObjectNode.ts
@@ -1,5 +1,4 @@
-import { resolveResourceId } from "../connectionsStore/selectors";
-import { useConnectionsStore } from "../connectionsStore/useConnectionsStore";
+import { liveCredentials, resolveResourceId } from "../connectionsStore/selectors";
 import { useFileStore, type DownloadProgress } from "../localFilesStore/useFileStore";
 import { createSignedFetch } from "../signedFetch";
 
@@ -63,7 +62,7 @@ export const getUint8ArrayForResourceId = async (resourceId: string): Promise<Ui
   // Live getter + connectionName: a download outliving the STS credentials can
   // refresh and retry instead of failing on ExpiredToken (C-242).
   const signedFetch = createSignedFetch(
-    () => useConnectionsStore.getState().connections[connectionName]?.credentials,
+    liveCredentials(connectionName),
     connectionConfig,
     connectionName,
   );


### PR DESCRIPTION
## Problem

Since browser-direct SigV4 (PR #101, C-193/C-198) two renewal paths are broken — Plane ticket C-242:

1. **STS refresher never installed.** `credentialsRefresh.ts` ships a `setCredentialsRefresher` hook point, but no production code ever called it. After the 1h credential lifetime, every `signedFetch` / `listObjectsClient` retry throws `ExpiredCredentialsError: no refresher is installed`. DuckDB-WASM is worse off: credentials are pinned via `SET s3_*` at singleton init and there is no retry path at all — parquet/cell-overlay reads fail hard.
2. **Keycloak session idles out.** Tiles used to flow through the server `/presign` endpoint, keeping the session alive as a side effect. Browser-direct reads produce zero server traffic, so the refresh token expires after the realm's 30-min SSO idle default; the next navigation destroys the session and forces re-login.

## Fix

- **`useCredentialsKeepAlive`** (new hook, mounted in `protected.layout.tsx`):
  - installs the refresher — single-flight `useRevalidator` revalidation re-runs the loader, `authMiddleware` re-mints stale STS credentials, then the hook waits (store subscription, 5s cap) for the rotated `AccessKeyId` to land in the connections store
  - revalidates every 4 minutes — inside the server's 5-minute staleness buffer (`isValidCredentials`), so credentials rotate *before* expiry and the Keycloak session never idles out mid-use
  - `visibilitychange` catch-up for throttled background tabs
- **`createDatabase`**: `SET s3_*` moved out of singleton init; re-applied whenever the caller resolves a rotated `AccessKeyId`. All DuckDB consumers already resolve fresh credentials per call via `resolveResourceId`, so no call-site changes needed.
- **`getBlobFromObjectNode`**: static credential snapshot → live store getter + `connectionName` (its retry path was unreachable).
- **`objects.route` / `DirectoryViewGrid`**: pass `connectionName` so existing live getters can trigger the refresh path.

## Verification

- typecheck, lint, prettier clean; existing signedFetch/listObjectsClient/db suites pass
- Manual fast-path: set `DurationSeconds: 900` (STS minimum) locally → credentials rotate on a keep-alive tick ~10 min in, viewer keeps working past expiry; with the interval disabled, tiles recover via the reactive refresher instead of dying

## Known limitation

A tab hidden longer than the Keycloak idle timeout still loses its session (browser intensive throttling defers timers). Real remedy is explicit realm session timeouts in cytario-infrastructure — follow-up noted in C-242.

## Review round (software-architect + fullstack-reviewer)

Applied:
- `liveCredentials(connectionName)` getter extracted to `connectionsStore/selectors.ts`; all `createSignedFetch` call sites and the hook use it (the live-vs-snapshot contract is now one reviewable line)
- `STS_STALENESS_BUFFER_MS` shared between the server staleness check and the client keep-alive interval (`interval = buffer − 1 min`), replacing the implicit 4-min/5-min magic-number pair
- `appliedKeyIds` keyed by connection identity (`WeakMap`) — a rebuilt connection can't inherit a stale "credentials already applied" verdict
- `SET s3_*` application serialized per resourceId — concurrent reads straddling a rotation can't interleave mismatched key/secret pairs
- `convertCsvToParquet` reuses `applyS3Credentials` (drops its divergent `SessionToken` handling)

Conscious decision: an expired Keycloak session now redirects to `/login` from a background keep-alive tick rather than on the next user navigation — immediate feedback instead of a silently broken UI.

Deferred to C-242 follow-up: long-running `COPY TO` in `convertCsvToParquet` outliving the 1h STS lifetime (no mid-write refresh path), and codifying realm session timeouts in cytario-infrastructure.
