### PR TITLE
fix(c-81): allow connection-root favorites with empty pathName

### DIFF
--- a/app/routes/favorites/__tests__/addFavorite.action.test.ts
+++ b/app/routes/favorites/__tests__/addFavorite.action.test.ts
@@ -99,6 +99,26 @@ describe("addFavorite action", () => {
     });
   });
 
+  test("adds a connection-root favorite with empty pathName", async () => {
+    mockAddFavorite.mockResolvedValue(undefined);
+
+    const formData = createFormData({
+      connectionName: "my-bucket",
+      pathName: "",
+      displayName: "my-bucket",
+    });
+
+    const response = await addFavoriteAction(createActionArgs("PUT", formData));
+    const json = await (response as Response).json();
+
+    expect(json).toEqual({ ok: true });
+    expect(mockAddFavorite).toHaveBeenCalledWith("user-1", {
+      connectionName: "my-bucket",
+      pathName: "",
+      displayName: "my-bucket",
+    });
+  });
+
   test("returns 400 with missing connectionName", async () => {
     const formData = createFormData({
       connectionName: "",

--- a/app/routes/favorites/__tests__/removeFavorite.action.test.ts
+++ b/app/routes/favorites/__tests__/removeFavorite.action.test.ts
@@ -70,6 +70,21 @@ describe("removeFavorite action", () => {
     expect(mockRemoveFavorite).toHaveBeenCalledWith("user-1", "my-bucket", "data/images/");
   });
 
+  test("removes a connection-root favorite with empty pathName", async () => {
+    mockRemoveFavorite.mockResolvedValue(undefined);
+
+    const formData = createFormData({
+      connectionName: "my-bucket",
+      pathName: "",
+    });
+
+    const response = await removeFavoriteAction(createActionArgs("DELETE", formData));
+    const json = await (response as Response).json();
+
+    expect(json).toEqual({ ok: true });
+    expect(mockRemoveFavorite).toHaveBeenCalledWith("user-1", "my-bucket", "");
+  });
+
   test("returns 400 with missing connectionName", async () => {
     const formData = createFormData({
       connectionName: "",

--- a/app/routes/favorites/favorites.schema.ts
+++ b/app/routes/favorites/favorites.schema.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
+// pathName is "" for connection-root favorites. The action guard collapses
+// empty strings to undefined, so default("") restores the root case here.
 export const addFavoriteSchema = z.object({
   connectionName: z.string().min(1),
-  pathName: z.string(),
+  pathName: z.string().optional().default(""),
   displayName: z.string().min(1),
   totalSize: z.coerce.number().optional(),
   lastModified: z.coerce.number().optional(),
@@ -10,5 +12,5 @@ export const addFavoriteSchema = z.object({
 
 export const removeFavoriteSchema = z.object({
   connectionName: z.string().min(1),
-  pathName: z.string(),
+  pathName: z.string().optional().default(""),
 });

--- a/app/routes/recent/__tests__/recordRecentlyViewed.action.test.ts
+++ b/app/routes/recent/__tests__/recordRecentlyViewed.action.test.ts
@@ -77,6 +77,28 @@ describe("recordRecentlyViewed action", () => {
     });
   });
 
+  test("records a connection-root entry with empty pathName", async () => {
+    mockUpsertRecentlyViewed.mockResolvedValue(undefined);
+
+    const formData = createFormData({
+      connectionName: "my-bucket",
+      pathName: "",
+      name: "my-bucket",
+      type: "directory",
+    });
+
+    const response = await recordRecentlyViewed(createActionArgs("POST", formData));
+    const json = await (response as Response).json();
+
+    expect(json).toEqual({ ok: true });
+    expect(mockUpsertRecentlyViewed).toHaveBeenCalledWith("user-1", {
+      connectionName: "my-bucket",
+      pathName: "",
+      name: "my-bucket",
+      type: "directory",
+    });
+  });
+
   test("returns 400 with invalid type", async () => {
     const formData = createFormData({
       connectionName: "my-bucket",

--- a/app/routes/recent/recent.schema.ts
+++ b/app/routes/recent/recent.schema.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
+// pathName is "" for connection-root entries. The action guard collapses
+// empty strings to undefined, so default("") restores the root case here —
+// matching favorites.schema.ts.
 export const recordViewedSchema = z.object({
   connectionName: z.string().min(1),
-  pathName: z.string(),
+  pathName: z.string().optional().default(""),
   name: z.string().min(1),
   type: z.enum(["file", "directory"]),
 });


### PR DESCRIPTION
## Problem

Toggling favorite on a **connection root** (e.g. `/connections/Ascent Pharma Group`) errored silently: `DELETE /favorites.data 400`. Nested paths (`/connections/.../e2e-fixtures`) worked fine.

## Root cause

The favorites action guard ([actionGuard.ts](https://github.com/cytario/cytario-web/blob/main/app/utils/actionGuard.ts)) collapses empty form-data strings to `undefined` so optional metadata fields (`totalSize`, `lastModified`) stay absent. This also clobbered `pathName=""` — the connection-root case — which then failed the required `z.string()` check in both favorite schemas. Result: add **and** remove returned 400 for connection roots. Only unset was visible in practice, since affected roots were already favorited (pre-refactor `/api/pinned`).

Distinct from the `shouldRevalidate` bug fixed in #130.

## Fix

`pathName` → `z.string().optional().default("")` in both `addFavoriteSchema` and `removeFavoriteSchema`. The collapsed value restores to the root path `""`.

## Tests

Added root-case (`pathName=""`) tests to both action suites — expect `ok:true`, not 400. Full favorites suite: 21 pass.

Follow-up to the recents/favorites consolidation (Plane C-81); ticket stays open for its remaining follow-ups.

## Follow-up (architect review)

Aligned `recent.schema.ts` `pathName` to the same `.optional().default("")` — `recordViewedSchema` had the identical bare-`z.string()` vs guard `""`→`undefined` mismatch. Not yet reachable (objects-route recent submit is gated on a truthy `urlPath`), but the two sibling schemas from the same refactor should agree. Added a connection-root test. Recent suite: 18 pass.
