### PR TITLE
fix(viewer): prevent split-view resize crash (React #185)

### DIFF
--- a/app/components/.client/ImageViewer/components/Image/ImagePanel.tsx
+++ b/app/components/.client/ImageViewer/components/Image/ImagePanel.tsx
@@ -70,16 +70,16 @@ const ImagePanelInner = ({
   const layers = [multiscaleLayer, ...markersLayers];
 
   useEffect(() => {
-    if (!metadata || !width || !height) return;
+    if (!isActivePanel || !metadata || !width || !height) return;
 
     if (!viewStateActive) {
       const initViewState = calculateViewStateToFit(metadata, { width, height }, { padding });
-
       setViewStateActive(initViewState);
     } else if (viewStateActive.width !== width || viewStateActive.height !== height) {
-      setViewStateActive({ ...viewStateActive, width, height });
+      const updatedViewState = { ...viewStateActive, width, height };
+      setViewStateActive(updatedViewState);
     }
-  }, [metadata, padding, setViewStateActive, width, height, viewStateActive]);
+  }, [isActivePanel, metadata, padding, setViewStateActive, width, height, viewStateActive]);
 
   const onViewStateChange = useCallback(
     ({ viewState }: { viewState: OrthographicViewState }) => {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -23,7 +23,7 @@ import { UserProfile } from "./.server/auth/getUserInfo";
 import { sessionContext, sessionMiddleware } from "./.server/auth/sessionMiddleware";
 import { sessionStorage } from "./.server/auth/sessionStorage";
 import { AppHeader } from "./components/AppHeader";
-import { Section } from "./components/Container";
+import { Container, Section } from "./components/Container";
 import { type NotificationInput } from "./components/Notification/Notification.store";
 import { cytarioConfig } from "./config";
 import { toastBridge, toToastVariant } from "./toast-bridge";
@@ -210,13 +210,15 @@ export function ErrorBoundary() {
 
   return (
     <Section>
-      <div role="alert">
-        <H1>{title}</H1>
-        <p>{message}</p>
-        <a href="/" className="text-(--color-text-brand) underline mt-4 inline-block">
-          Go home
-        </a>
-      </div>
+      <Container>
+        <div role="alert">
+          <H1>{title}</H1>
+          <p>{message}</p>
+          <a href="/" className="text-(--color-text-brand) underline mt-4 inline-block">
+            Go home
+          </a>
+        </div>
+      </Container>
     </Section>
   );
 }


### PR DESCRIPTION
## Problem

Dragging a sidebar in the viewer intermittently crashed with React error #185 (*Maximum update depth exceeded*). Reliably reproducible in **split view**, worsening with each added deck.gl panel.

## Root cause

Every `ImagePanel` wrote its own container `width`/`height` into the **shared** `viewStateActive` store slice. With multiple panels of differing sizes, each panel's resize effect demanded its own dimensions on the one shared value:

```
Panel A (w=500): viewStateActive.width(400) !== 500 → set 500
Panel B (w=400): viewStateActive.width(500) !== 400 → set 400
A → 500 → B → 400 → ...  ∞
```

The effect depends on `viewStateActive` and writes it, so the divergence never settled → nested-update limit. A sidebar drag resizes every panel's flex container at once (via ResizeObserver), igniting the war.

## Fix

Scope the dimension sync to the **active** panel only — one writer, converges. Inactive panels still render at their own size via the `<DeckGL width/height>` props (deck.gl ignores `viewState.width/height`; those are read only by `useMeasurements` and the reset button, both active-panel-only).

One-line guard change in `ImagePanel.tsx`.

## Test

- Single panel: unchanged (already the sole writer).
- Split view: drag sidebar → no crash.