### PR TITLE
refactor(tokens): adopt shadcn-aligned @cytario/design token utilities

### DIFF
--- a/app/components/.client/ImageViewer/components/ChannelsController/ChannelsControllerBrightfieldItem.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/ChannelsControllerBrightfieldItem.tsx
@@ -35,16 +35,16 @@ export function ChannelsControllerBrightfieldItem({
       relative
       flex items-center gap-2
       focus:outline-none
-      data-[focus]:outline-1
-      data-[focus]:outline-[var(--color-text-primary)]
+      focus-visible:outline-1
+      focus-visible:outline-foreground
       py-2
-      border-b border-[var(--color-surface-subtle)]
-      text-[var(--color-text-secondary)]
+      border-b border-card
+      text-muted-foreground
       transition-colors
       border-none
     `,
-    isVisible && "text-[var(--color-text-primary)]",
-    isActive && "bg-[var(--color-surface-subtle)]",
+    isVisible && "text-foreground",
+    isActive && "bg-card",
   );
 
   // Brightfield needs 3 channel slots
@@ -58,7 +58,7 @@ export function ChannelsControllerBrightfieldItem({
   return (
     <Radio value={BRIGHTFIELD_GROUP_ID} className={cx}>
       {/* Tri-color indicator */}
-      <div className="flex w-5 h-5 rounded-full overflow-hidden border-2 border-(--color-slate-500)">
+      <div className="flex w-5 h-5 rounded-full overflow-hidden border-2 border-border">
         <div className="grow h-full  bg-red-500" />
         <div className="grow h-full bg-green-500" />
         <div className="grow h-full  bg-blue-500" />
@@ -72,7 +72,7 @@ export function ChannelsControllerBrightfieldItem({
         <Switch
           isSelected={isVisible}
           onChange={() => toggleVisibility()}
-          color="var(--color-text-secondary)"
+          color="var(--color-muted-foreground)"
           isDisabled={disabled}
         />
       </Tooltip>

--- a/app/components/.client/ImageViewer/components/ChannelsController/ChannelsControllerItem.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/ChannelsControllerItem.tsx
@@ -46,16 +46,16 @@ export function ChannelsControllerItem({
       relative
       flex items-center gap-2
       focus:outline-none
-      data-[focus]:outline-1
-      data-[focus]:outline-[var(--color-text-primary)]
+      focus-visible:outline-1
+      focus-visible:outline-foreground
       py-2
-      border-b border-[var(--color-surface-subtle)]
-      text-[var(--color-text-secondary)]
+      border-b border-card
+      text-muted-foreground
       transition-colors
       border-none
     `,
-    isVisible && "text-[var(--color-text-primary)]",
-    isActive && "bg-[var(--color-surface-subtle)]",
+    isVisible && "text-foreground",
+    isActive && "bg-card",
   );
 
   const disabled = !isVisible && visibleChannelCount >= MAX_VISIBLE_CHANNELS;
@@ -86,7 +86,7 @@ export function ChannelsControllerItem({
 
       {/* Pixel Value */}
       {pixelValue > 0 && (
-        <span className="text-xs tabular-nums text-(--color-text-secondary)">{pixelValue}</span>
+        <span className="text-xs tabular-nums text-muted-foreground">{pixelValue}</span>
       )}
 
       {/* Visibility Toggle */}

--- a/app/components/.client/ImageViewer/components/ChannelsController/ColorPicker/ColorPicker.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/ColorPicker/ColorPicker.tsx
@@ -73,12 +73,12 @@ export function ColorPicker({ color, onColorChange }: ColorPickerProps) {
                   yChannel="brightness"
                   className="relative w-full h-40 rounded touch-none"
                 >
-                  <ColorThumb className="block w-4 h-4 rounded-full border-2 border-white shadow-md focus-visible:outline-2 focus-visible:outline-(--color-border-focus)" />
+                  <ColorThumb className="block w-4 h-4 rounded-full border-2 border-white shadow-md focus-visible:outline-2 focus-visible:outline-ring" />
                 </ColorArea>
 
                 <ColorSlider colorSpace="hsb" channel="hue" className="w-full" aria-label="Hue">
                   <SliderTrack className="relative h-3 rounded touch-none">
-                    <ColorThumb className="block w-4 h-4 rounded-full border-2 border-white shadow-md top-1/2 focus-visible:outline-2 focus-visible:outline-(--color-border-focus)" />
+                    <ColorThumb className="block w-4 h-4 rounded-full border-2 border-white shadow-md top-1/2 focus-visible:outline-2 focus-visible:outline-ring" />
                   </SliderTrack>
                 </ColorSlider>
 

--- a/app/components/.client/ImageViewer/components/ChannelsController/ColorPicker/ColorSwatch.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/ColorPicker/ColorSwatch.tsx
@@ -13,7 +13,7 @@ export function ColorSwatch({ color, ...props }: ColorSwatchProps) {
       <div
         className={`
           w-5 h-5 m-1 rounded-full border-2 
-          border-(--color-border-default) group-hover:border-(--color-border-strong)
+          border-border group-hover:border-border
         `}
         style={{ backgroundColor: rgb(color) }}
       />

--- a/app/components/.client/ImageViewer/components/ChannelsController/DomainSlider.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/DomainSlider.tsx
@@ -18,7 +18,7 @@ export const DomainSlider = ({
   const setContrastLimits = useViewerStore(select.setContrastLimits);
   const [min, max] = domain;
 
-  const color = selectedChannel ? rgb(selectedChannel.color) : "var(--color-text-tertiary)";
+  const color = selectedChannel ? rgb(selectedChannel.color) : "var(--color-muted-foreground)";
 
   // The slider operates in normalized [0, 1] ratio space, the same mapping the
   // histogram uses, so handle positions stay aligned under linear or log scaling.
@@ -43,14 +43,14 @@ export const DomainSlider = ({
           styles={{
             rail: { backgroundColor: "transparent", height: 1 },
             track: {
-              backgroundColor: "var(--color-surface-default)",
+              backgroundColor: "var(--color-background)",
               height: 1,
             },
             handle: {
               width: 16,
               height: 16,
               backgroundColor: color,
-              borderColor: "var(--color-surface-default)",
+              borderColor: "var(--color-background)",
               borderWidth: 2,
               boxShadow: "none",
               opacity: 1,

--- a/app/components/.client/ImageViewer/components/ChannelsController/Histogram.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/Histogram.tsx
@@ -47,12 +47,12 @@ export function Histogram() {
 
   return (
     <div ref={ref} className="relative top-0 overflow-hidden px-3 pt-3">
-      <div className="relative p-2 pb-2 bg-[var(--color-surface-subtle)] rounded overflow-visible">
+      <div className="relative p-2 pb-2 bg-card rounded overflow-visible">
         <div className="absolute right-2 top-2 z-10">
           <ToggleButton
             size="xs"
             variant="outlined"
-            className="text-(--color-text-tertiary)"
+            className="text-muted-foreground"
             aria-label={`Intensity axis scale: ${logScaleX ? "logarithmic" : "linear"}`}
             isSelected={logScaleX}
             onChange={setLogScaleX}
@@ -84,7 +84,7 @@ export function Histogram() {
 
         <DomainSlider domain={[0, maxDomain]} logScaleX={logScaleX} />
 
-        <div className="grid grid-cols-3 text-[10px] leading-loose text-(--color-text-tertiary) tabular-nums">
+        <div className="grid grid-cols-3 text-[10px] leading-loose text-muted-foreground tabular-nums">
           <span className="text-left">{xTicks[0]}</span>
           <span className="text-center">{xTicks[1]}</span>
           <span className="text-right">{xTicks[2]}</span>

--- a/app/components/.client/ImageViewer/components/ChannelsController/MinMaxSettings.tsx
+++ b/app/components/.client/ImageViewer/components/ChannelsController/MinMaxSettings.tsx
@@ -84,7 +84,7 @@ export function MinMaxSettings() {
         </label>
         <input
           id="min-contrast"
-          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-(--color-slate-500) bg-(--color-slate-950) text-(--color-slate-300) disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-border bg-background text-foreground disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
           type="number"
           value={minValue}
           disabled={!selectedChannel}
@@ -102,7 +102,7 @@ export function MinMaxSettings() {
         </label>
         <input
           id="max-contrast"
-          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-(--color-slate-500) bg-(--color-slate-950) text-(--color-slate-300) disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+          className="flex w-full h-8 px-2 text-base text-right rounded-sm border border-border bg-background text-foreground disabled:opacity-50 disabled:cursor-not-allowed [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
           type="number"
           value={maxValue}
           disabled={!selectedChannel}

--- a/app/components/.client/ImageViewer/components/Image/ImageContainer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/ImageContainer.tsx
@@ -33,17 +33,17 @@ export function ImageContainer({
   const error = useViewerStore(select.error);
 
   const style = `
-    relative flex flex-grow
+    relative flex grow
     w-full h-full 
     overflow-hidden
   `;
 
-  let background = "bg-[var(--color-surface-default)]";
+  let background = "bg-background";
   if (isPreview) background = "bg-black";
-  if (error) background = "bg-[var(--color-surface-muted)]";
+  if (error) background = "bg-muted";
 
-  let border = "border border-2 border-[var(--color-border-strong)]";
-  if (isActivePanel) border += " border-[var(--color-text-secondary)]";
+  let border = "border border-2 border-border";
+  if (isActivePanel) border += " border-muted-foreground";
   if (isPreview) border += " border-none";
   if (error) background += " border-none";
 
@@ -54,7 +54,7 @@ export function ImageContainer({
     pointer-events-none w-full h-full 
     absolute top-0 left-0
     border-[16px]
-    box-border border-[var(--color-text-secondary)]
+    box-border border-muted-foreground
   `,
     isActivePanel ? "animate-pulse-once" : "border-none",
   );
@@ -71,9 +71,9 @@ export function ImageContainer({
         {error ? (
           <div
             className={`
-          flex flex-grow w-full h-full flex-col
+          flex grow w-full h-full flex-col
           items-center justify-center text-center
-          overflow-hidden gap-1 p-2 text-(--color-slate-500)
+          overflow-hidden gap-1 p-2 text-muted-foreground
         `}
           >
             <ImageOff size={isPreview ? 20 : 32} strokeWidth={1.5} />

--- a/app/components/.client/ImageViewer/components/Image/ImagePanel.tsx
+++ b/app/components/.client/ImageViewer/components/Image/ImagePanel.tsx
@@ -132,9 +132,9 @@ const ImagePanelInner = ({
         <div
           className={`
             absolute px-2 py-1 rounded shadow-lg
-            bg-[var(--color-surface-default)]
-            border border-[var(--color-border-default)]
-            text-[var(--color-text-primary)] text-sm
+            bg-background
+            border border-border
+            text-foreground text-sm
             pointer-events-none
           `}
           style={{
@@ -215,7 +215,7 @@ const TileLoaderIndicator = ({
         {channelsLoadingTiles.map((_, index) => (
           <div
             key={index}
-            className="w-2 h-2 rounded-sm m-1 bg-white border border-[var(--color-border-default)] animate-pulse"
+            className="w-2 h-2 rounded-sm m-1 bg-white border border-border animate-pulse"
           />
         ))}
       </div>
@@ -223,7 +223,7 @@ const TileLoaderIndicator = ({
         {overlaysLoadingTiles.map((_, index) => (
           <div
             key={index}
-            className="w-2 h-2 rounded-sm m-1 bg-white border border-[var(--color-border-default)] animate-pulse"
+            className="w-2 h-2 rounded-sm m-1 bg-white border border-border animate-pulse"
           />
         ))}
       </div>

--- a/app/components/.client/ImageViewer/components/ImageViewer.tsx
+++ b/app/components/.client/ImageViewer/components/ImageViewer.tsx
@@ -39,7 +39,7 @@ export const Viewer = ({ url, signedFetch }: ViewerProps) => {
 
       <div
         data-theme="dark"
-        className="relative flex grow h-full bg-(--color-slate-950) text-(--color-text-primary) overflow-hidden"
+        className="relative flex grow h-full bg-background text-foreground overflow-hidden"
       >
         <ImagePanels />
         <Sidebar

--- a/app/components/.client/ImageViewer/components/Measurements/Crosshair.tsx
+++ b/app/components/.client/ImageViewer/components/Measurements/Crosshair.tsx
@@ -42,7 +42,7 @@ export const Crosshair = () => {
             x2={0}
             y2={+size}
             strokeWidth={3}
-            className="stroke-[var(--color-text-tertiary)]"
+            className="stroke-muted-foreground"
           />
           <line
             x1={-size}
@@ -50,7 +50,7 @@ export const Crosshair = () => {
             x2={+size}
             y2={0}
             strokeWidth={3}
-            className="stroke-[var(--color-text-tertiary)]"
+            className="stroke-muted-foreground"
           />
         </g>
         <g>

--- a/app/components/.client/ImageViewer/components/Measurements/Scale.tsx
+++ b/app/components/.client/ImageViewer/components/Measurements/Scale.tsx
@@ -47,7 +47,7 @@ export const Scale = () => {
         absolute top-0 right-0 
         flex flex-col items-center
         text-xs font-semibold
-        bg-[var(--color-text-secondary)] text-[var(--color-surface-default)]
+        bg-muted-foreground text-background
       `}
       style={{ width: size }}
     >

--- a/app/components/.client/ImageViewer/components/Measurements/SlideCarrier.tsx
+++ b/app/components/.client/ImageViewer/components/Measurements/SlideCarrier.tsx
@@ -49,7 +49,7 @@ const Size = ({ value, vertical = false }: { value: number; vertical?: boolean }
         h-4 
         origin-top-left 
         text-xs font-semibold
-        text-(--color-text-secondary)
+        text-muted-foreground
         `}
       style={{
         width: vertical ? imageHeightScreen : imageWidthScreen,

--- a/app/components/.client/ImageViewer/components/Measurements/Tick.tsx
+++ b/app/components/.client/ImageViewer/components/Measurements/Tick.tsx
@@ -11,8 +11,8 @@ export const Tick = ({ number, offset }: TickProps) => {
   const adjustedOffset = offset - 2; // Account for border width
 
   const cx = twMerge(
-    "absolute left-0 bg-[var(--color-surface-default)]",
-    "border-l border-l-[var(--color-text-secondary)]",
+    "absolute left-0 bg-background",
+    "border-l border-l-muted-foreground",
     isMajor ? "h-4" : "h-2",
   );
 

--- a/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.Item.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.Item.tsx
@@ -88,7 +88,7 @@ export const OverlaysControllerItem = ({
       <div className="flex items-center gap-1.5 px-3 pt-2">
         <button
           type="button"
-          className="flex-1 min-w-0 truncate rounded border border-[var(--color-border-default)] bg-[var(--color-surface-subtle)] px-2 py-1 text-xs text-[var(--color-text-primary)] text-left"
+          className="flex-1 min-w-0 truncate rounded border border-border bg-card px-2 py-1 text-xs text-foreground text-left"
           onClick={() => setIsOpen(!isOpen)}
         >
           {fileName}
@@ -143,7 +143,7 @@ export const OverlaysControllerItem = ({
               );
             })
           ) : (
-            <div className="p-4 text-sm text-[var(--color-text-secondary)]">
+            <div className="p-4 text-sm text-muted-foreground">
               No markers found in this overlay
             </div>
           )}

--- a/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.tsx
+++ b/app/components/.client/ImageViewer/components/OverlaysController/OverlaysController.tsx
@@ -42,7 +42,7 @@ export const OverlaysController = () => {
               onPress={() => setShowCellOutline(!showCellOutline)}
               variant="ghost"
               size="sm"
-              className={`border-none ${showCellOutline ? "stroke-(--color-text-primary)" : "stroke-(--color-text-tertiary)"}`}
+              className={`border-none ${showCellOutline ? "stroke-foreground" : "stroke-muted-foreground"}`}
             />
           )}
           <FeatureItemSlider

--- a/app/components/.client/ImageViewer/components/Presets/Presets.tsx
+++ b/app/components/.client/ImageViewer/components/Presets/Presets.tsx
@@ -24,8 +24,8 @@ export function Presets({ children }: { children: React.ReactNode }) {
         className={`
           flex items-center justify-between
           gap-1.5 px-3 pt-4 pb-3
-          border-b border-[var(--color-border-default)]
-          flex-shrink-0
+          border-b border-border
+          shrink-0
           relative left-0 right-0
         `}
       >
@@ -43,15 +43,15 @@ export function Presets({ children }: { children: React.ReactNode }) {
                 p-0
 
                 border transition-colors
-                border-[var(--color-border-strong)]
-                bg-[var(--color-surface-muted)]
-                data-[hovered]:bg-[var(--color-border-strong)]
+                border-border
+                bg-muted
+                data-hovered:bg-border
 
-                data-[selected]:border-[var(--color-border-focus)]
-                data-[selected]:ring-1
-                data-[selected]:ring-[var(--color-border-focus)]
-                data-[selected]:ring-offset-1
-                data-[selected]:ring-offset-[var(--color-surface-default)]
+                selected:border-ring
+                selected:ring-1
+                selected:ring-ring
+                selected:ring-offset-1
+                selected:ring-offset-background
               `}
             >
               <PresetLabel index={index} />
@@ -93,8 +93,8 @@ export const PresetLabel = ({ index }: { index: number }) => {
         className={`
           absolute top-0 left-0 px-1 py-px
           text-[10px] font-bold leading-tight
-          text-[var(--color-text-secondary)]
-          group-data-[selected]/tab:text-[var(--color-text-primary)]
+          text-muted-foreground
+          group-selected/tab:text-foreground
         `}
       >
         {index + 1}

--- a/app/components/.client/ImageViewer/components/SplitViewToggle.tsx
+++ b/app/components/.client/ImageViewer/components/SplitViewToggle.tsx
@@ -42,7 +42,7 @@ export const SplitViewToggle = () => {
           const background =
             colors.length > 0
               ? `linear-gradient(-45deg, ${colors.join(", ")})`
-              : "var(--color-surface-muted)";
+              : "var(--color-muted)";
 
           return (
             <div
@@ -52,7 +52,7 @@ export const SplitViewToggle = () => {
                 rounded-sm overflow-hidden
                 text-[10px] font-bold
                 border transition-all
-                ${activeImagePanelId === index ? "border-[var(--color-border-focus)] ring-1 ring-[var(--color-border-focus)] ring-offset-1 ring-offset-[var(--color-surface-default)]" : "border-[var(--color-border-strong)]"}
+                ${activeImagePanelId === index ? "border-ring ring-1 ring-ring ring-offset-1 ring-offset-background" : "border-border"}
               `}
               style={{ background }}
             >

--- a/app/components/AppHeader.tsx
+++ b/app/components/AppHeader.tsx
@@ -22,7 +22,7 @@ export function AppHeader() {
   return (
     <header
       data-theme="dark"
-      className="z-20 flex justify-between items-center h-12 bg-(--color-surface-default) top-0 left-0 right-0"
+      className="z-20 flex justify-between items-center h-12 bg-background top-0 left-0 right-0"
     >
       <div className="h-full flex items-center gap-1 shrink min-w-0 pl-2">
         <PanelToggle />

--- a/app/components/DataGrid/DataGrid.tsx
+++ b/app/components/DataGrid/DataGrid.tsx
@@ -93,7 +93,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
           cell: (info) => {
             const value = info.getValue();
             if (value === null || value === undefined) {
-              return <span className="text-(--color-text-tertiary) italic">null</span>;
+              return <span className="text-muted-foreground italic">null</span>;
             }
             if (typeof value === "boolean") {
               return <Checkbox isSelected={value} isDisabled />;
@@ -152,13 +152,13 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
   return (
     <div ref={containerRef} className="h-full overflow-auto">
       <table className="min-w-full border-collapse text-sm">
-        <thead className="bg-(--color-surface-muted) sticky top-0 z-10">
+        <thead className="bg-muted sticky top-0 z-10">
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className="grid" style={{ gridTemplateColumns }}>
               {headerGroup.headers.map((header) => (
                 <th
                   key={header.id}
-                  className={`border-b border-(--color-border-default) px-4 py-2 font-semibold ${
+                  className={`border-b border-border px-4 py-2 font-semibold ${
                     RIGHT_ALIGNED_COLUMNS.has(header.id) ? "text-right" : "text-left"
                   }`}
                 >
@@ -181,7 +181,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
             return (
               <tr
                 key={row.id}
-                className="hover:bg-(--color-surface-hover) absolute w-full grid"
+                className="hover:bg-accent absolute w-full grid"
                 style={{
                   gridTemplateColumns,
                   height: `${virtualRow.size}px`,
@@ -191,7 +191,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
-                    className={`border-b border-(--color-border-default) tabular-nums px-4 flex items-center ${
+                    className={`border-b border-border tabular-nums px-4 flex items-center ${
                       RIGHT_ALIGNED_COLUMNS.has(cell.column.id) ? "justify-end" : ""
                     }`}
                   >
@@ -204,7 +204,7 @@ export const DataGrid = ({ resourceId }: { resourceId: string }) => {
         </tbody>
       </table>
       {isFetchingMore && (
-        <div className="p-2 text-center text-(--color-text-tertiary)">Loading more...</div>
+        <div className="p-2 text-center text-muted-foreground">Loading more...</div>
       )}
     </div>
   );

--- a/app/components/DataGrid/WktSvg.tsx
+++ b/app/components/DataGrid/WktSvg.tsx
@@ -18,7 +18,7 @@ export const WktSvg = ({ wkt, size = 48 }: WktSvgProps) => {
   const paths = parseWkt(wkt);
 
   if (paths.length === 0) {
-    return <span className="text-(--color-text-tertiary) italic">invalid</span>;
+    return <span className="text-muted-foreground italic">invalid</span>;
   }
 
   // Calculate bounding box across all paths
@@ -58,7 +58,7 @@ export const WktSvg = ({ wkt, size = 48 }: WktSvgProps) => {
       width={size}
       height={size}
       viewBox={`0 0 ${size} ${size}`}
-      className="inline-block bg-(--color-surface-muted) rounded"
+      className="inline-block bg-muted rounded"
     >
       <path
         d={pathData}
@@ -66,7 +66,7 @@ export const WktSvg = ({ wkt, size = 48 }: WktSvgProps) => {
         fillOpacity={0.3}
         stroke="currentColor"
         strokeWidth={1}
-        className="text-(--color-text-accent)"
+        className="text-secondary"
       />
     </svg>
   );

--- a/app/components/DescriptionList.tsx
+++ b/app/components/DescriptionList.tsx
@@ -16,9 +16,7 @@ const DescriptionList = ({ data, className }: DescriptionListProps<any>) => {
           <React.Fragment key={key}>
             <dt className="font-bold text-sm w-32 truncate">{key}</dt>
             <dd>
-              <code className="text-(--color-text-secondary) px-2 py-1 bg-(--color-surface-subtle)">
-                {String(value)}
-              </code>
+              <code className="text-muted-foreground px-2 py-1 bg-card">{String(value)}</code>
             </dd>
           </React.Fragment>
         ))}

--- a/app/components/DirectoryView/DirectoryViewGrid.tsx
+++ b/app/components/DirectoryView/DirectoryViewGrid.tsx
@@ -49,7 +49,7 @@ function ImagePreviewSlot({
 }) {
   return (
     <ClientOnly>
-      <Suspense fallback={<div className="animate-pulse w-full h-full bg-(--color-slate-600)" />}>
+      <Suspense fallback={<div className="animate-pulse w-full h-full bg-muted" />}>
         <ViewerStoreProvider url={s3Url} signedFetch={signedFetch}>
           <ImagePreview />
         </ViewerStoreProvider>

--- a/app/components/DirectoryView/GridItem.tsx
+++ b/app/components/DirectoryView/GridItem.tsx
@@ -26,14 +26,14 @@ export function GridItem({ node, preview, children, className }: GridItemProps) 
 
   const cx = `
     group flex flex-col overflow-hidden rounded-lg
-    border border-(--color-border-default)
+    border border-border
     shadow-sm transition-all
-    hover:border-(--color-border-focus) hover:shadow-md
+    hover:border-ring hover:shadow-md
   `;
 
   return (
     <Link to={to} className={twMerge(cx, className)}>
-      <div className="shrink-0 overflow-hidden bg-(--color-slate-900) aspect-4/3 rounded-t-lg">
+      <div className="shrink-0 overflow-hidden bg-muted aspect-4/3 rounded-t-lg">
         {preview ?? (
           <div className="flex h-full w-full items-center justify-center">
             <NodeIcon node={node} size={32} />
@@ -41,7 +41,7 @@ export function GridItem({ node, preview, children, className }: GridItemProps) 
         )}
       </div>
 
-      <div className="flex flex-col gap-2 border-t border-(--color-border-default) bg-(--color-surface-default) px-3 py-2 rounded-b-lg">
+      <div className="flex flex-col gap-2 border-t border-border bg-background px-3 py-2 rounded-b-lg">
         <NodeLink node={node} isClickable={() => false} />
         {children && <div className="flex items-center gap-2">{children}</div>}
       </div>

--- a/app/components/DirectoryView/NodeLink/NodeLink.tsx
+++ b/app/components/DirectoryView/NodeLink/NodeLink.tsx
@@ -39,11 +39,11 @@ export function NodeLink({
   `;
 
   const clickAbleCx = `
-    hover:bg-(--color-surface-hover)
-    focus-visible:outline focus-visible:outline-(--color-border-focus)
+    hover:bg-accent
+    focus-visible:outline focus-visible:outline-ring
   `;
 
-  const activeCx = "bg-(--color-surface-selected) font-semibold text-(--color-text-primary)";
+  const activeCx = "bg-accent font-semibold text-foreground";
 
   const handleClick: MouseEventHandler<HTMLAnchorElement> = (event) => {
     if (!onClick) return;

--- a/app/components/DirectoryView/modals/Cyberduck.modal.tsx
+++ b/app/components/DirectoryView/modals/Cyberduck.modal.tsx
@@ -29,19 +29,19 @@ export default function CyberduckModal({ onClose }: { onClose: () => void }) {
 
   return (
     <RouteModal title="Access with Cyberduck" onClose={handleClose}>
-      <p className="text-(--color-text-secondary)">
+      <p className="text-muted-foreground">
         Cyberduck is a free desktop application that allows you to browse and manage your cloud
         storage files with a familiar file manager interface.
       </p>
 
-      <p className="text-(--color-text-secondary)">
+      <p className="text-muted-foreground">
         Download a pre-configured connection profile for <strong>{connectionName}</strong> that will
         automatically set up your authentication and bucket access in Cyberduck.
       </p>
 
-      <div className="bg-(--color-surface-subtle) border border-(--color-border-default) rounded-sm px-4 py-2 flex flex-col gap-2">
+      <div className="bg-card border border-border rounded-sm px-4 py-2 flex flex-col gap-2">
         <H3 className="text-lg font-normal">Quick Start</H3>
-        <ol className="list-decimal list-inside space-y-1 text-sm text-(--color-text-secondary)">
+        <ol className="list-decimal list-inside space-y-1 text-sm text-muted-foreground">
           <li>
             Download and install{" "}
             <Link href="https://cyberduck.io/download/" target="_blank" rel="noopener noreferrer">

--- a/app/components/FeatureItem/FeatureItem.tsx
+++ b/app/components/FeatureItem/FeatureItem.tsx
@@ -19,27 +19,27 @@ function FeatureItemInner({ title, badge, actions, header, children }: FeatureIt
   const setIsOpen = useFeatureItemStore((s) => s.setIsOpen);
 
   return (
-    <div className="flex flex-col w-full text-[var(--color-text-secondary)]">
-      <div className="z-10 sticky top-0 left-0 bg-[var(--color-surface-default)]">
+    <div className="flex flex-col w-full text-muted-foreground">
+      <div className="z-10 sticky top-0 left-0 bg-background">
         {/* Section divider */}
-        <div className="mx-3 h-px bg-[var(--color-border-default)]" />
+        <div className="mx-3 h-px bg-border" />
 
         <header className="flex items-center gap-2 px-3 pt-3 pb-2">
           <button
-            className="flex items-center gap-2 flex-grow text-left"
+            className="flex items-center gap-2 grow text-left"
             onClick={() => setIsOpen(!isOpen)}
           >
             {isOpen ? (
-              <ChevronDown size={14} className="text-[var(--color-text-secondary)] shrink-0" />
+              <ChevronDown size={14} className="text-muted-foreground shrink-0" />
             ) : (
-              <ChevronRight size={14} className="text-[var(--color-text-secondary)] shrink-0" />
+              <ChevronRight size={14} className="text-muted-foreground shrink-0" />
             )}
-            <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+            <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
               {title}
             </span>
           </button>
 
-          {badge && <span className="text-xs text-[var(--color-text-tertiary)]">{badge}</span>}
+          {badge && <span className="text-xs text-muted-foreground">{badge}</span>}
 
           {actions}
         </header>

--- a/app/components/LavaLoader.tsx
+++ b/app/components/LavaLoader.tsx
@@ -99,7 +99,7 @@ const LavaLoaderInner = ({ absolute = false, rows = 3, cols = 3 }: LavaLoaderPro
                 cx={size + col * size}
                 cy={size + row * size}
                 r={isActive ? 12 : 4}
-                className={`dot-${i}-${row} fill-(--color-slate-300) `}
+                className={`dot-${i}-${row} fill-muted-foreground `}
               />
             );
           })}

--- a/app/components/Layout/Footer.tsx
+++ b/app/components/Layout/Footer.tsx
@@ -6,10 +6,7 @@ interface FooterProps {
   className?: string;
 }
 export function Footer({ children, className }: FooterProps) {
-  const cx = twMerge(
-    "px-6 p-2 bg-(--color-surface-subtle) border-t border-(--color-border-strong)",
-    className,
-  );
+  const cx = twMerge("px-6 p-2 bg-card border-t border-border", className);
   return (
     <footer className={cx}>
       <div className="container mx-auto flex justify-between">{children}</div>

--- a/app/components/Sidebar/Explorer/SidebarSearchInput.tsx
+++ b/app/components/Sidebar/Explorer/SidebarSearchInput.tsx
@@ -36,7 +36,7 @@ export function SidebarSearchInput({ onQueryChange }: SidebarSearchInputProps) {
 
   return (
     <div className="flex items-center gap-1 px-2">
-      <Search size={16} className="shrink-0 text-(--color-text-secondary)" aria-hidden />
+      <Search size={16} className="shrink-0 text-muted-foreground" aria-hidden />
       <Input
         size="sm"
         id={SIDEBAR_SEARCH_INPUT_ID}

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -16,7 +16,7 @@ export const sidebarToggleId = (name: string) => `${slug(name)}-toggle`;
 // match. Teal accent explicitly (brand-accent = teal in light + dark), rather
 // than `variant="primary"` whose hue currently differs by theme.
 export const SIDEBAR_TOGGLE_ACTIVE_CLASS =
-  "bg-(--color-surface-accent) text-(--color-text-inverse) hover:bg-(--color-surface-accent)";
+  "bg-secondary text-primary-foreground hover:bg-secondary";
 
 const focusById = (id: string) => requestAnimationFrame(() => document.getElementById(id)?.focus());
 
@@ -110,7 +110,7 @@ export function Sidebar({
       data-theme="dark"
       style={{ width: motionWidth }}
       className={twMerge(
-        "relative shrink-0 border-(--color-border-default) bg-(--color-surface-default) text-(--color-text-primary)",
+        "relative shrink-0 border-border bg-background text-foreground",
         side === "left" ? "border-r" : "border-l",
       )}
     >

--- a/app/components/Sidebar/SidebarResizeHandle.tsx
+++ b/app/components/Sidebar/SidebarResizeHandle.tsx
@@ -73,7 +73,7 @@ export function SidebarResizeHandle({ store, side, motionWidth }: SidebarResizeH
       aria-valuenow={Math.round(isOpen ? width : 0)}
       aria-valuemin={0}
       aria-valuemax={SIDEBAR_MAX_WIDTH}
-      className={`absolute top-0 z-30 h-full w-4 cursor-ew-resize hover:bg-(--color-slate-400)/40 ${
+      className={`absolute top-0 z-30 h-full w-4 cursor-ew-resize hover:bg-accent/40 ${
         side === "left" ? "right-0 translate-x-full" : "left-0 -translate-x-full"
       }`}
     />

--- a/app/components/Table/ColumnResizeHandle.tsx
+++ b/app/components/Table/ColumnResizeHandle.tsx
@@ -12,10 +12,10 @@ export const ColumnResizeHandle = ({ header }: { header: Header<unknown, unknown
         absolute top-0 right-0 h-full w-2
         flex justify-end
         transition-colors duration-200
-        bg-transparent hover:bg-(--color-slate-300) active:bg-(--color-surface-accent)
+        bg-transparent hover:bg-accent active:bg-secondary
       `}
     >
-      <div className="w-[1px] h-full bg-(--color-slate-300)" />
+      <div className="w-px h-full bg-border" />
     </button>
   );
 };

--- a/app/components/Table/ColumnSortButton.tsx
+++ b/app/components/Table/ColumnSortButton.tsx
@@ -7,9 +7,9 @@ function getStyle(sortDirection: false | SortDirection) {
   switch (sortDirection) {
     case "desc":
     case "asc":
-      return "text-(--color-text-secondary) group-hover/header:text-(--color-text-primary)";
+      return "text-muted-foreground group-hover/header:text-foreground";
     default:
-      return "text-(--color-text-tertiary) opacity-0 group-hover/header:opacity-100";
+      return "text-muted-foreground opacity-0 group-hover/header:opacity-100";
   }
 }
 

--- a/app/components/Table/SelectionFooter.tsx
+++ b/app/components/Table/SelectionFooter.tsx
@@ -18,13 +18,13 @@ export function SelectionFooter({
     <div
       role="toolbar"
       aria-label={`Bulk actions for ${selectedCount} selected items`}
-      className="sticky bottom-0 z-20 border-t border-(--color-border-strong) bg-white/95 backdrop-blur px-6 py-3"
+      className="sticky bottom-0 z-20 border-t border-border bg-white/95 backdrop-blur px-6 py-3"
     >
       <div className="container mx-auto flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <span className="text-sm text-(--color-text-secondary)">
-            <span className="font-medium text-(--color-text-primary)">{selectedCount}</span> of{" "}
-            {totalCount} selected
+          <span className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{selectedCount}</span> of {totalCount}{" "}
+            selected
           </span>
           <Button variant="secondary" size="sm" onPress={onReset}>
             Clear selection

--- a/app/components/Table/Table.tsx
+++ b/app/components/Table/Table.tsx
@@ -161,7 +161,7 @@ export function Table<TData extends object>({
       {/* Sticky header — sticks vertically, scrolls horizontally (hidden scrollbar) */}
       <div
         ref={headerRef}
-        className="sticky top-0 z-10 bg-white border-b border-(--color-border-strong) overflow-x-auto"
+        className="sticky top-0 z-10 bg-white border-b border-border overflow-x-auto"
         style={{ scrollbarWidth: "none" }}
         onScroll={handleHeaderScroll}
       >

--- a/app/components/Table/TableBodyRow.tsx
+++ b/app/components/Table/TableBodyRow.tsx
@@ -42,10 +42,10 @@ export function TableBodyRow({
       tabIndex={0}
       onKeyDown={handleKeyDown}
       className={twMerge(
-        "w-full block border-b border-(--color-border-strong)",
-        "hover:bg-(--color-surface-subtle) transition-colors",
-        "focus-visible:outline-none focus-visible:bg-(--color-surface-muted) focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-(--color-border-focus)",
-        row.getIsSelected() && "bg-(--color-surface-selected)",
+        "w-full block border-b border-border",
+        "hover:bg-card transition-colors",
+        "focus-visible:outline-none focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+        row.getIsSelected() && "bg-accent",
         className,
       )}
     >
@@ -87,7 +87,7 @@ export function TableBodyRow({
 
         return isIndexColumn ? (
           <th key={cell.id} className="p-2" style={style}>
-            <div className="flex items-center gap-1 text-sm text-(--color-text-tertiary) tabular-nums justify-between">
+            <div className="flex items-center gap-1 text-sm text-muted-foreground tabular-nums justify-between">
               {enableRowSelection && (
                 <Checkbox isSelected={row.getIsSelected()} onChange={() => row.toggleSelected()} />
               )}

--- a/app/components/Table/TableHeaderRow.tsx
+++ b/app/components/Table/TableHeaderRow.tsx
@@ -66,15 +66,15 @@ export function TableHeaderRow({
         // Match FilterBar's label styling (Input/Select's internal <Label>).
         const tableHeadCx = `
           flex items-center justify-between gap-1 h-8 text-left
-          text-sm font-medium text-(--color-text-primary)
+          text-sm font-medium text-foreground
         `;
 
         const tableHeadToggleCx = `
           cursor-pointer
-          hover:text-(--color-text-secondary)
+          hover:text-muted-foreground
           focus-visible:outline-none
           focus-visible:ring-2
-          focus-visible:ring-(--color-border-focus)
+          focus-visible:ring-ring
           focus-visible:ring-offset-1
           rounded-sm
         `;
@@ -128,7 +128,7 @@ export function TableHeaderRow({
                       tableHeadCx,
                       tableHeadToggleCx,
                       isRight && "flex-row-reverse",
-                      isSorted && "text-(--color-text-primary)",
+                      isSorted && "text-foreground",
                     )}
                     onClick={header.column.getToggleSortingHandler() ?? undefined}
                   >

--- a/app/components/UserMenu.tsx
+++ b/app/components/UserMenu.tsx
@@ -26,7 +26,7 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
               <div className="font-semibold">
                 {user.given_name} {user.family_name}
               </div>
-              <div className="text-[var(--color-text-secondary)]">{user.email}</div>
+              <div className="text-muted-foreground">{user.email}</div>
             </div>
           </MenuHeader>
 
@@ -79,7 +79,7 @@ export function UserMenu({ user, accountSettingsUrl }: UserMenuProps) {
         icon={User}
         aria-label="User menu"
         variant="ghost"
-        className="flex-shrink-0 w-8 h-8 text-white hover:bg-white/15 pressed:bg-white/20"
+        className="shrink-0 w-8 h-8 text-white hover:bg-white/15 pressed:bg-white/20"
       />
     </Menu>
   );

--- a/app/components/__tests__/__snapshots__/Checkbox.test.tsx.snap
+++ b/app/components/__tests__/__snapshots__/Checkbox.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Checkbox component > matches snapshot when checked 1`] = `
 <DocumentFragment>
   <label
-    class="group flex items-center gap-2 text-sm text-(--color-text-primary) cursor-pointer disabled:opacity-50 disabled:cursor-default"
+    class="group flex items-center gap-2 text-sm text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-default"
     data-rac=""
     data-react-aria-pressable="true"
     data-selected="true"
@@ -20,11 +20,11 @@ exports[`Checkbox component > matches snapshot when checked 1`] = `
       />
     </span>
     <div
-      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-(--color-border-focus) group-focus-visible:ring-offset-2 bg-(--color-action-primary) border-(--color-action-primary)"
+      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 bg-primary border-primary"
     >
       <svg
         aria-hidden="true"
-        class="lucide lucide-check w-4 h-4 text-(--color-text-inverse)"
+        class="lucide lucide-check w-4 h-4 text-primary-foreground"
         fill="none"
         height="24"
         stroke="currentColor"
@@ -47,7 +47,7 @@ exports[`Checkbox component > matches snapshot when checked 1`] = `
 exports[`Checkbox component > matches snapshot when not checked 1`] = `
 <DocumentFragment>
   <label
-    class="group flex items-center gap-2 text-sm text-(--color-text-primary) cursor-pointer disabled:opacity-50 disabled:cursor-default"
+    class="group flex items-center gap-2 text-sm text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-default"
     data-rac=""
     data-react-aria-pressable="true"
   >
@@ -62,7 +62,7 @@ exports[`Checkbox component > matches snapshot when not checked 1`] = `
       />
     </span>
     <div
-      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-(--color-border-focus) group-focus-visible:ring-offset-2 bg-(--color-surface-default) border-(--color-border-default) group-hover:border-(--color-border-strong)"
+      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 bg-background border-border group-hover:border-border"
     />
   </label>
 </DocumentFragment>
@@ -71,7 +71,7 @@ exports[`Checkbox component > matches snapshot when not checked 1`] = `
 exports[`Checkbox component > renders as checked when isSelected prop is true 1`] = `
 <DocumentFragment>
   <label
-    class="group flex items-center gap-2 text-sm text-(--color-text-primary) cursor-pointer disabled:opacity-50 disabled:cursor-default"
+    class="group flex items-center gap-2 text-sm text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-default"
     data-rac=""
     data-react-aria-pressable="true"
     data-selected="true"
@@ -88,11 +88,11 @@ exports[`Checkbox component > renders as checked when isSelected prop is true 1`
       />
     </span>
     <div
-      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-(--color-border-focus) group-focus-visible:ring-offset-2 bg-(--color-action-primary) border-(--color-action-primary)"
+      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 bg-primary border-primary"
     >
       <svg
         aria-hidden="true"
-        class="lucide lucide-check w-4 h-4 text-(--color-text-inverse)"
+        class="lucide lucide-check w-4 h-4 text-primary-foreground"
         fill="none"
         height="24"
         stroke="currentColor"
@@ -115,7 +115,7 @@ exports[`Checkbox component > renders as checked when isSelected prop is true 1`
 exports[`Checkbox component > renders correctly 1`] = `
 <DocumentFragment>
   <label
-    class="group flex items-center gap-2 text-sm text-(--color-text-primary) cursor-pointer disabled:opacity-50 disabled:cursor-default"
+    class="group flex items-center gap-2 text-sm text-foreground cursor-pointer disabled:opacity-50 disabled:cursor-default"
     data-rac=""
     data-react-aria-pressable="true"
   >
@@ -130,7 +130,7 @@ exports[`Checkbox component > renders correctly 1`] = `
       />
     </span>
     <div
-      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-(--color-border-focus) group-focus-visible:ring-offset-2 bg-(--color-surface-default) border-(--color-border-default) group-hover:border-(--color-border-strong)"
+      class="flex items-center justify-center w-6 h-6 shrink-0 rounded-sm border transition-colors group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 bg-background border-border group-hover:border-border"
     />
   </label>
 </DocumentFragment>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -137,10 +137,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body className="flex flex-col h-screen text-(--color-text-secondary) overflow-hidden font-montserrat bg-white">
+      <body className="flex flex-col h-screen text-muted-foreground overflow-hidden font-montserrat bg-white">
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-white focus:text-(--color-text-accent)"
+          className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-2 focus:bg-white focus:text-secondary"
         >
           Skip to content
         </a>
@@ -149,9 +149,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
           <div
             role="progressbar"
             aria-label="Loading page"
-            className="fixed top-0 left-0 right-0 z-50 h-1 bg-(--color-surface-accent)/30"
+            className="fixed top-0 left-0 right-0 z-50 h-1 bg-secondary/30"
           >
-            <div className="h-full bg-(--color-surface-accent) animate-progress-bar" />
+            <div className="h-full bg-secondary animate-progress-bar" />
           </div>
         )}
 
@@ -214,7 +214,7 @@ export function ErrorBoundary() {
         <div role="alert">
           <H1>{title}</H1>
           <p>{message}</p>
-          <a href="/" className="text-(--color-text-brand) underline mt-4 inline-block">
+          <a href="/" className="text-primary underline mt-4 inline-block">
             Go home
           </a>
         </div>

--- a/app/routes/admin/bulkInvite/bulkInvite.form.tsx
+++ b/app/routes/admin/bulkInvite/bulkInvite.form.tsx
@@ -125,7 +125,7 @@ export function BulkInviteForm({ onNonEmptyCountChange }: BulkInviteFormProps) {
         handleSubmit();
       }}
     >
-      <p className="text-sm text-(--color-text-tertiary) mb-4">
+      <p className="text-sm text-muted-foreground mb-4">
         Keycloak emails the invite to each address below. Group membership can be assigned after
         each user accepts.
       </p>
@@ -138,7 +138,7 @@ export function BulkInviteForm({ onNonEmptyCountChange }: BulkInviteFormProps) {
 
       <table ref={tableRef} className="w-full border-collapse">
         <thead>
-          <tr className="text-left text-sm text-(--color-text-tertiary)">
+          <tr className="text-left text-sm text-muted-foreground">
             <th scope="col" className="w-10 pr-2 py-2 font-medium">
               #
             </th>
@@ -160,7 +160,7 @@ export function BulkInviteForm({ onNonEmptyCountChange }: BulkInviteFormProps) {
           {rows.map((row, i) => {
             return (
               <tr key={row.id}>
-                <td className="pr-2 py-1 text-sm text-(--color-text-tertiary) tabular-nums text-right">
+                <td className="pr-2 py-1 text-sm text-muted-foreground tabular-nums text-right">
                   {i + 1}
                 </td>
                 <td className="px-1 py-1">

--- a/app/routes/admin/createGroup/createGroup.form.tsx
+++ b/app/routes/admin/createGroup/createGroup.form.tsx
@@ -47,12 +47,12 @@ export function CreateGroupForm({ scope }: CreateGroupFormProps) {
       </Fieldset>
 
       {nameValue.trim() && (
-        <div className="flex items-center gap-2 text-sm text-(--color-text-tertiary)">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
           Full path: <ScopePill scope={`${scope}/${nameValue.trim()}`} />
         </div>
       )}
 
-      <p className="text-sm text-(--color-text-tertiary)">
+      <p className="text-sm text-muted-foreground">
         You will be added as an admin of this group automatically.
       </p>
     </form>

--- a/app/routes/admin/inviteUser/inviteUser.form.tsx
+++ b/app/routes/admin/inviteUser/inviteUser.form.tsx
@@ -93,7 +93,7 @@ export function InviteUserForm({ scope, inviteAnother, actionData }: InviteUserF
             />
           )}
         />
-        <p className="text-sm text-(--color-text-tertiary)">
+        <p className="text-sm text-muted-foreground">
           Keycloak emails the invite to the address above. Group membership can be assigned after
           the user accepts.
         </p>

--- a/app/routes/admin/inviteUser/inviteUser.modal.tsx
+++ b/app/routes/admin/inviteUser/inviteUser.modal.tsx
@@ -35,7 +35,7 @@ export default function InviteModal() {
       <InviteUserForm scope={scope} inviteAnother={inviteAnother} actionData={actionData} />
       <footer className="flex items-center gap-3 mt-6">
         <Checkbox isSelected={inviteAnother} onChange={setInviteAnother} className="mr-auto">
-          <span className="text-sm text-(--color-text-secondary)">Invite another</span>
+          <span className="text-sm text-muted-foreground">Invite another</span>
         </Checkbox>
         <Button onPress={() => navigate(-1)} variant="secondary">
           Cancel

--- a/app/routes/admin/updateUser/updateUser.form.tsx
+++ b/app/routes/admin/updateUser/updateUser.form.tsx
@@ -213,7 +213,7 @@ export const UpdateUserForm = ({ user, groups, groupPaths }: UpdateUserFormProps
                     aria-label={group.path}
                     checked={memberGroupIds.has(group.id)}
                     onChange={() => toggleGroup(group.id)}
-                    className="w-4 h-4 cursor-pointer accent-(--color-action-primary)"
+                    className="w-4 h-4 cursor-pointer accent-primary"
                   />
                   <ScopePill scope={group.path} />
                 </label>
@@ -231,10 +231,10 @@ export const UpdateUserForm = ({ user, groups, groupPaths }: UpdateUserFormProps
         confirmLabel="Save Changes"
         confirmVariant="primary"
       >
-        <p className="text-sm text-(--color-text-secondary)">
+        <p className="text-sm text-muted-foreground">
           You are about to make the following changes:
         </p>
-        <ul className="list-disc list-inside text-sm text-(--color-text-primary) space-y-1">
+        <ul className="list-disc list-inside text-sm text-foreground space-y-1">
           {warnings.map((w) => (
             <li key={w}>{w}</li>
           ))}

--- a/app/routes/admin/users/BulkActions.tsx
+++ b/app/routes/admin/users/BulkActions.tsx
@@ -190,9 +190,8 @@ export function BulkActions({ selectedUserIds, users, groups, onSuccess }: BulkA
           confirmLabel={config.confirmLabel}
           confirmVariant={config.confirmVariant}
         >
-          <p className="text-sm text-(--color-text-secondary)">
-            This will affect{" "}
-            <span className="font-medium text-(--color-text-primary)">{count}</span> user
+          <p className="text-sm text-muted-foreground">
+            This will affect <span className="font-medium text-foreground">{count}</span> user
             {count !== 1 ? "s" : ""}.
           </p>
           {config.needsGroup && (

--- a/app/routes/admin/users/users.route.tsx
+++ b/app/routes/admin/users/users.route.tsx
@@ -154,7 +154,7 @@ function buildCellRenderers(scope: string): CellRenderers<UserRow> {
     name: (row) => (
       <Link
         to={`${row.userId}?scope=${encodeURIComponent(scope)}`}
-        className="text-(--color-text-accent) hover:underline"
+        className="text-secondary hover:underline"
       >
         {row.name}
       </Link>
@@ -222,7 +222,7 @@ export default function AdminUsersRoute() {
   return (
     <Section>
       <SectionHeader name={headingLabel}>
-        <span className="text-sm text-(--color-text-tertiary)">
+        <span className="text-sm text-muted-foreground">
           {data.length} {data.length === 1 ? "user" : "users"}
         </span>
         <ButtonLink
@@ -253,10 +253,7 @@ export default function AdminUsersRoute() {
 
       <Container>
         <section aria-labelledby="connections-heading" className="mb-6">
-          <h3
-            id="connections-heading"
-            className="text-sm font-medium text-(--color-text-tertiary) mb-2"
-          >
+          <h3 id="connections-heading" className="text-sm font-medium text-muted-foreground mb-2">
             Connections
           </h3>
           {connections.length > 0 ? (
@@ -265,12 +262,10 @@ export default function AdminUsersRoute() {
                 <li key={conn.name}>
                   <Link
                     to={`/connections/${encodeURIComponent(conn.name)}`}
-                    className="inline-flex items-center gap-2 rounded-lg border border-(--color-border-default) bg-(--color-surface-subtle) px-3 py-1.5 text-sm hover:border-(--color-border-strong) hover:bg-white transition-colors"
+                    className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-sm hover:border-border hover:bg-white transition-colors"
                   >
                     <span className="h-2 w-2 rounded-full bg-green-500 shrink-0" />
-                    <span className="font-medium text-(--color-text-accent) hover:underline">
-                      {conn.name}
-                    </span>
+                    <span className="font-medium text-secondary hover:underline">{conn.name}</span>
                     <ProviderPill provider={conn.provider} />
                   </Link>
                 </li>

--- a/app/routes/auth/login.route.tsx
+++ b/app/routes/auth/login.route.tsx
@@ -81,7 +81,7 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 export default function LoginRoute() {
   return (
     <div className="flex items-center justify-center h-screen">
-      <p role="status" className="text-(--color-text-tertiary)">
+      <p role="status" className="text-muted-foreground">
         Redirecting to login...
       </p>
     </div>

--- a/app/routes/config.route.tsx
+++ b/app/routes/config.route.tsx
@@ -26,7 +26,7 @@ function PreferencesSection() {
       <Switch isSelected={showHiddenFiles} onChange={toggleShowHiddenFiles} className="text-sm">
         Show hidden files
       </Switch>
-      <p className="text-xs text-(--color-text-secondary)">
+      <p className="text-xs text-muted-foreground">
         Reveal dot-prefixed files and directories in browse views.
       </p>
     </div>
@@ -53,7 +53,7 @@ export default function ConfigRoute() {
       </Button>
       <div>
         {typeof window !== "undefined" && (
-          <code className="block bg-(--color-surface-muted) p-4 overflow-auto">
+          <code className="block bg-muted p-4 overflow-auto">
             {JSON.stringify(localStorage, null, 2)}
           </code>
         )}

--- a/app/routes/connections/connection.form.tsx
+++ b/app/routes/connections/connection.form.tsx
@@ -48,8 +48,8 @@ const FIELD_TO_STEP: Record<string, number> = {
   bucketEndpoint: 1,
 };
 
-const dtClass = "text-[var(--color-text-secondary)]";
-const ddClass = "font-[number:var(--font-weight-medium)] text-[var(--color-text-primary)]";
+const dtClass = "text-muted-foreground";
+const ddClass = "font-[number:var(--font-weight-medium)] text-foreground";
 
 function SummaryRow({ label, value }: { label: string; value: string }) {
   return (
@@ -351,14 +351,14 @@ export const ConnectionForm = ({
 
           {currentStep === LAST_STEP && (
             <div>
-              <p className="mb-(--spacing-2) text-(length:--font-size-sm) font-medium text-(--color-text-primary)">
+              <p className="mb-(--spacing-2) text-(length:--font-size-sm) font-medium text-foreground">
                 Summary
               </p>
               <div
                 className={[
                   "rounded-[var(--border-radius-md)]",
-                  "border border-[var(--color-border-default)]",
-                  "bg-[var(--color-surface-subtle)]",
+                  "border border-border",
+                  "bg-card",
                   "p-[var(--spacing-4)]",
                 ].join(" ")}
               >

--- a/app/routes/objects/objects.route.tsx
+++ b/app/routes/objects/objects.route.tsx
@@ -286,7 +286,7 @@ export default function ObjectsRoute() {
       <div
         role="status"
         aria-live="polite"
-        className="flex h-full items-center justify-center p-8 text-(--color-text-tertiary)"
+        className="flex h-full items-center justify-center p-8 text-muted-foreground"
       >
         Loading…
       </div>

--- a/app/routes/onboarding.route.tsx
+++ b/app/routes/onboarding.route.tsx
@@ -5,10 +5,10 @@ export const meta: MetaFunction = () => [{ title: "Welcome to Cytario" }];
 
 export default function OnboardingRoute() {
   return (
-    <main className="flex h-screen items-center justify-center bg-(--color-surface-default) px-6">
+    <main className="flex h-screen items-center justify-center bg-background px-6">
       <section className="flex max-w-xl flex-col items-start gap-6">
-        <h1 className="text-2xl font-semibold text-(--color-text-primary)">Welcome to Cytario</h1>
-        <p className="text-(--color-text-secondary)">
+        <h1 className="text-2xl font-semibold text-foreground">Welcome to Cytario</h1>
+        <p className="text-muted-foreground">
           Your account is not yet linked to an organization. An administrator needs to add you
           before you can access workspace data. Once you have been added, sign out and back in to
           activate your organization.

--- a/app/routes/search.route.tsx
+++ b/app/routes/search.route.tsx
@@ -133,7 +133,7 @@ export default function SearchRoute() {
     <Section>
       <H1>{`Search: ${searchQuery}`}</H1>
 
-      <div className="bg-(--color-surface-muted) p-2">
+      <div className="bg-muted p-2">
         <DirectoryViewTree
           nodes={nodes}
           kind="entries"

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "tw-animate-css";
+@import "@cytario/design/tokens/utilities.css";
 @plugin "tailwindcss-react-aria-components";
 
 /* Match cytario-design's selector convention */
@@ -42,11 +43,11 @@
 
 html,
 body {
-  @apply bg-(--color-surface-default) text-(--color-text-primary);
+  @apply bg-background text-foreground;
 }
 
 ::selection {
-  @apply bg-(--color-surface-brand)/60 text-white;
+  @apply bg-primary/60 text-white;
 }
 
 @font-face {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/client-sts": "^3.687.0",
         "@aws-sdk/s3-request-presigner": "^3.693.0",
         "@cornerstonejs/codec-openjpeg": "^1.3.0",
-        "@cytario/design": "^5.3.0",
+        "@cytario/design": "^6.0.0",
         "@deck.gl/core": "~9.1.15",
         "@deck.gl/extensions": "~9.1.15",
         "@deck.gl/geo-layers": "~9.1.15",
@@ -1410,9 +1410,9 @@
       }
     },
     "node_modules/@cytario/design": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-5.3.0.tgz",
-      "integrity": "sha512-DDg+7fI8ax65YVndB64cuPzIZa1KV+3wQtYI0VoYcb4fHs/qF7kc4XYNHjuMaCiBe0qj5Q+ThKPUvAFnJfx99A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-6.0.0.tgz",
+      "integrity": "sha512-XbAbxV4yqv8XDH+kTjDiNT+YLQl26Cito15dujSGuLc36okmZlRA4KtT+9IwT26/F3VWc2TRXNc3zskiJwEM4Q==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "tailwind-merge": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/client-sts": "^3.687.0",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cytario/design": "^5.3.0",
+    "@cytario/design": "^6.0.0",
     "@deck.gl/core": "~9.1.15",
     "@deck.gl/extensions": "~9.1.15",
     "@deck.gl/geo-layers": "~9.1.15",


### PR DESCRIPTION
**Draft — blocked on cytario/cytario-design#21 publishing `@cytario/design@6.0.0`.**

Web side of the C-253 phase-2b token rename. Migrates all chrome to the idiomatic semantic utilities (`bg-background`, `text-destructive`, `hover:bg-primary-hover`) in place of the `bg-(--color-surface-default)` arbitrary-CSS-var syntax.

## What changed
- `@import "@cytario/design/tokens/utilities.css"` in `app/tailwind.css` so the `@theme inline` layer generates the clean utilities at build.
- Property-preserving codemod across `app/` (incl. the `tailwind.css` `@apply` rules and `::selection`).
- Regenerated the Checkbox snapshot (class-name rename only).

## Verification (against a locally linked design build)
- `typecheck` ✓, `vitest` 1401 passed ✓, production `build` ✓
- `bg-background`/`text-foreground`/`text-destructive` compile to `var(--color-*)` in the bundle.
- `secondary` buttons now render solid teal (design-side variant change).

## Remaining before un-drafting
1. design#21 merges → `@cytario/design@6.0.0` publishes.
2. Bump dependency `@cytario/design` `^5.3.0 → ^6.0.0` (+ lockfile).
3. Visual QA of dark-scoped regions (AppHeader / Sidebar / DataGrid) and the teal secondary buttons.

Part of C-253.