### PR TITLE
feat(slots): provide host runtime config (portal/webapp URL) to client plugin slots

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,8 @@
 # Services
 WEB_HOST=http://localhost:5173
+# Optional: customer portal base URL, surfaced to client plugin slots.
+# Leave unset on deployments without a portal (e.g. OSS).
+# PORTAL_HOST=http://localhost:5174
 
 # Identity Provider (example: Keycloak; BASE_URL should be set to your IdP's base URL)
 BASE_URL=http://localhost:8080/realms/master

--- a/app/components/PluginSlots.tsx
+++ b/app/components/PluginSlots.tsx
@@ -2,15 +2,16 @@ import { Fragment, type ComponentType } from "react";
 
 import { ClientOnly } from "./ClientOnly";
 import { slotRegistry } from "./slotRegistry";
-import type { Identity, SlotName, SlotProps } from "@cytario/plugin-api";
+import type { HostConfig, Identity, SlotName, SlotProps } from "@cytario/plugin-api";
 
 interface PluginSlotsProps {
   name: SlotName;
   identity: Identity;
+  hostConfig: HostConfig;
 }
 
 // Client-only via ClientOnly: plugin overlay/banner must not enter SSR HTML (CSP).
-export function PluginSlots({ name, identity }: PluginSlotsProps) {
+export function PluginSlots({ name, identity, hostConfig }: PluginSlotsProps) {
   const components = slotRegistry.get(name) as ComponentType<SlotProps>[];
 
   return (
@@ -18,7 +19,7 @@ export function PluginSlots({ name, identity }: PluginSlotsProps) {
       {components.map((Component, index) => (
         // Index key OK: registry is append-only (no unregister/reorder).
         <Fragment key={index}>
-          <Component identity={identity} />
+          <Component identity={identity} hostConfig={hostConfig} />
         </Fragment>
       ))}
     </ClientOnly>

--- a/app/components/__tests__/PluginSlots.test.tsx
+++ b/app/components/__tests__/PluginSlots.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 
-import type { Identity, SlotProps } from "@cytario/plugin-api";
+import type { HostConfig, Identity, SlotProps } from "@cytario/plugin-api";
 import { PluginSlots } from "~/components/PluginSlots";
 import { slotRegistry } from "~/components/slotRegistry";
 
@@ -10,6 +10,11 @@ const identity: Identity = {
   organizationAttributes: { subscription_status: ["active"] },
   groups: ["lab/team-a"],
   adminScopes: ["*"],
+};
+
+const hostConfig: HostConfig = {
+  portalUrl: "https://admin.example.test",
+  webappUrl: "https://app.example.test",
 };
 
 describe("PluginSlots", () => {
@@ -25,10 +30,24 @@ describe("PluginSlots", () => {
     slotRegistry.scopedFor("test-plugin").register("app-banner", First);
     slotRegistry.scopedFor("test-plugin").register("app-banner", Second);
 
-    render(<PluginSlots name="app-banner" identity={identity} />);
+    render(<PluginSlots name="app-banner" identity={identity} hostConfig={hostConfig} />);
 
     expect(screen.getByTestId("first")).toHaveTextContent("testcorp");
     expect(screen.getByTestId("second")).toHaveTextContent("lab/team-a");
+  });
+
+  test("passes hostConfig to registered components", () => {
+    const Cta = ({ hostConfig: cfg }: SlotProps) => (
+      <a href={`${cfg.portalUrl}/billing`}>upgrade</a>
+    );
+    slotRegistry.scopedFor("test-plugin").register("app-banner", Cta);
+
+    render(<PluginSlots name="app-banner" identity={identity} hostConfig={hostConfig} />);
+
+    expect(screen.getByText("upgrade")).toHaveAttribute(
+      "href",
+      "https://admin.example.test/billing",
+    );
   });
 
   test("supports multiple components per slot", () => {
@@ -39,7 +58,7 @@ describe("PluginSlots", () => {
     slotRegistry.scopedFor("test-plugin").register("app-overlay", B);
     slotRegistry.scopedFor("test-plugin").register("app-overlay", C);
 
-    render(<PluginSlots name="app-overlay" identity={identity} />);
+    render(<PluginSlots name="app-overlay" identity={identity} hostConfig={hostConfig} />);
 
     expect(screen.getAllByTestId(/^[abc]$/)).toHaveLength(3);
   });
@@ -48,7 +67,9 @@ describe("PluginSlots", () => {
     const Banner = () => <div>banner</div>;
     slotRegistry.scopedFor("test-plugin").register("app-banner", Banner);
 
-    const html = renderToString(<PluginSlots name="app-banner" identity={identity} />);
+    const html = renderToString(
+      <PluginSlots name="app-banner" identity={identity} hostConfig={hostConfig} />,
+    );
 
     expect(html).toBe("");
   });

--- a/app/config.ts
+++ b/app/config.ts
@@ -3,6 +3,8 @@ import { CookieOptions } from "react-router";
 interface CytarioConfig {
   endpoints: {
     webapp: string;
+    /** Customer portal base URL. Unset on deployments without a portal (e.g. OSS). */
+    portal?: string;
   };
   auth: {
     baseUrl: string;
@@ -42,11 +44,13 @@ const {
   COOKIE_SECRET,
   NODE_ENV,
   WEB_HOST,
+  PORTAL_HOST,
 } = process.env;
 
 export const cytarioConfig: Readonly<CytarioConfig> = {
   endpoints: {
     webapp: WEB_HOST!,
+    portal: PORTAL_HOST,
   },
   auth: {
     baseUrl: BASE_URL!,

--- a/app/routes/layouts/protected.layout.tsx
+++ b/app/routes/layouts/protected.layout.tsx
@@ -11,6 +11,7 @@ import { toIdentity } from "~/.server/auth/getUserInfo";
 import { createLabel } from "~/.server/logging";
 import { PluginSlots } from "~/components/PluginSlots";
 import { ExplorerSidebar } from "~/components/Sidebar/Explorer/ExplorerSidebar";
+import { cytarioConfig } from "~/config";
 import { useCredentialsKeepAlive } from "~/hooks/useCredentialsKeepAlive";
 import { useInitConnections } from "~/hooks/useInitConnections";
 import { loadFavorites } from "~/routes/favorites/favorites.loader";
@@ -52,6 +53,10 @@ export const loader = async ({ context }: LoaderFunctionArgs) => {
     credentials,
     credentialErrors,
     identity: toIdentity(user),
+    hostConfig: {
+      portalUrl: cytarioConfig.endpoints.portal,
+      webappUrl: cytarioConfig.endpoints.webapp,
+    },
     recentlyViewed,
     favorites,
   };
@@ -63,7 +68,7 @@ export const clientLoader = ({ serverLoader }: ClientLoaderFunctionArgs) =>
   serverLoader<typeof loader>();
 
 export default function ProtectedLayout() {
-  const { connectionConfigs, credentials, credentialErrors, identity } =
+  const { connectionConfigs, credentials, credentialErrors, identity, hostConfig } =
     useLoaderData<typeof loader>();
   useInitConnections(connectionConfigs, credentials, credentialErrors);
   useCredentialsKeepAlive();
@@ -71,7 +76,7 @@ export default function ProtectedLayout() {
 
   return (
     <div className="flex h-full flex-col">
-      <PluginSlots name="app-banner" identity={identity} />
+      <PluginSlots name="app-banner" identity={identity} hostConfig={hostConfig} />
       <div className="relative flex flex-1 min-h-0">
         <ExplorerSidebar />
 
@@ -80,7 +85,7 @@ export default function ProtectedLayout() {
         </div>
         <ModalOutlet />
       </div>
-      <PluginSlots name="app-overlay" identity={identity} />
+      <PluginSlots name="app-overlay" identity={identity} hostConfig={hostConfig} />
     </div>
   );
 }

--- a/packages/plugin-api/src/__tests__/gatesSlotsSurface.test.ts
+++ b/packages/plugin-api/src/__tests__/gatesSlotsSurface.test.ts
@@ -101,11 +101,25 @@ describe("auth / gates / slots surface", () => {
     expect(calls.map((c) => c.slot)).toEqual(["app-overlay", "app-banner"]);
   });
 
-  test("SlotProps carries the Identity projection", () => {
+  test("SlotProps carries the Identity projection and host runtime URLs", () => {
     const props: SlotProps = {
       identity: { organizationAttributes: {}, groups: [], adminScopes: [] },
+      hostConfig: {
+        portalUrl: "https://admin.cytario.com",
+        webappUrl: "https://app.cytario.com",
+      },
     };
     expect(props.identity.groups).toEqual([]);
+    expect(props.hostConfig.portalUrl).toBe("https://admin.cytario.com");
+    expect(props.hostConfig.webappUrl).toBe("https://app.cytario.com");
+  });
+
+  test("hostConfig.portalUrl is optional for portal-less hosts", () => {
+    const props: SlotProps = {
+      identity: { organizationAttributes: {}, groups: [], adminScopes: [] },
+      hostConfig: { webappUrl: "https://app.cytario.com" },
+    };
+    expect(props.hostConfig.portalUrl).toBeUndefined();
   });
 
   test("a CytarioPlugin can register a gate and slots via PluginContext", () => {

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -26,7 +26,7 @@ export type {
 export { normalizePixelType } from "./image";
 export type { Identity } from "./auth";
 export type { GateOutcome, GateRequest, SessionGate, GateRegistry } from "./gates";
-export type { SlotName, SlotProps, SlotRegistry } from "./slots";
+export type { SlotName, SlotProps, SlotRegistry, HostConfig } from "./slots";
 
 export { assertApiCompatible, IncompatiblePluginError } from "./apiVersion";
 export { sanitizeHeaders } from "./headers";

--- a/packages/plugin-api/src/slots.ts
+++ b/packages/plugin-api/src/slots.ts
@@ -3,9 +3,26 @@ import type { Identity } from "./auth";
 /** Host-defined mount points. v1 surface. */
 export type SlotName = "app-overlay" | "app-banner";
 
-/** Props the host passes to every slot component (client-only). */
+/** Host runtime URLs handed to slot components for cross-app linking. */
+export interface HostConfig {
+  /**
+   * Absolute base URL of the customer-facing portal (billing, account).
+   * Optional: undefined when the host has no portal (e.g. an OSS deployment).
+   * Consumers must handle its absence rather than fall back to a hardcoded origin.
+   */
+  portalUrl?: string;
+  /** Absolute base URL of this webapp instance (the image browser). */
+  webappUrl: string;
+}
+
+/**
+ * Props the host passes to every slot component (client-only): the identity
+ * projection and host runtime URLs. `hostConfig` is host-populated at render
+ * time and always present; safe URLs only (no PII or secrets).
+ */
 export interface SlotProps {
   identity: Identity;
+  hostConfig: HostConfig;
 }
 
 export interface SlotRegistry {


### PR DESCRIPTION
## What

Extends the host→client plugin contract so client slot components receive environment-correct URLs at runtime instead of a build-time-baked origin.

- **@cytario/plugin-api**: add `HostConfig { portalUrl?, webappUrl }` and a `hostConfig` field on `SlotProps`. `portalUrl` is optional (undefined on portal-less deployments, e.g. OSS); `webappUrl` always present. Additive surface — plugins ignoring the field keep compiling; `apiVersion` stays within `^3` (minor).
- **cytario-web (host)**: new optional `PORTAL_HOST` env → `endpoints.portal`. `ProtectedLayout` loader projects `hostConfig` from host runtime env; `PluginSlots` forwards it to each registered `app-banner` / `app-overlay` component alongside `identity`.

## Why

`saas-plugin`'s subscription banner CTA linked to the hardcoded prod portal origin regardless of environment, forcing re-login in dev/staging. Root cause is structural: client slots can't read `process.env`, so the URL must be supplied by the host at runtime. See C-279 for the full diagnosis and rejected options (B: untyped `window` global; C: host owns navigation).

## Decision: `hostConfig` required on SlotProps, `portalUrl` optional within it

The host always supplies `hostConfig`, so the field is required (no needless narrowing in consumers). `portalUrl` inside it is optional because portal-less deployments have no portal — consumers must handle its absence rather than fall back to a hardcoded origin.

## Acceptance criteria

- [x] Client bundle path no longer carries a hardcoded portal origin (host supplies it at runtime).
- [x] Server gate redirects unchanged (gate path not touched here).
- [x] `apiVersion` compatibility preserved — no major bump; plugins missing `hostConfig` still load.
- [ ] **saas-plugin** consumes `props.hostConfig`, splits config, drops the client `readEnv` fallback, bumps apiVersion floor — *separate external repo, follow-up.*

## Verification

typecheck ✅ · lint 0 errors ✅ · prettier ✅ · plugin-api + PluginSlots suites green.

## Sequencing

plugin-api must publish the minor within `^3` (semantic-release picks up the `feat:`) before saas-plugin can consume `hostConfig`.

Refs C-279 (left unbracketed — ticket stays open until the saas-plugin work lands).