### PR TITLE
docs: refresh token references for shadcn-aligned names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,9 +195,9 @@ import { cytarioConfig } from "~/config";
 - Custom font: Montserrat
 - Use `motion` library for animations
 - **No hardcoded color values** — never use hex (`#94a3b8`), named (`"white"`), or rgb literals in TypeScript/TSX. Use design tokens from `@cytario/design` instead:
-  - Tailwind classes: `text-slate-400`, `bg-neutral-0`, `border-slate-200`
-  - CSS variables in inline styles: `var(--color-slate-400)`, `var(--color-text-secondary)`
-  - Semantic tokens preferred over raw scales: `--color-text-tertiary` over `--color-slate-400`
+  - Semantic utilities (preferred): `text-foreground`, `bg-background`, `bg-primary`, `text-muted-foreground`, `border-border`, `bg-destructive`
+  - CSS variables in inline styles / CSS-in-JS only: `var(--color-muted-foreground)`, `var(--color-primary)`
+  - For a genuine neutral shade with no semantic role, use the slate **var** form `bg-(--color-slate-300)` — never the raw `bg-slate-300` utility, which the ESLint guardrail bans
   - Exceptions: SVG visualization code (deck.gl overlays, scientific imaging palettes) where raw RGBA arrays are required by the rendering API
 
 ### Testing

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -7,8 +7,10 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
-  /* Colors come from @cytario/design tokens (--color-surface-*, --color-text-*,
-     --color-teal-*, --color-purple-*); do not redefine them here. */
+  /* Colors come from @cytario/design tokens: semantic utilities (bg-background,
+     text-foreground, bg-primary, text-muted-foreground, …) generated from the
+     @theme inline layer, plus the --color-teal-* / --color-purple-* primitive
+     scales. Do not redefine them here. */
 
   /* Custom font family */
   --font-montserrat: "Montserrat", sans-serif;


### PR DESCRIPTION
Follow-up to #137 (the `@cytario/design@6.0.0` token bump): update docs/comments that still referenced the old role-prefixed tokens.

- `app/tailwind.css` `@theme` comment: `--color-surface-*`/`--color-text-*` families → the semantic utilities (`bg-background`, `text-foreground`, `bg-primary`, …) generated from the `@theme inline` layer, plus the teal/purple primitives.
- `CLAUDE.md` token guidance: drop the stale raw-gray examples (`text-slate-400`, `bg-neutral-0`) that the ESLint guardrail now bans; point at the semantic utilities and the slate **var** form for genuine neutral shades.

Docs only — no code changes. Part of C-253.