### PR TITLE
refactor(color): consume design tokens, drop parallel brand palette [C-253]

### DIFF
--- a/app/components/.client/ImageViewer/components/ChannelsController/ChannelsControllerBrightfieldItem.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/ChannelsControllerBrightfieldItem.tsx
@@ -58,7 +58,7 @@ export function ChannelsControllerBrightfieldItem({
   return (
     <Radio value={BRIGHTFIELD_GROUP_ID} className={cx}>
       {/* Tri-color indicator */}
-      <div className="flex w-5 h-5 rounded-full overflow-hidden border-2 border-slate-500">
+      <div className="flex w-5 h-5 rounded-full overflow-hidden border-2 border-(--color-slate-500)">
         <div className="grow h-full  bg-red-500" />
         <div className="grow h-full bg-green-500" />
         <div className="grow h-full  bg-blue-500" />

--- a/app/components/.client/ImageViewer/components/ChannelsController/MinMaxSettings.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/MinMaxSettings.tsx
@@ -84,7 +84,7 @@ export function MinMaxSettings() {
         </label>
         <input
           id="min-contrast"
-          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-slate-500 bg-slate-950 text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-(--color-slate-500) bg-(--color-slate-950) text-(--color-slate-300) disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
           type="number"
           value={minValue}
           disabled={!selectedChannel}
@@ -102,7 +102,7 @@ export function MinMaxSettings() {
         </label>
         <input
           id="max-contrast"
-          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-slate-500 bg-slate-950 text-slate-300 disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-(--color-slate-500) bg-(--color-slate-950) text-(--color-slate-300) disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
           type="number"
           value={maxValue}
           disabled={!selectedChannel}

--- a/app/components/.client/ImageViewer/components/Image/ImageContainer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/ImageContainer.tsx
@@ -73,7 +73,7 @@ export function ImageContainer({
             className={`
           flex flex-grow w-full h-full flex-col
           items-center justify-center text-center
-          overflow-hidden gap-1 p-2 text-slate-500
+          overflow-hidden gap-1 p-2 text-(--color-slate-500)
         `}
           >
             <ImageOff size={isPreview ? 20 : 32} strokeWidth={1.5} />

--- a/app/components/.client/ImageViewer/components/ImageViewer.tsx
+++ b/app/components/.client/ImageViewer/components/ImageViewer.tsx
@@ -39,7 +39,7 @@ export const Viewer = ({ url, signedFetch }: ViewerProps) => {
 
       <div
         data-theme="dark"
-        className="relative flex grow h-full bg-neutral-950 text-(--color-text-primary) overflow-hidden"
+        className="relative flex grow h-full bg-(--color-slate-950) text-(--color-text-primary) overflow-hidden"
       >
         <ImagePanels />
         <Sidebar

--- a/app/components/AppHeader.tsx
+++ b/app/components/AppHeader.tsx
@@ -22,7 +22,7 @@ export function AppHeader() {
   return (
     <header
       data-theme="dark"
-      className="z-20 flex justify-between items-center h-12 bg-slate-900 top-0 left-0 right-0"
+      className="z-20 flex justify-between items-center h-12 bg-(--color-surface-default) top-0 left-0 right-0"
     >
       <div className="h-full flex items-center gap-1 shrink min-w-0 pl-2">
         <PanelToggle />

--- a/app/components/DataGrid/DataGrid.tsx
+++ b/app/components/DataGrid/DataGrid.tsx
@@ -93,7 +93,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
           cell: (info) => {
             const value = info.getValue();
             if (value === null || value === undefined) {
-              return <span className="text-gray-400 italic">null</span>;
+              return <span className="text-(--color-text-tertiary) italic">null</span>;
             }
             if (typeof value === "boolean") {
               return <Checkbox isSelected={value} isDisabled />;
@@ -152,13 +152,13 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
   return (
     <div ref={containerRef} className="h-full overflow-auto">
       <table className="min-w-full border-collapse text-sm">
-        <thead className="bg-gray-100 dark:bg-slate-800 sticky top-0 z-10">
+        <thead className="bg-(--color-surface-muted) sticky top-0 z-10">
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className="grid" style={{ gridTemplateColumns }}>
               {headerGroup.headers.map((header) => (
                 <th
                   key={header.id}
-                  className={`border-b border-gray-200 dark:border-slate-700 px-4 py-2 font-semibold ${
+                  className={`border-b border-(--color-border-default) px-4 py-2 font-semibold ${
                     RIGHT_ALIGNED_COLUMNS.has(header.id) ? "text-right" : "text-left"
                   }`}
                 >
@@ -181,7 +181,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
             return (
               <tr
                 key={row.id}
-                className="hover:bg-gray-50 dark:hover:bg-slate-800 absolute w-full grid"
+                className="hover:bg-(--color-surface-hover) absolute w-full grid"
                 style={{
                   gridTemplateColumns,
                   height: `${virtualRow.size}px`,
@@ -191,7 +191,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
-                    className={`border-b border-gray-100 dark:border-slate-700 tabular-nums px-4 flex items-center ${
+                    className={`border-b border-(--color-border-default) tabular-nums px-4 flex items-center ${
                       RIGHT_ALIGNED_COLUMNS.has(cell.column.id) ? "justify-end" : ""
                     }`}
                   >
@@ -203,7 +203,9 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
           })}
         </tbody>
       </table>
-      {isFetchingMore && <div className="p-2 text-center text-gray-500">Loading more...</div>}
+      {isFetchingMore && (
+        <div className="p-2 text-center text-(--color-text-tertiary)">Loading more...</div>
+      )}
     </div>
   );
 };

--- a/app/components/DataGrid/WktSvg.tsx
+++ b/app/components/DataGrid/WktSvg.tsx
@@ -18,7 +18,7 @@ export const WktSvg = ({ wkt, size = 48 }: WktSvgProps) => {
   const paths = parseWkt(wkt);
 
   if (paths.length === 0) {
-    return <span className="text-gray-400 italic">invalid</span>;
+    return <span className="text-(--color-text-tertiary) italic">invalid</span>;
   }
 
   // Calculate bounding box across all paths
@@ -58,7 +58,7 @@ export const WktSvg = ({ wkt, size = 48 }: WktSvgProps) => {
       width={size}
       height={size}
       viewBox={`0 0 ${size} ${size}`}
-      className="inline-block bg-gray-50 dark:bg-slate-700 rounded"
+      className="inline-block bg-(--color-surface-muted) rounded"
     >
       <path
         d={pathData}
@@ -66,7 +66,7 @@ export const WktSvg = ({ wkt, size = 48 }: WktSvgProps) => {
         fillOpacity={0.3}
         stroke="currentColor"
         strokeWidth={1}
-        className="text-cytario-turquoise-700"
+        className="text-(--color-text-accent)"
       />
     </svg>
   );

--- a/app/components/DescriptionList.tsx
+++ b/app/components/DescriptionList.tsx
@@ -16,7 +16,9 @@ const DescriptionList = ({ data, className }: DescriptionListProps<any>) => {
           <React.Fragment key={key}>
             <dt className="font-bold text-sm w-32 truncate">{key}</dt>
             <dd>
-              <code className="text-slate-700 px-2 py-1 bg-slate-50">{String(value)}</code>
+              <code className="text-(--color-text-secondary) px-2 py-1 bg-(--color-surface-subtle)">
+                {String(value)}
+              </code>
             </dd>
           </React.Fragment>
         ))}

--- a/app/components/DirectoryView/DirectoryViewGrid.tsx
+++ b/app/components/DirectoryView/DirectoryViewGrid.tsx
@@ -49,7 +49,7 @@ function ImagePreviewSlot({
 }) {
   return (
     <ClientOnly>
-      <Suspense fallback={<div className="animate-pulse w-full h-full bg-slate-600" />}>
+      <Suspense fallback={<div className="animate-pulse w-full h-full bg-(--color-slate-600)" />}>
         <ViewerStoreProvider url={s3Url} signedFetch={signedFetch}>
           <ImagePreview />
         </ViewerStoreProvider>

--- a/app/components/DirectoryView/GridItem.tsx
+++ b/app/components/DirectoryView/GridItem.tsx
@@ -33,7 +33,7 @@ export function GridItem({ node, preview, children, className }: GridItemProps) 
 
   return (
     <Link to={to} className={twMerge(cx, className)}>
-      <div className="shrink-0 overflow-hidden bg-neutral-900 aspect-4/3 rounded-t-lg">
+      <div className="shrink-0 overflow-hidden bg-(--color-slate-900) aspect-4/3 rounded-t-lg">
         {preview ?? (
           <div className="flex h-full w-full items-center justify-center">
             <NodeIcon node={node} size={32} />

--- a/app/components/DirectoryView/NodeLink/NodeLink.tsx
+++ b/app/components/DirectoryView/NodeLink/NodeLink.tsx
@@ -39,7 +39,7 @@ export function NodeLink({
   `;
 
   const clickAbleCx = `
-    hover:bg-slate-100 dark:hover:bg-slate-800
+    hover:bg-(--color-surface-hover)
     focus-visible:outline focus-visible:outline-(--color-border-focus)
   `;
 

--- a/app/components/LavaLoader.tsx
+++ b/app/components/LavaLoader.tsx
@@ -99,7 +99,7 @@ const LavaLoaderInner = ({ absolute = false, rows = 3, cols = 3 }: LavaLoaderPro
                 cx={size + col * size}
                 cy={size + row * size}
                 r={isActive ? 12 : 4}
-                className={`dot-${i}-${row} fill-slate-300 `}
+                className={`dot-${i}-${row} fill-(--color-slate-300) `}
               />
             );
           })}

--- a/app/components/Layout/Footer.tsx
+++ b/app/components/Layout/Footer.tsx
@@ -6,7 +6,10 @@ interface FooterProps {
   className?: string;
 }
 export function Footer({ children, className }: FooterProps) {
-  const cx = twMerge("px-6 p-2 bg-slate-50 border-t border-slate-300", className);
+  const cx = twMerge(
+    "px-6 p-2 bg-(--color-surface-subtle) border-t border-(--color-border-strong)",
+    className,
+  );
   return (
     <footer className={cx}>
       <div className="container mx-auto flex justify-between">{children}</div>

--- a/app/components/Logo.tsx
+++ b/app/components/Logo.tsx
@@ -1,4 +1,6 @@
-import { ColorBrandAccent, ColorBrandPrimary } from "@cytario/design";
+// The logo is the fixed brand identity — use the brand primitives directly
+// (theme-invariant), not theme-adaptive semantic tokens.
+import { ColorPurple700, ColorTeal500 } from "@cytario/design";
 import { motion } from "framer-motion";
 
 const W = 56;
@@ -23,7 +25,7 @@ const pathVariants = {
 
 export const Logo = ({
   color = "white",
-  highlightColor = ColorBrandAccent,
+  highlightColor = ColorTeal500,
   scale = 1,
   className,
 }: {
@@ -50,7 +52,7 @@ export const Logo = ({
       width={width}
       height={height}
       viewBox={`0 0 ${W} ${H}`}
-      fill={color ?? ColorBrandPrimary}
+      fill={color ?? ColorPurple700}
       className={className}
       variants={containerVariants}
       initial="hidden"

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -16,7 +16,7 @@ export const sidebarToggleId = (name: string) => `${slug(name)}-toggle`;
 // match. Teal accent explicitly (brand-accent = teal in light + dark), rather
 // than `variant="primary"` whose hue currently differs by theme.
 export const SIDEBAR_TOGGLE_ACTIVE_CLASS =
-  "bg-(--color-brand-accent) text-(--color-text-inverse) hover:bg-(--color-brand-accent)";
+  "bg-(--color-surface-accent) text-(--color-text-inverse) hover:bg-(--color-surface-accent)";
 
 const focusById = (id: string) => requestAnimationFrame(() => document.getElementById(id)?.focus());
 

--- a/app/components/Sidebar/SidebarResizeHandle.tsx
+++ b/app/components/Sidebar/SidebarResizeHandle.tsx
@@ -73,7 +73,7 @@ export function SidebarResizeHandle({ store, side, motionWidth }: SidebarResizeH
       aria-valuenow={Math.round(isOpen ? width : 0)}
       aria-valuemin={0}
       aria-valuemax={SIDEBAR_MAX_WIDTH}
-      className={`absolute top-0 z-30 h-full w-4 cursor-ew-resize hover:bg-slate-400/40 ${
+      className={`absolute top-0 z-30 h-full w-4 cursor-ew-resize hover:bg-(--color-slate-400)/40 ${
         side === "left" ? "right-0 translate-x-full" : "left-0 -translate-x-full"
       }`}
     />

--- a/app/components/Table/ColumnResizeHandle.tsx
+++ b/app/components/Table/ColumnResizeHandle.tsx
@@ -12,10 +12,10 @@ export const ColumnResizeHandle = ({ header }: { header: Header<unknown, unknown
         absolute top-0 right-0 h-full w-2
         flex justify-end
         transition-colors duration-200
-        bg-transparent hover:bg-slate-300 active:bg-cytario-turquoise-500
+        bg-transparent hover:bg-(--color-slate-300) active:bg-(--color-surface-accent)
       `}
     >
-      <div className="w-[1px] h-full bg-slate-300" />
+      <div className="w-[1px] h-full bg-(--color-slate-300)" />
     </button>
   );
 };

--- a/app/components/Table/ColumnSortButton.tsx
+++ b/app/components/Table/ColumnSortButton.tsx
@@ -7,9 +7,9 @@ function getStyle(sortDirection: false | SortDirection) {
   switch (sortDirection) {
     case "desc":
     case "asc":
-      return "text-slate-700 group-hover/header:text-slate-900";
+      return "text-(--color-text-secondary) group-hover/header:text-(--color-text-primary)";
     default:
-      return "text-slate-500 opacity-0 group-hover/header:opacity-100";
+      return "text-(--color-text-tertiary) opacity-0 group-hover/header:opacity-100";
   }
 }
 

--- a/app/components/Table/SelectionFooter.tsx
+++ b/app/components/Table/SelectionFooter.tsx
@@ -18,13 +18,13 @@ export function SelectionFooter({
     <div
       role="toolbar"
       aria-label={`Bulk actions for ${selectedCount} selected items`}
-      className="sticky bottom-0 z-20 border-t border-slate-300 bg-white/95 backdrop-blur px-6 py-3"
+      className="sticky bottom-0 z-20 border-t border-(--color-border-strong) bg-white/95 backdrop-blur px-6 py-3"
     >
       <div className="container mx-auto flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="text-sm text-slate-600">
-            <span className="font-medium text-slate-900">{selectedCount}</span> of {totalCount}{" "}
-            selected
+          <span className="text-sm text-(--color-text-secondary)">
+            <span className="font-medium text-(--color-text-primary)">{selectedCount}</span> of{" "}
+            {totalCount} selected
           </span>
           <Button variant="secondary" size="sm" onPress={onReset}>
             Clear selection

--- a/app/components/Table/Table.tsx
+++ b/app/components/Table/Table.tsx
@@ -161,7 +161,7 @@ export function Table<TData extends object>({
       {/* Sticky header — sticks vertically, scrolls horizontally (hidden scrollbar) */}
       <div
         ref={headerRef}
-        className="sticky top-0 z-10 bg-white border-b border-slate-300 overflow-x-auto"
+        className="sticky top-0 z-10 bg-white border-b border-(--color-border-strong) overflow-x-auto"
         style={{ scrollbarWidth: "none" }}
         onScroll={handleHeaderScroll}
       >

--- a/app/components/Table/TableBodyRow.tsx
+++ b/app/components/Table/TableBodyRow.tsx
@@ -42,10 +42,10 @@ export function TableBodyRow({
       tabIndex={0}
       onKeyDown={handleKeyDown}
       className={twMerge(
-        "w-full block border-b border-slate-300",
-        "hover:bg-slate-50 transition-colors",
-        "focus-visible:outline-none focus-visible:bg-slate-100 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-cytario-turquoise-700",
-        row.getIsSelected() && "bg-cytario-turquoise-50",
+        "w-full block border-b border-(--color-border-strong)",
+        "hover:bg-(--color-surface-subtle) transition-colors",
+        "focus-visible:outline-none focus-visible:bg-(--color-surface-muted) focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--color-border-focus)",
+        row.getIsSelected() && "bg-(--color-surface-selected)",
         className,
       )}
     >
@@ -87,7 +87,7 @@ export function TableBodyRow({
 
         return isIndexColumn ? (
           <th key={cell.id} className="p-2" style={style}>
-            <div className="flex items-center gap-1 text-sm text-slate-500 tabular-nums justify-between">
+            <div className="flex items-center gap-1 text-sm text-(--color-text-tertiary) tabular-nums justify-between">
               {enableRowSelection && (
                 <Checkbox isSelected={row.getIsSelected()} onChange={() => row.toggleSelected()} />
               )}

--- a/app/components/Table/TableHeaderRow.tsx
+++ b/app/components/Table/TableHeaderRow.tsx
@@ -74,7 +74,7 @@ export function TableHeaderRow({
           hover:text-(--color-text-secondary)
           focus-visible:outline-none
           focus-visible:ring-2
-          focus-visible:ring-cytario-turquoise-700
+          focus-visible:ring-(--color-border-focus)
           focus-visible:ring-offset-1
           rounded-sm
         `;
@@ -128,7 +128,7 @@ export function TableHeaderRow({
                       tableHeadCx,
                       tableHeadToggleCx,
                       isRight && "flex-row-reverse",
-                      isSorted && "text-slate-900",
+                      isSorted && "text-(--color-text-primary)",
                     )}
                     onClick={header.column.getToggleSortingHandler() ?? undefined}
                   >

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -137,10 +137,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body className="flex flex-col h-screen text-slate-700 overflow-hidden font-montserrat bg-white">
+      <body className="flex flex-col h-screen text-(--color-text-secondary) overflow-hidden font-montserrat bg-white">
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-white focus:text-cytario-turquoise-700"
+          className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-white focus:text-(--color-text-accent)"
         >
           Skip to content
         </a>
@@ -149,9 +149,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <div
             role="progressbar"
             aria-label="Loading page"
-            className="fixed top-0 left-0 right-0 z-50 h-1 bg-cytario-turquoise-700/30"
+            className="fixed top-0 left-0 right-0 z-50 h-1 bg-(--color-surface-accent)/30"
           >
-            <div className="h-full bg-cytario-turquoise-700 animate-progress-bar" />
+            <div className="h-full bg-(--color-surface-accent) animate-progress-bar" />
           </div>
         )}
 
@@ -213,7 +213,7 @@ export function ErrorBoundary() {
       <div role="alert">
         <H1>{title}</H1>
         <p>{message}</p>
-        <a href="/" className="text-cytario-purple-500 underline mt-4 inline-block">
+        <a href="/" className="text-(--color-text-brand) underline mt-4 inline-block">
           Go home
         </a>
       </div>

--- a/app/routes/admin/bulkInvite/bulkInvite.form.tsx
+++ b/app/routes/admin/bulkInvite/bulkInvite.form.tsx
@@ -125,7 +125,7 @@ export function BulkInviteForm({ onNonEmptyCountChange }: BulkInviteFormProps) {
         handleSubmit();
       }}
     >
-      <p className="text-sm text-slate-500 mb-4">
+      <p className="text-sm text-(--color-text-tertiary) mb-4">
         Keycloak emails the invite to each address below. Group membership can be assigned after
         each user accepts.
       </p>
@@ -138,7 +138,7 @@ export function BulkInviteForm({ onNonEmptyCountChange }: BulkInviteFormProps) {
 
       <table ref={tableRef} className="w-full border-collapse">
         <thead>
-          <tr className="text-left text-sm text-slate-500">
+          <tr className="text-left text-sm text-(--color-text-tertiary)">
             <th scope="col" className="w-10 pr-2 py-2 font-medium">
               #
             </th>
@@ -160,7 +160,7 @@ export function BulkInviteForm({ onNonEmptyCountChange }: BulkInviteFormProps) {
           {rows.map((row, i) => {
             return (
               <tr key={row.id}>
-                <td className="pr-2 py-1 text-sm text-slate-400 tabular-nums text-right">
+                <td className="pr-2 py-1 text-sm text-(--color-text-tertiary) tabular-nums text-right">
                   {i + 1}
                 </td>
                 <td className="px-1 py-1">

--- a/app/routes/admin/createGroup/createGroup.form.tsx
+++ b/app/routes/admin/createGroup/createGroup.form.tsx
@@ -47,12 +47,12 @@ export function CreateGroupForm({ scope }: CreateGroupFormProps) {
       </Fieldset>
 
       {nameValue.trim() && (
-        <div className="flex items-center gap-2 text-sm text-slate-500">
+        <div className="flex items-center gap-2 text-sm text-(--color-text-tertiary)">
           Full path: <ScopePill scope={`${scope}/${nameValue.trim()}`} />
         </div>
       )}
 
-      <p className="text-sm text-slate-500">
+      <p className="text-sm text-(--color-text-tertiary)">
         You will be added as an admin of this group automatically.
       </p>
     </form>

--- a/app/routes/admin/inviteUser/inviteUser.form.tsx
+++ b/app/routes/admin/inviteUser/inviteUser.form.tsx
@@ -93,7 +93,7 @@ export function InviteUserForm({ scope, inviteAnother, actionData }: InviteUserF
             />
           )}
         />
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-(--color-text-tertiary)">
           Keycloak emails the invite to the address above. Group membership can be assigned after
           the user accepts.
         </p>

--- a/app/routes/admin/inviteUser/inviteUser.modal.tsx
+++ b/app/routes/admin/inviteUser/inviteUser.modal.tsx
@@ -35,7 +35,7 @@ export default function InviteModal() {
       <InviteUserForm scope={scope} inviteAnother={inviteAnother} actionData={actionData} />
       <footer className="flex items-center gap-3 mt-6">
         <Checkbox isSelected={inviteAnother} onChange={setInviteAnother} className="mr-auto">
-          <span className="text-sm text-slate-600">Invite another</span>
+          <span className="text-sm text-(--color-text-secondary)">Invite another</span>
         </Checkbox>
         <Button onPress={() => navigate(-1)} variant="secondary">
           Cancel

--- a/app/routes/admin/updateUser/updateUser.form.tsx
+++ b/app/routes/admin/updateUser/updateUser.form.tsx
@@ -231,8 +231,10 @@ export const UpdateUserForm = ({ user, groups, groupPaths }: UpdateUserFormProps
         confirmLabel="Save Changes"
         confirmVariant="primary"
       >
-        <p className="text-sm text-slate-600">You are about to make the following changes:</p>
-        <ul className="list-disc list-inside text-sm text-slate-900 space-y-1">
+        <p className="text-sm text-(--color-text-secondary)">
+          You are about to make the following changes:
+        </p>
+        <ul className="list-disc list-inside text-sm text-(--color-text-primary) space-y-1">
           {warnings.map((w) => (
             <li key={w}>{w}</li>
           ))}

--- a/app/routes/admin/users/BulkActions.tsx
+++ b/app/routes/admin/users/BulkActions.tsx
@@ -190,8 +190,9 @@ export function BulkActions({ selectedUserIds, users, groups, onSuccess }: BulkA
           confirmLabel={config.confirmLabel}
           confirmVariant={config.confirmVariant}
         >
-          <p className="text-sm text-slate-600">
-            This will affect <span className="font-medium text-slate-900">{count}</span> user
+          <p className="text-sm text-(--color-text-secondary)">
+            This will affect{" "}
+            <span className="font-medium text-(--color-text-primary)">{count}</span> user
             {count !== 1 ? "s" : ""}.
           </p>
           {config.needsGroup && (

--- a/app/routes/admin/users/users.route.tsx
+++ b/app/routes/admin/users/users.route.tsx
@@ -154,7 +154,7 @@ function buildCellRenderers(scope: string): CellRenderers<UserRow> {
     name: (row) => (
       <Link
         to={`${row.userId}?scope=${encodeURIComponent(scope)}`}
-        className="text-cytario-turquoise-700 hover:underline"
+        className="text-(--color-text-accent) hover:underline"
       >
         {row.name}
       </Link>
@@ -222,7 +222,7 @@ export default function AdminUsersRoute() {
   return (
     <Section>
       <SectionHeader name={headingLabel}>
-        <span className="text-sm text-slate-500">
+        <span className="text-sm text-(--color-text-tertiary)">
           {data.length} {data.length === 1 ? "user" : "users"}
         </span>
         <ButtonLink
@@ -253,7 +253,10 @@ export default function AdminUsersRoute() {
 
       <Container>
         <section aria-labelledby="connections-heading" className="mb-6">
-          <h3 id="connections-heading" className="text-sm font-medium text-slate-500 mb-2">
+          <h3
+            id="connections-heading"
+            className="text-sm font-medium text-(--color-text-tertiary) mb-2"
+          >
             Connections
           </h3>
           {connections.length > 0 ? (
@@ -262,10 +265,10 @@ export default function AdminUsersRoute() {
                 <li key={conn.name}>
                   <Link
                     to={`/connections/${encodeURIComponent(conn.name)}`}
-                    className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm hover:border-slate-300 hover:bg-white transition-colors"
+                    className="inline-flex items-center gap-2 rounded-lg border border-(--color-border-default) bg-(--color-surface-subtle) px-3 py-1.5 text-sm hover:border-(--color-border-strong) hover:bg-white transition-colors"
                   >
                     <span className="h-2 w-2 rounded-full bg-green-500 shrink-0" />
-                    <span className="font-medium text-cytario-turquoise-700 hover:underline">
+                    <span className="font-medium text-(--color-text-accent) hover:underline">
                       {conn.name}
                     </span>
                     <ProviderPill provider={conn.provider} />

--- a/app/routes/auth/login.route.tsx
+++ b/app/routes/auth/login.route.tsx
@@ -81,7 +81,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export default function LoginRoute() {
   return (
     <div className="flex items-center justify-center h-screen">
-      <p role="status" className="text-slate-500">
+      <p role="status" className="text-(--color-text-tertiary)">
         Redirecting to login...
       </p>
     </div>

--- a/app/routes/config.route.tsx
+++ b/app/routes/config.route.tsx
@@ -53,7 +53,7 @@ export default function ConfigRoute() {
       </Button>
       <div>
         {typeof window !== "undefined" && (
-          <code className="block bg-slate-100 p-4 overflow-auto">
+          <code className="block bg-(--color-surface-muted) p-4 overflow-auto">
             {JSON.stringify(localStorage, null, 2)}
           </code>
         )}

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -286,7 +286,7 @@ export default function ObjectsRoute() {
       <div
         role="status"
         aria-live="polite"
-        className="flex h-full items-center justify-center p-8 text-slate-500"
+        className="flex h-full items-center justify-center p-8 text-(--color-text-tertiary)"
       >
         Loading…
       </div>

--- a/app/routes/onboarding.route.tsx
+++ b/app/routes/onboarding.route.tsx
@@ -5,12 +5,10 @@ export const meta: MetaFunction = () => [{ title: "Welcome to Cytario" }];
 
 export default function OnboardingRoute() {
   return (
-    <main className="flex h-screen items-center justify-center bg-neutral-0 px-6">
+    <main className="flex h-screen items-center justify-center bg-(--color-surface-default) px-6">
       <section className="flex max-w-xl flex-col items-start gap-6">
-        <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">
-          Welcome to Cytario
-        </h1>
-        <p className="text-slate-600 dark:text-slate-300">
+        <h1 className="text-2xl font-semibold text-(--color-text-primary)">Welcome to Cytario</h1>
+        <p className="text-(--color-text-secondary)">
           Your account is not yet linked to an organization. An administrator needs to add you
           before you can access workspace data. Once you have been added, sign out and back in to
           activate your organization.

--- a/app/routes/search.route.tsx
+++ b/app/routes/search.route.tsx
@@ -133,7 +133,7 @@ export default function SearchRoute() {
     <Section>
       <H1>{`Search: ${searchQuery}`}</H1>
 
-      <div className="bg-slate-100 p-2">
+      <div className="bg-(--color-surface-muted) p-2">
         <DirectoryViewTree
           nodes={nodes}
           kind="entries"

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -6,20 +6,8 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
-  /* Custom colors */
-  --color-cytario-purple-500: #5c2483;
-
-  --color-cytario-turquoise-50: #f0fafa;
-  --color-cytario-turquoise-100: #cceded;
-  --color-cytario-turquoise-200: #99dbdb;
-  --color-cytario-turquoise-300: #66c9c9;
-  --color-cytario-turquoise-400: #4dc3c3;
-  --color-cytario-turquoise-500: #35b7b8;
-  --color-cytario-turquoise-600: #2a9293;
-  --color-cytario-turquoise-700: #1f7172;
-  --color-cytario-turquoise-800: #165859;
-  --color-cytario-turquoise-900: #0d3f40;
-  --color-cytario-turquoise-950: #072425;
+  /* Colors come from @cytario/design tokens (--color-surface-*, --color-text-*,
+     --color-teal-*, --color-purple-*); do not redefine them here. */
 
   /* Custom font family */
   --font-montserrat: "Montserrat", sans-serif;
@@ -54,11 +42,11 @@
 
 html,
 body {
-  @apply bg-white text-slate-900 dark:bg-slate-900 dark:text-slate-300;
+  @apply bg-(--color-surface-default) text-(--color-text-primary);
 }
 
 ::selection {
-  @apply bg-cytario-purple-500/60 text-white;
+  @apply bg-(--color-surface-brand)/60 text-white;
 }
 
 @font-face {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,24 @@ export default [
           },
         },
       ],
+      // Chrome must use design tokens (bg-(--color-*)), never raw Tailwind
+      // gray-family utilities or the retired cytario-* brand palette. Genuine
+      // shades go through the slate CSS var: e.g. bg-(--color-slate-300).
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "Literal[value=/(?:text|bg|border|ring|divide|fill|stroke|from|via|to|outline|placeholder|shadow)-(?:slate|gray|neutral|zinc|stone)-[0-9]|cytario-(?:purple|turquoise)/]",
+          message:
+            "Use design tokens (e.g. text-(--color-text-secondary), bg-(--color-surface-subtle)) instead of raw Tailwind gray/cytario color utilities.",
+        },
+        {
+          selector:
+            "TemplateElement[value.cooked=/(?:text|bg|border|ring|divide|fill|stroke|from|via|to|outline|placeholder|shadow)-(?:slate|gray|neutral|zinc|stone)-[0-9]|cytario-(?:purple|turquoise)/]",
+          message:
+            "Use design tokens (e.g. text-(--color-text-secondary), bg-(--color-surface-subtle)) instead of raw Tailwind gray/cytario color utilities.",
+        },
+      ],
     },
     settings: {
       react: {


### PR DESCRIPTION
Migrates cytario-web onto the `@cytario/design` color tokens. Part of [C-253](https://app.plane.so/cytario/browse/C-253/).

> **Depends on** cytario-design#20 — consumes its `surface-*` / `text-*` tokens and the removal of the `brand-*` family. Needs a published `@cytario/design` bump before merge (fine in local-linked dev).

## What
- **Removed the parallel brand palette** — deleted the app-local `--color-cytario-purple/turquoise` scale (it diverged from the design system's teal/purple); use design tokens instead.
- **Raw gray utilities → semantic tokens** — migrated `slate-/gray-/neutral-*` Tailwind utilities to `text-*` / `surface-*` / `border-*` tokens by role; shade-only greys routed through the slate CSS var.
- **Collapsed hand-rolled `dark:` overrides** into auto-theming tokens (hover uses the new `surface-hover` overlay) — base body bg/text now theme automatically.
- **Brand usage is role-correct** — fills use `surface-brand`/`surface-accent`, branded text uses `text-brand`; `Logo` uses the brand **primitives** directly (fixed identity, theme-invariant). The property-agnostic `brand-*` family is gone.
- **ESLint guardrail** — bans raw gray/`cytario-*` color utilities so chrome can only use tokens.

## Verify
- `npx tsc --noEmit` clean; ESLint passes (pre-existing `@cytario/design/styles.css` import-resolution warning aside).
- Run the app; view `AppHeader` / `Sidebar` / `DataGrid` / admin tables (incl. dark-scoped regions) — colors theme correctly; no `cytario-*` or raw-gray classes remain.

## Notes
- The idiomatic `primary`/`secondary` rename and any further consolidation are deferred (design 2b).