### PR TITLE
feat(c-272): share tile cache across ImagePanels

### DIFF
--- a/app/components/.client/ImageViewer/components/Image/Channels/useChannelsLayer.ts
+++ b/app/components/.client/ImageViewer/components/Image/Channels/useChannelsLayer.ts
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import { select } from "../../../state/store/selectors";
 import { useViewerStore } from "../../../state/store/ViewerStoreContext";
 import { mapChannelConfigsToState } from "../../../utils/mapChannelConfigsToState";
+import { getCachedTile } from "../../../utils/sharedTileCache";
 import { useTilesLoading } from "../../../utils/useTilesLoading";
 
 const EMPTY_OBJECT = Object.freeze({});
@@ -46,7 +47,7 @@ export const useChannelsLayer = (imagePanelId: number, onHover?: (info: PickingI
   const loader = useMemo(() => {
     if (!rawLoader || rawLoader.length === 0) return rawLoader;
 
-    return rawLoader.map((loaderLevel) => {
+    return rawLoader.map((loaderLevel, levelIndex) => {
       const originalGetTile = loaderLevel.getTile.bind(loaderLevel);
 
       // Create wrapped loader that preserves all original properties
@@ -59,7 +60,12 @@ export const useChannelsLayer = (imagePanelId: number, onHover?: (info: PickingI
         loadTile(tileId);
 
         try {
-          const result = await originalGetTile(params);
+          // Shared across panels: a second ImagePanel's getTile resolves from
+          // memory instead of refetching. Keyed by pyramid level + tile coords
+          // + full selection (channel/z/t); namespaced to rawLoader so an image
+          // switch drops the cache. signal is intentionally excluded from the key.
+          const cacheKey = `${levelIndex}:${params.x}:${params.y}:${JSON.stringify(params.selection)}`;
+          const result = await getCachedTile(rawLoader, cacheKey, () => originalGetTile(params));
 
           finishTile(tileId);
 

--- a/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/Overlays/OverlaysLayer.tsx
@@ -11,6 +11,7 @@ import { AdditiveScatterplotLayer } from "./AdditiveScatterplotLayer";
 import { getPolygon } from "./getPolygon";
 import { MarkerProps } from "./markerUniforms";
 import { CellMarker } from "../../../state/store/types";
+import { OVERLAY_CACHE_NS, getCachedTile } from "../../../utils/sharedTileCache";
 import { toastBridge } from "~/toast-bridge";
 import { isPointMode } from "~/utils/db/getGeomQuery";
 import { getTileDataWasm } from "~/utils/db/getTileDataWasm";
@@ -64,7 +65,13 @@ export const OverlaysLayer = ({
       // Get ALL marker column names (not just enabled ones)
       const allMarkerKeys = Object.keys(fileMarkers);
 
-      const data = await getTileDataWasm(resourceId, index, allMarkerKeys);
+      // Shared across panels: the 2nd ImagePanel reuses the 1st panel's DuckDB
+      // result instead of re-running the query. Keyed by resource + tile index
+      // + marker columns; markers are part of the key because they shape the query.
+      const cacheKey = `${resourceId}|${index.z}-${index.x}-${index.y}|${allMarkerKeys.join(",")}`;
+      const data = await getCachedTile(OVERLAY_CACHE_NS, cacheKey, () =>
+        getTileDataWasm(resourceId, index, allMarkerKeys),
+      );
 
       return data;
     } catch (error) {

--- a/app/components/.client/ImageViewer/utils/sharedTileCache.ts
+++ b/app/components/.client/ImageViewer/utils/sharedTileCache.ts
@@ -1,0 +1,58 @@
+import { LRUCache } from "lru-cache";
+
+/**
+ * Process-wide tile cache shared across ImagePanels.
+ *
+ * Each ImagePanel renders its own DeckGL instance, so deck.gl's per-layer
+ * Tileset2D cache is isolated per canvas — enabling split view forces the 2nd
+ * panel to refetch/redecode every tile from scratch. This cache sits *below*
+ * deck.gl: it memoizes the underlying fetch (channel getTile / overlay query)
+ * by tile key so a second panel resolves from memory instead of the network.
+ *
+ * Keyed by a namespace object (the shared loader array for channels, a module
+ * sentinel for overlays) via WeakMap, so entries are dropped when the loader is
+ * replaced (image switch) and never collide across images.
+ */
+
+const MAX_ENTRIES_PER_NAMESPACE = 2000;
+
+type Cache = LRUCache<string, Promise<unknown>>;
+
+const caches = new WeakMap<object, Cache>();
+
+/** Stable namespace for overlay (DuckDB) tile queries — keyed by resourceId in the cache key. */
+export const OVERLAY_CACHE_NS: object = {};
+
+function cacheFor(namespace: object): Cache {
+  let cache = caches.get(namespace);
+  if (!cache) {
+    cache = new LRUCache<string, Promise<unknown>>({ max: MAX_ENTRIES_PER_NAMESPACE });
+    caches.set(namespace, cache);
+  }
+  return cache;
+}
+
+/**
+ * Return a memoized in-flight (or resolved) promise for `key`, fetching via
+ * `fetcher` on miss. Failed fetches (including aborts) are evicted so the next
+ * caller refetches — keeps a panned-away panel's abort from poisoning the cache.
+ */
+export function getCachedTile<T>(
+  namespace: object,
+  key: string,
+  fetcher: () => Promise<T>,
+): Promise<T> {
+  const cache = cacheFor(namespace);
+
+  const existing = cache.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const promise = fetcher().catch((error) => {
+    cache.delete(key);
+    throw error;
+  });
+
+  cache.set(key, promise);
+
+  return promise;
+}


### PR DESCRIPTION
## C-272: share tile cache across ImagePanels

https://app.plane.so/cytario/browse/C-272/

### Problem
Each `ImagePanel` renders its own `DeckGL` instance, so deck.gl's per-layer `Tileset2D` cache is isolated per canvas. Enabling **split view** forced the 2nd panel to re-fetch and re-decode every tile (channels + overlays) from scratch — even though the 1st panel had already loaded them. Toggling channels/overlays *within* a panel is instant by contrast, because those change render props, not tile-fetch keys.

### Fix
A process-wide in-memory tile cache (`sharedTileCache.ts`) that sits **below** deck.gl, memoizing the underlying fetch by tile key:
- **channels** — wraps `getTile` in `useChannelsLayer` (key: pyramid level + tile coords + selection)
- **overlays** — wraps the DuckDB query in `OverlaysLayer` (key: resourceId + tile index + marker columns)

A 2nd panel now resolves from memory instead of the network/DuckDB. Built on `lru-cache` (already used in `genericDecoder` / `sessionStorage`), namespaced per-loader via `WeakMap` so an image switch drops the cache and keys never collide across images.

In-flight promises are cached so concurrent panels coalesce to a single request; failed/aborted fetches are evicted so a panned-away panel can't poison the cache.

**Pure runtime cache** — no persistence, client-only, dropped on reload/image-switch.

### Preliminary benchmark
Split-view entry, OME-TIFF + overlays, local MinIO. Measured the 2nd panel's tile requests via a runtime cache-bypass A/B:

| | 2nd-panel tile fetches | wall-time to render panel 2 |
|---|---|---|
| Before (no shared cache) | 5 | ~2.1 s |
| After (shared cache) | **0** | **~1.2 s** |

Every panel-2 tile served from panel-1's cache. Benefit scales with visible tile count and S3 latency; numbers are from a localhost MinIO fit-view, so real remote S3 wins are larger.

_Caveat: wall-time includes a fixed React-mount + deck.gl-init floor (~1.2 s); the fetch-bound signal (5 → 0 requests) is the cleaner metric._
