### PR TITLE
feat(auth): add generic /auth/refresh token-refresh primitive [C-292]

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,6 +15,10 @@ const authRoutes = [
     file: "routes/auth/callback.route.tsx",
   },
   {
+    path: "/auth/refresh",
+    file: "routes/auth/refresh.route.tsx",
+  },
+  {
     path: "/onboarding",
     file: "routes/onboarding.route.tsx",
   },

--- a/app/routes/auth/__tests__/refresh.test.tsx
+++ b/app/routes/auth/__tests__/refresh.test.tsx
@@ -101,6 +101,51 @@ describe("refresh loader (token-refresh primitive)", () => {
     expect(sessionStorage.commitSession).toHaveBeenCalledWith(session);
   });
 
+  // `Sec-`-prefixed headers are forbidden header names the Request constructor
+  // silently drops, so stub the request shape to carry Sec-Fetch-Mode.
+  const requestWithFetchMode = (urlStr: string, mode: string) =>
+    ({
+      url: urlStr,
+      headers: { get: (key: string) => (key === "Sec-Fetch-Mode" ? mode : null) },
+    }) as unknown as Request;
+
+  test("rejects cross-site subresource requests without touching the session", async () => {
+    const session = buildSession();
+    (getSession as Mock).mockResolvedValue(session);
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const request = requestWithFetchMode(
+      "http://localhost/auth/refresh?return_to=/dashboard",
+      "no-cors",
+    );
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect(response.status).toBe(404);
+    expect(getSession).not.toHaveBeenCalled();
+    expect(refreshAccessTokenWithLock).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  test("allows top-level navigations (Sec-Fetch-Mode: navigate)", async () => {
+    const session = buildSession();
+    (getSession as Mock).mockResolvedValue(session);
+    (refreshAccessTokenWithLock as Mock).mockResolvedValue({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      idToken: "new-id",
+    });
+    (getUserInfo as Mock).mockResolvedValue({ sub: "123" });
+
+    const request = requestWithFetchMode(
+      "http://localhost/auth/refresh?return_to=/dashboard",
+      "navigate",
+    );
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/dashboard");
+  });
+
   test("validates return_to against open-redirect guard", async () => {
     const session = buildSession();
     (getSession as Mock).mockResolvedValue(session);

--- a/app/routes/auth/__tests__/refresh.test.tsx
+++ b/app/routes/auth/__tests__/refresh.test.tsx
@@ -1,0 +1,150 @@
+import { LoaderFunctionArgs } from "react-router";
+import { Mock } from "vitest";
+
+import { loader } from "../refresh.route";
+import { getUserInfo } from "~/.server/auth/getUserInfo";
+import { validateRedirectTo } from "~/.server/auth/oauthState";
+import { refreshAccessTokenWithLock } from "~/.server/auth/refreshAuthTokens";
+import { sessionStorage } from "~/.server/auth/sessionStorage";
+
+vi.mock("~/.server/auth/getSession", () => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock("~/.server/auth/getUserInfo", () => ({
+  getUserInfo: vi.fn(),
+}));
+
+vi.mock("~/.server/auth/oauthState", () => ({
+  validateRedirectTo: vi.fn((v?: string) => {
+    if (!v) return "/";
+    return v.startsWith("/") ? v : "/";
+  }),
+}));
+
+vi.mock("~/.server/auth/refreshAuthTokens", () => ({
+  refreshAccessTokenWithLock: vi.fn(),
+}));
+
+vi.mock("~/.server/auth/sessionStorage", () => ({
+  sessionStorage: {
+    commitSession: vi.fn().mockResolvedValue("session-cookie"),
+  },
+}));
+
+vi.mock("react-router", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    // @ts-expect-error -- importOriginal returns unknown; spread is safe here
+    ...actual,
+    redirect: vi.fn(
+      (url, init) =>
+        new Response(null, { status: 302, headers: { Location: url, ...init?.headers } }),
+    ),
+  };
+});
+
+const { getSession } = await import("~/.server/auth/getSession");
+
+const buildSession = (overrides: Record<string, unknown> = {}) => {
+  const store: Record<string, unknown> = {
+    user: { sub: "123", email: "test@example.com" },
+    authTokens: { accessToken: "old-access", refreshToken: "old-refresh", idToken: "old-id" },
+    ...overrides,
+  };
+  return {
+    id: "session-id-123",
+    get: vi.fn((key: string) => store[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      store[key] = value;
+    }),
+    __store: store,
+  };
+};
+
+describe("refresh loader (token-refresh primitive)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("re-mints tokens, refreshes user, redirects to validated return_to", async () => {
+    const session = buildSession();
+    (getSession as Mock).mockResolvedValue(session);
+    (refreshAccessTokenWithLock as Mock).mockResolvedValue({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      idToken: "new-id",
+    });
+    (getUserInfo as Mock).mockResolvedValue({
+      sub: "123",
+      email: "test@example.com",
+      organization: "acme",
+    });
+
+    const request = new Request("http://localhost/auth/refresh?return_to=/dashboard");
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect(refreshAccessTokenWithLock).toHaveBeenCalledWith("session-id-123", "old-refresh");
+    expect(getUserInfo).toHaveBeenCalledWith("new-access");
+    expect(session.set).toHaveBeenCalledWith("authTokens", {
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      idToken: "new-id",
+    });
+    expect(session.__store.user).toEqual({
+      sub: "123",
+      email: "test@example.com",
+      organization: "acme",
+    });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/dashboard");
+    expect(sessionStorage.commitSession).toHaveBeenCalledWith(session);
+  });
+
+  test("validates return_to against open-redirect guard", async () => {
+    const session = buildSession();
+    (getSession as Mock).mockResolvedValue(session);
+    (refreshAccessTokenWithLock as Mock).mockResolvedValue({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+      idToken: "new-id",
+    });
+    (getUserInfo as Mock).mockResolvedValue({ sub: "123" });
+
+    const request = new Request(
+      "http://localhost/auth/refresh?return_to=https://evil.example.com/phish",
+    );
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect(validateRedirectTo).toHaveBeenCalledWith("https://evil.example.com/phish");
+    expect(response.headers.get("Location")).toBe("/");
+  });
+
+  test("falls back to login when no active session", async () => {
+    const session = buildSession({ user: undefined, authTokens: undefined });
+    (getSession as Mock).mockResolvedValue(session);
+
+    const request = new Request("http://localhost/auth/refresh?return_to=/dashboard");
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect(refreshAccessTokenWithLock).not.toHaveBeenCalled();
+    expect(response.headers.get("Location")).toBe(
+      `/login?redirect=${encodeURIComponent("/dashboard")}`,
+    );
+  });
+
+  test("falls back to login when refresh fails", async () => {
+    const session = buildSession();
+    (getSession as Mock).mockResolvedValue(session);
+    (refreshAccessTokenWithLock as Mock).mockRejectedValue(new Error("refresh expired"));
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const request = new Request("http://localhost/auth/refresh?return_to=/dashboard");
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect(response.headers.get("Location")).toBe(
+      `/login?redirect=${encodeURIComponent("/dashboard")}`,
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/app/routes/auth/refresh.route.tsx
+++ b/app/routes/auth/refresh.route.tsx
@@ -1,0 +1,67 @@
+import { LoaderFunctionArgs, redirect } from "react-router";
+
+import { getSession } from "~/.server/auth/getSession";
+import { getUserInfo } from "~/.server/auth/getUserInfo";
+import { validateRedirectTo } from "~/.server/auth/oauthState";
+import { refreshAccessTokenWithLock } from "~/.server/auth/refreshAuthTokens";
+import { sessionStorage } from "~/.server/auth/sessionStorage";
+import { createLabel } from "~/.server/logging";
+
+const label = createLabel("auth-refresh", "magenta");
+
+/**
+ * Generic token-refresh primitive.
+ *
+ * On an authenticated session, performs a Keycloak `refresh_token` grant,
+ * re-fetches the user profile (so newly-present claims like `organization`
+ * land on the session), persists both, and redirects to a validated
+ * `return_to`. Carries no org/trial/billing logic — callers decide when a
+ * refresh is warranted.
+ *
+ * Any failure (no session, expired/failed refresh) falls back to interactive
+ * login rather than erroring.
+ */
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  console.info(`${label} Refresh initiated`);
+
+  const url = new URL(request.url);
+  const returnTo = validateRedirectTo(url.searchParams.get("return_to") || undefined);
+  const loginFallback = `/login?redirect=${encodeURIComponent(returnTo)}`;
+
+  const session = await getSession(request);
+  const user = session.get("user");
+  const authTokens = session.get("authTokens");
+
+  if (!user || !authTokens?.refreshToken) {
+    console.info(`${label} No active session, falling back to login`);
+    return redirect(loginFallback);
+  }
+
+  try {
+    const newAuthTokens = await refreshAccessTokenWithLock(session.id, authTokens.refreshToken);
+    const refreshedUser = await getUserInfo(newAuthTokens.accessToken);
+
+    session.set("authTokens", newAuthTokens);
+    session.set("user", refreshedUser);
+
+    console.info(`${label} Tokens re-minted, redirecting to:`, returnTo);
+
+    return redirect(returnTo, {
+      headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
+    });
+  } catch (error) {
+    console.error(`${label} Refresh failed, falling back to login:`, error);
+    return redirect(loginFallback);
+  }
+};
+
+// Loading state shown briefly before redirect fires.
+export default function RefreshRoute() {
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <p role="status" className="text-muted-foreground">
+        Refreshing session...
+      </p>
+    </div>
+  );
+}

--- a/app/routes/auth/refresh.route.tsx
+++ b/app/routes/auth/refresh.route.tsx
@@ -24,6 +24,18 @@ const label = createLabel("auth-refresh", "magenta");
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   console.info(`${label} Refresh initiated`);
 
+  // Refreshing re-mints tokens, so this GET is state-mutating. Restrict it to
+  // top-level navigations: a browser sends `Sec-Fetch-Mode: navigate` for real
+  // navigations (incl. server-issued redirects), but `no-cors`/`cors` for
+  // cross-site subresource embeds (`<img src=...>`, fetch). Rejecting the
+  // latter blocks forced-refresh CSRF and Keycloak amplification. Non-browser
+  // clients omit the header and are allowed.
+  const fetchMode = request.headers.get("Sec-Fetch-Mode");
+  if (fetchMode && fetchMode !== "navigate") {
+    console.warn(`${label} Rejected non-navigation request (Sec-Fetch-Mode: ${fetchMode})`);
+    return new Response("Not Found", { status: 404 });
+  }
+
   const url = new URL(request.url);
   const returnTo = validateRedirectTo(url.searchParams.get("return_to") || undefined);
   const loginFallback = `/login?redirect=${encodeURIComponent(returnTo)}`;


### PR DESCRIPTION
## Summary

Adds a host-side `GET /auth/refresh?return_to=<path>` route. On an authenticated session it performs a Keycloak `refresh_token` grant, re-fetches the user profile, persists both back to the session, and redirects to a validated `return_to`.

The re-fetch is the crux: `authMiddleware` reads `user.organization` from the session `user` object, so re-minting tokens alone would not surface a newly-present `organization` claim. Re-fetching `getUserInfo` with the new access token lands the claim and breaks the onboarding redirect loop described in C-292.

`/auth/login` cannot serve this — it short-circuits an active session and never re-mints.

## Behaviour

- Re-mints the access token via the `refresh_token` grant (reuses `refreshAccessTokenWithLock` — the existing distributed-lock primitive), updates the session, redirects to validated `return_to`.
- A token lacking the `organization` claim carries it after refresh, once the user is an org member.
- `return_to` runs through the same open-redirect guard (`validateRedirectTo`) as login; off-host targets reject to `/`.
- No session, or a failed/expired refresh, falls back to interactive login (`/login?redirect=<return_to>`) rather than throwing.
- No org/trial/billing logic — purely generic auth. Callers decide *when* a refresh is warranted.

## Scope

- `app/routes/auth/refresh.route.tsx` — the route
- `app/routes.ts` — registration next to `/auth/callback`
- `app/routes/auth/__tests__/refresh.test.tsx` — happy path, open-redirect guard, no-session fallback, refresh-fail fallback

## Notes

The SaaS consumer (`onboardRedirect` routing its `return_to` through this primitive) is a separate plugin-side change.

[C-292]