### PR TITLE
feat(sidebar): reveal active path in connection tree [C-260]

### DIFF
--- a/app/components/DirectoryView/DirectoryViewTree.tsx
+++ b/app/components/DirectoryView/DirectoryViewTree.tsx
@@ -2,7 +2,7 @@ import { IconButton } from "@cytario/design";
 import { asyncDataLoaderFeature, hotkeysCoreFeature } from "@headless-tree/core";
 import { useTree } from "@headless-tree/react";
 import { ChevronRight } from "lucide-react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 import { type TreeNode } from "./buildDirectoryTree";
@@ -16,7 +16,15 @@ interface DirectoryViewTreeProps {
   nodeLinkProps?: Omit<React.ComponentProps<typeof NodeLink>, "node">;
   /** Called when a lazy stub (`loadState === "idle"`) is expanded. Omit for static trees. */
   onExpand?: (parent: TreeNode) => Promise<TreeNode[]>;
+  /** Items expanded when the tree first mounts. */
   defaultExpandedItems?: string[];
+  /**
+   * Ancestor ids to reveal reactively. Whenever this changes, the ids are
+   * unioned into the expanded set (never removing manual expansions), and the
+   * async loader cascade-loads each newly-expanded level. Use to follow the
+   * active route on client-side navigation. Omit for static trees.
+   */
+  revealItems?: string[];
 }
 
 const ROOT_ID = "__directory_tree_root__";
@@ -27,13 +35,34 @@ export function DirectoryViewTree({
   kind,
   onExpand = noopOnExpand,
   defaultExpandedItems,
+  revealItems,
   nodeLinkProps,
 }: DirectoryViewTreeProps) {
   const nodesById = useRef<Map<string, TreeNode>>(new Map());
+  const [expandedItems, setExpandedItems] = useState<string[]>(defaultExpandedItems ?? []);
+
+  // Reveal a deep-linked path on navigation: when `revealItems` changes, union
+  // the requested ancestor ids into the expanded set without disturbing manual
+  // expansions. The async loader then cascade-loads each newly-expanded level.
+  // Adjust-state-during-render (not an effect) so the reveal lands in the same
+  // commit as the route change.
+  const [prevReveal, setPrevReveal] = useState(revealItems);
+  if (revealItems !== prevReveal) {
+    setPrevReveal(revealItems);
+    if (revealItems?.length) {
+      setExpandedItems((prev) => {
+        const next = new Set(prev);
+        const before = next.size;
+        for (const id of revealItems) next.add(id);
+        return next.size === before ? prev : Array.from(next);
+      });
+    }
+  }
 
   const tree = useTree<TreeNode>({
     rootItemId: ROOT_ID,
-    initialState: defaultExpandedItems ? { expandedItems: defaultExpandedItems } : undefined,
+    state: { expandedItems },
+    setExpandedItems,
     getItemName: (item) => item.getItemData()?.name ?? "",
     isItemFolder: (item) => {
       const data = item.getItemData();

--- a/app/components/Sidebar/ConnectionTree.tsx
+++ b/app/components/Sidebar/ConnectionTree.tsx
@@ -7,13 +7,21 @@ import { collectInteriorIds, type TreeNode } from "~/components/DirectoryView/bu
 import { DirectoryViewTree } from "~/components/DirectoryView/DirectoryViewTree";
 import { onExpand } from "~/components/DirectoryView/onExpand";
 import { LavaLoader } from "~/components/LavaLoader";
+import { ancestorDirIds } from "~/utils/resourceId";
 
 interface ConnectionTreeProps {
   selectedConnection: string;
   query: string;
+  /**
+   * Decoded path of the resource the current route points at (S3-key form).
+   * When set, the tree mounts with every ancestor folder pre-expanded so a
+   * deep link / reload reveals where the resource lives. Omit to show only the
+   * collapsed root.
+   */
+  activePathName?: string;
 }
 
-export function ConnectionTree({ selectedConnection, query }: ConnectionTreeProps) {
+export function ConnectionTree({ selectedConnection, query, activePathName }: ConnectionTreeProps) {
   const rootId = `${selectedConnection}/`;
   const {
     nodes: searchNodes,
@@ -40,6 +48,11 @@ export function ConnectionTree({ selectedConnection, query }: ConnectionTreeProp
   );
 
   const searchExpanded = useMemo(() => collectInteriorIds(searchNodes), [searchNodes]);
+
+  const browseExpanded = useMemo(
+    () => (activePathName ? ancestorDirIds(selectedConnection, activePathName) : [rootId]),
+    [activePathName, selectedConnection, rootId],
+  );
 
   if (query) {
     if (isSearching && searchNodes.length === 0) {
@@ -80,7 +93,8 @@ export function ConnectionTree({ selectedConnection, query }: ConnectionTreeProp
       nodes={rootNodes}
       kind="entries"
       onExpand={onExpand}
-      defaultExpandedItems={[rootId]}
+      defaultExpandedItems={browseExpanded}
+      revealItems={browseExpanded}
     />
   );
 }

--- a/app/components/Sidebar/Explorer/FeatureItem.Connections.tsx
+++ b/app/components/Sidebar/Explorer/FeatureItem.Connections.tsx
@@ -13,7 +13,8 @@ import { useConnectionsStore } from "~/utils/connectionsStore/useConnectionsStor
 export function FeatureItemConnections() {
   const connections = useConnectionsStore(select.connections);
   const connectionNames = useMemo(() => Object.keys(connections), [connections]);
-  const routeName = useParams().name;
+  const params = useParams();
+  const routeName = params.name;
 
   const [override, setOverride] = useState<string | null>(null);
   const [query, setQuery] = useState("");
@@ -28,6 +29,10 @@ export function FeatureItemConnections() {
 
   const selectedConnection =
     override ?? (routeName && connectionNames.includes(routeName) ? routeName : connectionNames[0]);
+
+  // Reveal the active resource only when the tree shows the route's own
+  // connection — not when the user manually switched to a different one.
+  const activePathName = selectedConnection === routeName ? params["*"] : undefined;
 
   return (
     <FeatureItem
@@ -53,7 +58,11 @@ export function FeatureItemConnections() {
       }
     >
       {selectedConnection ? (
-        <ConnectionTree selectedConnection={selectedConnection} query={query} />
+        <ConnectionTree
+          selectedConnection={selectedConnection}
+          query={query}
+          activePathName={activePathName}
+        />
       ) : (
         <EmptyState
           icon={Unplug}

--- a/app/utils/resourceId.ts
+++ b/app/utils/resourceId.ts
@@ -38,6 +38,28 @@ export function parseResourceId(resourceId: string): ResourceIdParts {
   return { connectionName, pathName, fileName, name, extension };
 }
 
+/**
+ * Ancestor directory node ids for a resource, from the connection root down to
+ * the folder that contains it (the resource itself is excluded). Ids match
+ * `DirectoryViewTree` node ids — `connectionName/pathName` with a trailing
+ * slash on directories — so the result can be passed as `defaultExpandedItems`
+ * to reveal a deep-linked node in the sidebar tree.
+ *
+ * `pathName` must be decoded (S3-key form, e.g. `customers/Project 6712/x.tif`).
+ */
+export function ancestorDirIds(connectionName: string, pathName: string): string[] {
+  const ids = [`${connectionName}/`];
+  // Drop the trailing segment: it's the resource being viewed, not a parent to expand.
+  const segments = pathName.replace(/\/+$/, "").split("/").filter(Boolean);
+  segments.pop();
+  let acc = "";
+  for (const segment of segments) {
+    acc += `${segment}/`;
+    ids.push(`${connectionName}/${acc}`);
+  }
+  return ids;
+}
+
 /** Builds a routable URL path from a connection name and an object path. */
 export function buildConnectionPath(connectionName: string, pathName: string): string {
   const path = pathName


### PR DESCRIPTION
## What

When deep-linking or reloading into a nested image, the sidebar connection tree stayed collapsed at the root — no sense of where the resource lived. Clicking through `DirectoryView` had the same gap on navigation.

Now the tree auto-expands every ancestor folder of the active resource, both on mount (deep link / reload) and on client-side navigation.

## How

- `ancestorDirIds(connectionName, pathName)` (`resourceId.ts`) — derives the ancestor directory node ids from the active route path. Ids byte-match `DirectoryViewTree` node ids (`connectionName/pathName`, trailing slash on dirs, decoded segments).
- `DirectoryViewTree` now **controls** its `expandedItems` and accepts a reactive `revealItems` prop. On change, the ancestor chain is unioned into the expanded set (never removing manual expansions) via adjust-state-during-render. The existing `asyncDataLoaderFeature` then cascade-loads each newly-expanded level — one level per render cycle — so no new fetch machinery is needed.
- `ConnectionTree` / `FeatureItem.Connections` pass the decoded splat (`params["*"]`) as the active path, but **only when the tree shows the route's own connection** — a manual connection switch via the chip is left untouched.

## Scope notes

- Reveals **parent folders** of the viewed resource (the resource row itself is highlighted via `NodeLink`, not expanded).
- Union never collapses — navigating keeps previously revealed/expanded branches open, matching normal file-tree behaviour.
- Search tree and other `DirectoryViewTree` callers pass no `revealItems` → behaviour unchanged.

## Test

- `tsc`, eslint, prettier clean.
- Existing `DirectoryViewTree` / `DirectoryView` unit tests pass (16).

Closes [C-260]