### PR TITLE
fix(c-140): Logo a11y — role="img", link label, reduced-motion

### DIFF
--- a/app/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/app/components/Breadcrumbs/Breadcrumbs.tsx
@@ -36,7 +36,7 @@ export function Breadcrumbs() {
   return (
     <div className="flex h-full items-center mx-2 gap-1">
       {rootCrumb && (
-        <Link to={rootCrumb.to} className="flex items-center h-full px-1">
+        <Link to={rootCrumb.to} aria-label="Go to home" className="flex items-center h-full px-1">
           <Logo scale={1.4} />
         </Link>
       )}

--- a/app/components/Logo.tsx
+++ b/app/components/Logo.tsx
@@ -1,7 +1,7 @@
 // The logo is the fixed brand identity — use the brand primitives directly
 // (theme-invariant), not theme-adaptive semantic tokens.
 import { ColorPurple700, ColorTeal500 } from "@cytario/design";
-import { motion } from "framer-motion";
+import { motion, useReducedMotion } from "framer-motion";
 
 const W = 56;
 const H = 20;
@@ -34,6 +34,7 @@ export const Logo = ({
   scale?: number;
   className?: string;
 }) => {
+  const reduceMotion = useReducedMotion();
   const width = W * scale;
   const height = H * scale;
   const paths = {
@@ -48,6 +49,7 @@ export const Logo = ({
   };
   return (
     <motion.svg
+      role="img"
       aria-label="Cytario Logo"
       width={width}
       height={height}
@@ -55,7 +57,7 @@ export const Logo = ({
       fill={color ?? ColorPurple700}
       className={className}
       variants={containerVariants}
-      initial="hidden"
+      initial={reduceMotion ? false : "hidden"}
       animate="visible"
     >
       {Object.entries(paths).map(([key, d]) => (

--- a/app/components/__tests__/__snapshots__/Logo.test.tsx.snap
+++ b/app/components/__tests__/__snapshots__/Logo.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`it matches the snapshot 1`] = `
     aria-label="Cytario Logo"
     fill="white"
     height="20"
+    role="img"
     viewBox="0 0 56 20"
     width="56"
   >


### PR DESCRIPTION
## Summary

Accessibility pass on the brand Logo, folding two related tickets into one PR (same component, same a11y review).

**C-140** — Logo SVG role + accessible link name
- Added `role="img"` to the Logo `<motion.svg>` so NVDA + Chrome announce it as a single image instead of walking the per-letter path IDs (`c`, `y`, `t`, …, `®`) as separate unlabelled nodes.
- Added `aria-label="Go to home"` to the Breadcrumbs home link. Per the accessible-name spec, a link's `aria-label` is authoritative and does not concatenate descendant names, so the nested SVG is not double-announced — no `aria-hidden` / extra prop needed.

**C-141** — respect `prefers-reduced-motion`
- Logo stagger fade-in now checks `useReducedMotion()`; when reduced motion is requested, paths render at full opacity immediately (`initial={false}`).
- The "replays on every route change" sub-concern does not occur: `AppHeader` mounts above the `Outlet` in `root.tsx`, so the Logo mounts once per session and the stagger never re-triggers on client-side navigation. No guard needed.

## Test plan
- `npm run typecheck` — clean
- `npm run lint` — clean (pre-existing DataGrid warning unrelated)
- `vitest` Logo + Breadcrumbs — pass; Logo snapshot regenerated to include `role="img"`

Closes [C-140] [C-141]