### PR TITLE
fix(auth): refresh org claim via silent re-auth (prompt=none) [C-292]

### DIFF
--- a/app/routes/auth/__tests__/callback.test.tsx
+++ b/app/routes/auth/__tests__/callback.test.tsx
@@ -182,6 +182,23 @@ describe("callback loader", () => {
     });
   });
 
+  test("falls back to interactive login on silent re-auth login_required", async () => {
+    const consoleSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const request = new Request(
+      "http://localhost/auth/callback?error=login_required&state=valid-state",
+    );
+
+    const response = await loader({ request } as LoaderFunctionArgs);
+
+    expect((response as Response).status).toBe(302);
+    // Return path recovered from the one-shot state, no error notification.
+    expect((response as Response).headers.get("Location")).toBe(
+      `/login?redirect=${encodeURIComponent("/dashboard")}`,
+    );
+    expect(mockSession.set).not.toHaveBeenCalledWith("notification", expect.anything());
+    consoleSpy.mockRestore();
+  });
+
   test("catches errors and shows generic message", async () => {
     vi.mocked(exchangeAuthCode).mockRejectedValue(new Error("Token exchange failed: 400"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/app/routes/auth/__tests__/refresh.test.tsx
+++ b/app/routes/auth/__tests__/refresh.test.tsx
@@ -2,33 +2,32 @@ import { LoaderFunctionArgs } from "react-router";
 import { Mock } from "vitest";
 
 import { loader } from "../refresh.route";
-import { getUserInfo } from "~/.server/auth/getUserInfo";
-import { validateRedirectTo } from "~/.server/auth/oauthState";
-import { refreshAccessTokenWithLock } from "~/.server/auth/refreshAuthTokens";
-import { sessionStorage } from "~/.server/auth/sessionStorage";
+import { generateOAuthState, validateRedirectTo } from "~/.server/auth/oauthState";
+import { getWellKnownEndpoints } from "~/.server/auth/wellKnownEndpoints";
 
 vi.mock("~/.server/auth/getSession", () => ({
   getSession: vi.fn(),
 }));
 
-vi.mock("~/.server/auth/getUserInfo", () => ({
-  getUserInfo: vi.fn(),
-}));
-
 vi.mock("~/.server/auth/oauthState", () => ({
+  generateOAuthState: vi.fn(),
   validateRedirectTo: vi.fn((v?: string) => {
     if (!v) return "/";
     return v.startsWith("/") ? v : "/";
   }),
 }));
 
-vi.mock("~/.server/auth/refreshAuthTokens", () => ({
-  refreshAccessTokenWithLock: vi.fn(),
+vi.mock("~/.server/auth/wellKnownEndpoints", () => ({
+  getWellKnownEndpoints: vi.fn(),
 }));
 
-vi.mock("~/.server/auth/sessionStorage", () => ({
-  sessionStorage: {
-    commitSession: vi.fn().mockResolvedValue("session-cookie"),
+vi.mock("~/config", () => ({
+  cytarioConfig: {
+    endpoints: { webapp: "https://app.example.com" },
+    auth: {
+      clientId: "test-client-id",
+      scopes: ["openid", "profile", "organization"],
+    },
   },
 }));
 
@@ -46,59 +45,48 @@ vi.mock("react-router", async (importOriginal) => {
 
 const { getSession } = await import("~/.server/auth/getSession");
 
-const buildSession = (overrides: Record<string, unknown> = {}) => {
-  const store: Record<string, unknown> = {
-    user: { sub: "123", email: "test@example.com" },
-    authTokens: { accessToken: "old-access", refreshToken: "old-refresh", idToken: "old-id" },
-    ...overrides,
-  };
-  return {
-    id: "session-id-123",
-    get: vi.fn((key: string) => store[key]),
-    set: vi.fn((key: string, value: unknown) => {
-      store[key] = value;
-    }),
-    __store: store,
-  };
+const authenticatedSession = () => ({
+  id: "session-id-123",
+  get: vi.fn((key: string) => (key === "user" ? { sub: "123", email: "test@example.com" } : null)),
+});
+
+const primeOAuthState = () => {
+  (generateOAuthState as Mock).mockResolvedValue({
+    state: "random-state-123",
+    codeChallenge: "test-challenge",
+    nonce: "test-nonce",
+  });
+  (getWellKnownEndpoints as Mock).mockResolvedValue({
+    authorization_endpoint: "https://keycloak.example.com/auth",
+  });
 };
 
-describe("refresh loader (token-refresh primitive)", () => {
+describe("refresh loader (silent re-authentication primitive)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test("re-mints tokens, refreshes user, redirects to validated return_to", async () => {
-    const session = buildSession();
-    (getSession as Mock).mockResolvedValue(session);
-    (refreshAccessTokenWithLock as Mock).mockResolvedValue({
-      accessToken: "new-access",
-      refreshToken: "new-refresh",
-      idToken: "new-id",
-    });
-    (getUserInfo as Mock).mockResolvedValue({
-      sub: "123",
-      email: "test@example.com",
-      organization: "acme",
-    });
+  test("redirects to Keycloak with prompt=none and PKCE params", async () => {
+    (getSession as Mock).mockResolvedValue(authenticatedSession());
+    primeOAuthState();
 
     const request = new Request("http://localhost/auth/refresh?return_to=/dashboard");
     const response = await loader({ request } as LoaderFunctionArgs);
 
-    expect(refreshAccessTokenWithLock).toHaveBeenCalledWith("session-id-123", "old-refresh");
-    expect(getUserInfo).toHaveBeenCalledWith("new-access");
-    expect(session.set).toHaveBeenCalledWith("authTokens", {
-      accessToken: "new-access",
-      refreshToken: "new-refresh",
-      idToken: "new-id",
-    });
-    expect(session.__store.user).toEqual({
-      sub: "123",
-      email: "test@example.com",
-      organization: "acme",
-    });
+    expect(generateOAuthState).toHaveBeenCalledWith("/dashboard");
     expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toBe("/dashboard");
-    expect(sessionStorage.commitSession).toHaveBeenCalledWith(session);
+
+    const location = response.headers.get("Location")!;
+    expect(location).toContain("https://keycloak.example.com/auth");
+    expect(location).toContain("prompt=none");
+    expect(location).toContain("response_type=code");
+    expect(location).toContain("state=random-state-123");
+    expect(location).toContain("code_challenge=test-challenge");
+    expect(location).toContain("code_challenge_method=S256");
+    expect(location).toContain("nonce=test-nonce");
+    expect(location).toContain(
+      "redirect_uri=" + encodeURIComponent("https://app.example.com/auth/callback"),
+    );
   });
 
   // `Sec-`-prefixed headers are forbidden header names the Request constructor
@@ -110,8 +98,7 @@ describe("refresh loader (token-refresh primitive)", () => {
     }) as unknown as Request;
 
   test("rejects cross-site subresource requests without touching the session", async () => {
-    const session = buildSession();
-    (getSession as Mock).mockResolvedValue(session);
+    (getSession as Mock).mockResolvedValue(authenticatedSession());
     const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const request = requestWithFetchMode(
@@ -122,19 +109,13 @@ describe("refresh loader (token-refresh primitive)", () => {
 
     expect(response.status).toBe(404);
     expect(getSession).not.toHaveBeenCalled();
-    expect(refreshAccessTokenWithLock).not.toHaveBeenCalled();
+    expect(generateOAuthState).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });
 
   test("allows top-level navigations (Sec-Fetch-Mode: navigate)", async () => {
-    const session = buildSession();
-    (getSession as Mock).mockResolvedValue(session);
-    (refreshAccessTokenWithLock as Mock).mockResolvedValue({
-      accessToken: "new-access",
-      refreshToken: "new-refresh",
-      idToken: "new-id",
-    });
-    (getUserInfo as Mock).mockResolvedValue({ sub: "123" });
+    (getSession as Mock).mockResolvedValue(authenticatedSession());
+    primeOAuthState();
 
     const request = requestWithFetchMode(
       "http://localhost/auth/refresh?return_to=/dashboard",
@@ -143,45 +124,38 @@ describe("refresh loader (token-refresh primitive)", () => {
     const response = await loader({ request } as LoaderFunctionArgs);
 
     expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toBe("/dashboard");
+    expect(response.headers.get("Location")).toContain("prompt=none");
   });
 
   test("validates return_to against open-redirect guard", async () => {
-    const session = buildSession();
-    (getSession as Mock).mockResolvedValue(session);
-    (refreshAccessTokenWithLock as Mock).mockResolvedValue({
-      accessToken: "new-access",
-      refreshToken: "new-refresh",
-      idToken: "new-id",
-    });
-    (getUserInfo as Mock).mockResolvedValue({ sub: "123" });
+    (getSession as Mock).mockResolvedValue(authenticatedSession());
+    primeOAuthState();
 
     const request = new Request(
       "http://localhost/auth/refresh?return_to=https://evil.example.com/phish",
     );
-    const response = await loader({ request } as LoaderFunctionArgs);
+    await loader({ request } as LoaderFunctionArgs);
 
     expect(validateRedirectTo).toHaveBeenCalledWith("https://evil.example.com/phish");
-    expect(response.headers.get("Location")).toBe("/");
+    // Off-host target collapses to "/", so no return path is carried into state.
+    expect(generateOAuthState).toHaveBeenCalledWith(undefined);
   });
 
-  test("falls back to login when no active session", async () => {
-    const session = buildSession({ user: undefined, authTokens: undefined });
-    (getSession as Mock).mockResolvedValue(session);
+  test("falls back to interactive login when no active session", async () => {
+    (getSession as Mock).mockResolvedValue({ get: vi.fn(() => null) });
 
     const request = new Request("http://localhost/auth/refresh?return_to=/dashboard");
     const response = await loader({ request } as LoaderFunctionArgs);
 
-    expect(refreshAccessTokenWithLock).not.toHaveBeenCalled();
+    expect(generateOAuthState).not.toHaveBeenCalled();
     expect(response.headers.get("Location")).toBe(
       `/login?redirect=${encodeURIComponent("/dashboard")}`,
     );
   });
 
-  test("falls back to login when refresh fails", async () => {
-    const session = buildSession();
-    (getSession as Mock).mockResolvedValue(session);
-    (refreshAccessTokenWithLock as Mock).mockRejectedValue(new Error("refresh expired"));
+  test("falls back to interactive login when state generation fails", async () => {
+    (getSession as Mock).mockResolvedValue(authenticatedSession());
+    (generateOAuthState as Mock).mockRejectedValue(new Error("Redis connection failed"));
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const request = new Request("http://localhost/auth/refresh?return_to=/dashboard");

--- a/app/routes/auth/callback.route.tsx
+++ b/app/routes/auth/callback.route.tsx
@@ -38,6 +38,17 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   // Handle errors from authorization server
   if (error) {
+    // A silent re-auth (prompt=none) has no usable SSO session — this is an
+    // expected outcome, not a failure. Fall back to interactive login,
+    // recovering the return path from the (one-shot) state.
+    if (error === "login_required" || error === "interaction_required") {
+      const redirectTo = validateRedirectTo(
+        state ? (await validateOAuthState(state))?.redirectTo : undefined,
+      );
+      console.info(`${label} Silent re-auth not possible (${error}), redirecting to login`);
+      return redirect(`/login?redirect=${encodeURIComponent(redirectTo)}`);
+    }
+
     console.error(`${label} Authorization error:`, error, errorDescription);
     return failWithNotification(
       request,

--- a/app/routes/auth/refresh.route.tsx
+++ b/app/routes/auth/refresh.route.tsx
@@ -1,35 +1,38 @@
 import { LoaderFunctionArgs, redirect } from "react-router";
 
 import { getSession } from "~/.server/auth/getSession";
-import { getUserInfo } from "~/.server/auth/getUserInfo";
-import { validateRedirectTo } from "~/.server/auth/oauthState";
-import { refreshAccessTokenWithLock } from "~/.server/auth/refreshAuthTokens";
-import { sessionStorage } from "~/.server/auth/sessionStorage";
+import { generateOAuthState, validateRedirectTo } from "~/.server/auth/oauthState";
+import { getWellKnownEndpoints } from "~/.server/auth/wellKnownEndpoints";
 import { createLabel } from "~/.server/logging";
+import { cytarioConfig } from "~/config";
 
 const label = createLabel("auth-refresh", "magenta");
 
 /**
- * Generic token-refresh primitive.
+ * Generic claim-refresh primitive via OIDC silent re-authentication.
  *
- * On an authenticated session, performs a Keycloak `refresh_token` grant,
- * re-fetches the user profile (so newly-present claims like `organization`
- * land on the session), persists both, and redirects to a validated
- * `return_to`. Carries no org/trial/billing logic — callers decide when a
- * refresh is warranted.
+ * A `refresh_token` grant only reissues a token from the cached Keycloak
+ * session, so claims resolved out-of-band after login (e.g. an `organization`
+ * membership added via the admin API) never appear. This route instead starts
+ * an Authorization Code flow with `prompt=none`: Keycloak reuses the existing
+ * SSO cookie (no interactive prompt) but performs a fresh authentication that
+ * re-resolves membership and re-runs mappers, so the new token carries the
+ * current claims. `/auth/callback` completes the exchange and writes the
+ * session as usual.
  *
- * Any failure (no session, expired/failed refresh) falls back to interactive
- * login rather than erroring.
+ * Carries no org/trial/billing logic — callers decide when a refresh is
+ * warranted. No session, or a Keycloak `login_required`/`interaction_required`
+ * (handled in the callback), falls back to interactive login.
  */
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  console.info(`${label} Refresh initiated`);
+  console.info(`${label} Silent refresh initiated`);
 
-  // Refreshing re-mints tokens, so this GET is state-mutating. Restrict it to
-  // top-level navigations: a browser sends `Sec-Fetch-Mode: navigate` for real
-  // navigations (incl. server-issued redirects), but `no-cors`/`cors` for
-  // cross-site subresource embeds (`<img src=...>`, fetch). Rejecting the
-  // latter blocks forced-refresh CSRF and Keycloak amplification. Non-browser
-  // clients omit the header and are allowed.
+  // Re-authenticating mutates the session, so this GET is state-changing.
+  // Restrict it to top-level navigations: a browser sends `Sec-Fetch-Mode:
+  // navigate` for real navigations (incl. server-issued redirects), but
+  // `no-cors`/`cors` for cross-site subresource embeds (`<img src=...>`,
+  // fetch). Rejecting the latter blocks forced-refresh CSRF and Keycloak
+  // amplification. Non-browser clients omit the header and are allowed.
   const fetchMode = request.headers.get("Sec-Fetch-Mode");
   if (fetchMode && fetchMode !== "navigate") {
     console.warn(`${label} Rejected non-navigation request (Sec-Fetch-Mode: ${fetchMode})`);
@@ -41,28 +44,36 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const loginFallback = `/login?redirect=${encodeURIComponent(returnTo)}`;
 
   const session = await getSession(request);
-  const user = session.get("user");
-  const authTokens = session.get("authTokens");
-
-  if (!user || !authTokens?.refreshToken) {
-    console.info(`${label} No active session, falling back to login`);
+  if (!session.get("user")) {
+    console.info(`${label} No active session, falling back to interactive login`);
     return redirect(loginFallback);
   }
 
   try {
-    const newAuthTokens = await refreshAccessTokenWithLock(session.id, authTokens.refreshToken);
-    const refreshedUser = await getUserInfo(newAuthTokens.accessToken);
+    const { state, codeChallenge, nonce } = await generateOAuthState(
+      returnTo === "/" ? undefined : returnTo,
+    );
 
-    session.set("authTokens", newAuthTokens);
-    session.set("user", refreshedUser);
+    const wellKnownEndpoints = await getWellKnownEndpoints();
 
-    console.info(`${label} Tokens re-minted, redirecting to:`, returnTo);
+    const redirectUri = `${cytarioConfig.endpoints.webapp}/auth/callback`;
+    const authUrl = new URL(wellKnownEndpoints.authorization_endpoint);
+    authUrl.searchParams.set("client_id", cytarioConfig.auth.clientId);
+    authUrl.searchParams.set("redirect_uri", redirectUri);
+    authUrl.searchParams.set("response_type", "code");
+    authUrl.searchParams.set("scope", cytarioConfig.auth.scopes.join(" "));
+    authUrl.searchParams.set("state", state);
+    authUrl.searchParams.set("code_challenge", codeChallenge);
+    authUrl.searchParams.set("code_challenge_method", "S256");
+    authUrl.searchParams.set("nonce", nonce);
+    // Silent re-authentication: reuse the SSO session, never show a prompt.
+    authUrl.searchParams.set("prompt", "none");
 
-    return redirect(returnTo, {
-      headers: { "Set-Cookie": await sessionStorage.commitSession(session) },
-    });
+    console.info(`${label} Redirecting to Keycloak for silent re-authentication`);
+
+    return redirect(authUrl.toString());
   } catch (error) {
-    console.error(`${label} Refresh failed, falling back to login:`, error);
+    console.error(`${label} Failed to initiate silent refresh:`, error);
     return redirect(loginFallback);
   }
 };


### PR DESCRIPTION
## Problem

The `/auth/refresh` primitive (PR #147) used a Keycloak `refresh_token` grant, but in practice the `organization` claim still didn't surface — the onboarding redirect loop C-292 set out to fix persisted.

**Root cause:** a `refresh_token` grant only reissues a token from the **cached Keycloak session**. Organization membership is resolved and bound to that session at authentication time. The saas-plugin portal adds membership out-of-band via the admin API, which never touches the live SSO session, and a refresh grant does not re-resolve it. Re-fetching userinfo can't help either — it's populated from the same session-bound mappers.

## Fix

Switch `/auth/refresh` to an OIDC **silent re-authentication** (`prompt=none`):

- Redirects the browser to Keycloak's authorize endpoint with `prompt=none`.
- Keycloak reuses the existing SSO cookie — **no interactive prompt** — but performs a fresh authentication that re-resolves org membership and re-runs mappers, so the new token carries the current `organization` claim.
- The existing `/auth/callback` completes the code exchange, verifies, re-fetches userinfo, and writes the session.
- On `error=login_required` / `interaction_required` (no usable SSO session), the callback recovers `return_to` from the one-shot state and falls back to interactive login — treated as an expected outcome, not an auth failure (no error toast).

Alternative considered — Keycloak **token exchange v2** (server-only, no browser round-trip) — rejected: feature-flagged preview, org-membership re-evaluation not guaranteed. `prompt=none` is the robust, standard mechanism and stays in the auth layer.

## Preserved from #147

- `Sec-Fetch-Mode` navigation guard (rejects cross-site subresource embeds → CSRF / Keycloak amplification).
- `return_to` validated through the `validateRedirectTo` open-redirect guard.
- No session / failure → interactive login fallback.
- No org/trial/billing logic — purely generic auth.

## Commits

- `feat(auth): handle prompt=none login_required in callback`
- `fix(auth): refresh claims via silent re-auth instead of refresh_token grant`

## Tests

`refresh.test.tsx` rewritten (prompt=none redirect, nav guard, open-redirect, no-session + failure fallbacks); `callback.test.tsx` adds the `login_required` fallback case. 18 auth-route tests pass.

[C-292]