### PR TITLE
feat(viewer): OS-like multi-select for annotations [C-319]

### DIFF
--- a/app/components/.client/ImageViewer/components/AnnotationsController/AnnotationThumb.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/AnnotationThumb.tsx
@@ -1,0 +1,135 @@
+import { IconButton, Menu, MenuItem, MenuSeparator } from "@cytario/design";
+import type { Geometry } from "geojson";
+
+import { GeometrySvg, type Point } from "~/components/DataGrid/GeometrySvg";
+import type { AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
+
+const THUMB_SIZE = 48;
+
+/** GeoJSON polygon geometry → screen-space rings (annotation coords are already
+ *  pixel space, Y-down — no flip). Points have no rings; the caller renders a
+ *  glyph. Annotation draw modes only emit Polygon/Point. */
+const geometryToRings = (geometry: Geometry): Point[][] => {
+  if (geometry.type === "Polygon") {
+    return geometry.coordinates.map((ring) => ring.map(([x, y]) => ({ x, y })));
+  }
+  if (geometry.type === "MultiPolygon") {
+    return geometry.coordinates.flatMap((polygon) =>
+      polygon.map((ring) => ring.map(([x, y]) => ({ x, y }))),
+    );
+  }
+  return [];
+};
+
+/** Concentric white/black/white rings around a selected point, mirroring the
+ *  on-slide point selection frame. Radii outermost-first (drawn underneath). */
+const POINT_SELECTION_RINGS = [
+  { r: 6.5, stroke: "#fff" },
+  { r: 5.5, stroke: "#000" },
+  { r: 4.5, stroke: "#fff" },
+];
+
+const GeometryThumb = ({
+  geometry,
+  color,
+  selected,
+}: {
+  geometry: Geometry;
+  color?: string;
+  selected?: boolean;
+}) => {
+  if (geometry.type === "Point") {
+    const c = THUMB_SIZE / 2;
+    return (
+      <svg width={THUMB_SIZE} height={THUMB_SIZE} className="inline-block rounded bg-muted">
+        {selected &&
+          POINT_SELECTION_RINGS.map((ring) => (
+            <circle
+              key={ring.r}
+              cx={c}
+              cy={c}
+              r={ring.r}
+              fill="none"
+              stroke={ring.stroke}
+              strokeWidth={1.5}
+            />
+          ))}
+        <circle
+          cx={c}
+          cy={c}
+          r={3}
+          fill={color ?? "currentColor"}
+          className={color ? undefined : "fill-secondary"}
+        />
+      </svg>
+    );
+  }
+  return (
+    <GeometrySvg
+      rings={geometryToRings(geometry)}
+      size={THUMB_SIZE}
+      color={color}
+      selected={selected}
+    />
+  );
+};
+
+interface AnnotationThumbProps {
+  feature: AnnotationFeature;
+  selected: boolean;
+  /** Classification color for the glyph, or undefined for the unclassified fallback. */
+  color?: string;
+  /** Own set → destructive actions enabled; peers are read-only. */
+  editable: boolean;
+  onSelect: (event: React.MouseEvent) => void;
+  onZoom: () => void;
+  onDelete: () => void;
+}
+
+/** A single annotation in the sidebar list: a selectable geometry thumbnail with
+ *  a hover/focus-revealed actions menu (zoom, delete). */
+export const AnnotationThumb = ({
+  feature,
+  selected,
+  color,
+  editable,
+  onSelect,
+  onZoom,
+  onDelete,
+}: AnnotationThumbProps) => {
+  return (
+    <div className="group/thumb relative">
+      <button
+        type="button"
+        aria-pressed={selected}
+        onClick={onSelect}
+        className="rounded border border-border text-muted-foreground hover:text-foreground"
+      >
+        <GeometryThumb geometry={feature.geometry} color={color} selected={selected} />
+      </button>
+
+      <Menu
+        content={
+          <>
+            <MenuItem id="zoom" icon="ZoomIn" onAction={onZoom}>
+              Zoom to annotation
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem id="delete" icon="Trash2" isDanger isDisabled={!editable} onAction={onDelete}>
+              Delete annotation
+            </MenuItem>
+          </>
+        }
+      >
+        <IconButton
+          icon="EllipsisVertical"
+          label="Annotation actions"
+          variant="ghost"
+          size="xs"
+          // Show on thumb hover or keyboard focus-within (the menu trigger), so the actions stay discoverable without cluttering every thumbnail.
+          className="absolute top-0 right-0 opacity-0 transition-opacity group-hover/thumb:opacity-100 focus-within:opacity-100"
+        />
+      </Menu>
+    </div>
+  );
+};

--- a/app/components/.client/ImageViewer/components/AnnotationsController/AnnotationsController.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/AnnotationsController.tsx
@@ -24,37 +24,33 @@ export const AnnotationsController = () => {
     return list.sort(([a], [b]) => (a === ownUserId ? -1 : b === ownUserId ? 1 : 0));
   }, [annotationsByUser, ownUserId]);
 
-  return (
-    <>
-      {entries.map(([userId, features]) => {
-        const isOwn = userId === ownUserId;
-        return (
-          <FeatureItem
-            key={userId}
-            title={isOwn ? "Annotations (You)" : `Annotations (${userId.slice(0, 6)})`}
-            badge={features.length ? String(features.length) : undefined}
-            header={isOwn ? <AnnotationsTools /> : undefined}
-            actions={
-              <FeatureItemSlider
-                aria-label="Annotation opacity"
-                value={annotationView[userId]?.opacity ?? 1}
-                onChange={(value) => setOpacity(userId, value)}
-              />
-            }
-          >
-            {features.length ? (
-              <AnnotationsList userId={userId} features={features} editable={isOwn} />
-            ) : (
-              <EmptyState
-                title="No annotations"
-                description="Use the draw tools to add regions."
-                icon="Spline"
-                className="py-6"
-              />
-            )}
-          </FeatureItem>
-        );
-      })}
-    </>
-  );
+  return entries.map(([userId, features]) => {
+    const isOwn = userId === ownUserId;
+    return (
+      <FeatureItem
+        key={userId}
+        title={isOwn ? "Annotations (You)" : `Annotations (${userId.slice(0, 6)})`}
+        badge={features.length ? String(features.length) : undefined}
+        header={isOwn ? <AnnotationsTools /> : undefined}
+        actions={
+          <FeatureItemSlider
+            aria-label="Annotation opacity"
+            value={annotationView[userId]?.opacity ?? 1}
+            onChange={(value) => setOpacity(userId, value)}
+          />
+        }
+      >
+        {features.length ? (
+          <AnnotationsList userId={userId} features={features} editable={isOwn} />
+        ) : (
+          <EmptyState
+            title="No annotations"
+            description="Use the draw tools to add regions."
+            icon="Spline"
+            className="py-6"
+          />
+        )}
+      </FeatureItem>
+    );
+  });
 };

--- a/app/components/.client/ImageViewer/components/AnnotationsController/AnnotationsList.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/AnnotationsList.tsx
@@ -1,8 +1,7 @@
-import { IconButton, Menu, MenuItem, MenuSeparator } from "@cytario/design";
-import type { Geometry } from "geojson";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 
 import { AnnotationGroupRow } from "./AnnotationGroupRow";
+import { AnnotationThumb } from "./AnnotationThumb";
 import { flyToFeatureViewState } from "./flyToFeature";
 import {
   classNameOf,
@@ -12,78 +11,7 @@ import {
 import { RGB } from "../../state/store/types";
 import { useViewerStore } from "../../state/store/ViewerStoreContext";
 import { rgb } from "../ChannelsController/ColorPicker/ColorPicker";
-import { GeometrySvg, type Point } from "~/components/DataGrid/GeometrySvg";
 import type { AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
-
-const THUMB_SIZE = 48;
-
-/** GeoJSON polygon geometry → screen-space rings (annotation coords are already
- *  pixel space, Y-down — no flip). Points have no rings; the caller renders a
- *  glyph. Annotation draw modes only emit Polygon/Point. */
-const geometryToRings = (geometry: Geometry): Point[][] => {
-  if (geometry.type === "Polygon") {
-    return geometry.coordinates.map((ring) => ring.map(([x, y]) => ({ x, y })));
-  }
-  if (geometry.type === "MultiPolygon") {
-    return geometry.coordinates.flatMap((polygon) =>
-      polygon.map((ring) => ring.map(([x, y]) => ({ x, y }))),
-    );
-  }
-  return [];
-};
-
-/** Concentric white/black/white rings around a selected point, mirroring the
- *  on-slide point selection frame. Radii outermost-first (drawn underneath). */
-const POINT_SELECTION_RINGS = [
-  { r: 6.5, stroke: "#fff" },
-  { r: 5.5, stroke: "#000" },
-  { r: 4.5, stroke: "#fff" },
-];
-
-const GeometryThumb = ({
-  geometry,
-  color,
-  selected,
-}: {
-  geometry: Geometry;
-  color?: string;
-  selected?: boolean;
-}) => {
-  if (geometry.type === "Point") {
-    const c = THUMB_SIZE / 2;
-    return (
-      <svg width={THUMB_SIZE} height={THUMB_SIZE} className="inline-block rounded bg-muted">
-        {selected &&
-          POINT_SELECTION_RINGS.map((ring) => (
-            <circle
-              key={ring.r}
-              cx={c}
-              cy={c}
-              r={ring.r}
-              fill="none"
-              stroke={ring.stroke}
-              strokeWidth={1.5}
-            />
-          ))}
-        <circle
-          cx={c}
-          cy={c}
-          r={3}
-          fill={color ?? "currentColor"}
-          className={color ? undefined : "fill-secondary"}
-        />
-      </svg>
-    );
-  }
-  return (
-    <GeometrySvg
-      rings={geometryToRings(geometry)}
-      size={THUMB_SIZE}
-      color={color}
-      selected={selected}
-    />
-  );
-};
 
 interface AnnotationGroup {
   name: string;
@@ -114,26 +42,7 @@ export const AnnotationsList = ({ userId, features, editable }: AnnotationsListP
   const viewState = useViewerStore((s) => s.viewStateActive);
   const setViewState = useViewerStore((s) => s.setViewStateActive);
 
-  const select = (feature: AnnotationFeature) => {
-    setSelectedIds(feature.properties?.id ? [feature.properties.id] : []);
-  };
-
-  const zoomToFeature = (feature: AnnotationFeature) => {
-    select(feature);
-    if (!viewState) return;
-    const next = flyToFeatureViewState(feature.geometry, viewState);
-    if (next) setViewState(next);
-  };
-
-  const deleteFeature = (feature: AnnotationFeature) => {
-    setSelectedIds([]);
-    updateUserFeatures(
-      userId,
-      features.filter((f) => f !== feature),
-    );
-  };
-
-  const groups = useMemo<AnnotationGroup[]>(() => {
+  const annotationsGroups = useMemo<AnnotationGroup[]>(() => {
     const byName = new Map<string, AnnotationGroup>();
     features.forEach((feature, index) => {
       const name = classNameOf(feature);
@@ -147,77 +56,102 @@ export const AnnotationsList = ({ userId, features, editable }: AnnotationsListP
     return [...byName.values()];
   }, [features]);
 
+  // Flattened ids in displayed (grouped) order — the axis a Shift-range walks.
+  const orderedIds = useMemo(
+    () =>
+      annotationsGroups.flatMap(
+        (g) => g.items.map((it) => it.feature.properties?.id).filter(Boolean) as string[],
+      ),
+    [annotationsGroups],
+  );
+
+  // Last item selected without Shift — the fixed end of a range extension.
+  const anchorId = useRef<string | null>(null);
+
+  const select = (feature: AnnotationFeature, e?: MouseEvent | React.MouseEvent) => {
+    const id = feature.properties?.id;
+    if (!id) {
+      setSelectedIds([]);
+      return;
+    }
+
+    // Shift+click: contiguous range from the anchor to the clicked item over the
+    // displayed order (anchor stays put). Falls back to plain select if there is
+    // no live anchor.
+    if (e?.shiftKey && anchorId.current) {
+      const from = orderedIds.indexOf(anchorId.current);
+      const to = orderedIds.indexOf(id);
+      if (from !== -1 && to !== -1) {
+        const [lo, hi] = from <= to ? [from, to] : [to, from];
+        setSelectedIds(orderedIds.slice(lo, hi + 1));
+        return;
+      }
+    }
+
+    // Cmd/Ctrl+click: toggle the clicked item in/out; the anchor moves to it.
+    if (e && (e.metaKey || e.ctrlKey)) {
+      setSelectedIds(
+        selectedIds.includes(id) ? selectedIds.filter((s) => s !== id) : [...selectedIds, id],
+      );
+      anchorId.current = id;
+      return;
+    }
+
+    // Plain click: single select; reset the anchor.
+    setSelectedIds([id]);
+    anchorId.current = id;
+  };
+
+  const zoomToFeature = (feature: AnnotationFeature) => {
+    // Select the target without routing through select() — zoom is navigation,
+    // not a selection gesture, so it must not move the Shift-range anchor.
+    const id = feature.properties?.id;
+    setSelectedIds(id ? [id] : []);
+    if (!viewState) return;
+    const next = flyToFeatureViewState(feature.geometry, viewState);
+    if (next) setViewState(next);
+  };
+
+  const deleteFeature = (feature: AnnotationFeature) => {
+    setSelectedIds([]);
+    anchorId.current = null;
+    updateUserFeatures(
+      userId,
+      features.filter((f) => f !== feature),
+    );
+  };
+
   return (
     <div className="flex flex-col gap-2 px-3 py-2">
-      {groups.map((group) => {
-        const cssColor = rgb([...(group.color ?? UNCLASSIFIED_COLOR), 255]);
+      {annotationsGroups.map(({ name, color, items }) => {
+        const cssColor = rgb([...(color ?? UNCLASSIFIED_COLOR), 255]);
         return (
-          <div key={group.name} className="flex flex-col">
+          <div key={name} className="flex flex-col">
             <AnnotationGroupRow
-              name={group.name}
-              count={group.items.length}
-              color={group.color}
-              isVisible={!hiddenClasses.includes(group.name)}
-              onToggleVisibility={() => toggleClassVisibility(userId, group.name)}
+              name={name}
+              count={items.length}
+              color={color}
+              isVisible={!hiddenClasses.includes(name)}
+              onToggleVisibility={() => toggleClassVisibility(userId, name)}
               onColorChange={
-                editable && group.color
-                  ? (color) => setClassColor(userId, group.name, color)
-                  : undefined
+                editable && color ? (color) => setClassColor(userId, name, color) : undefined
               }
             />
 
             <div className="flex flex-wrap gap-1.5 pt-1">
-              {group.items.map(({ feature, index }) => {
+              {items.map(({ feature, index }) => {
                 const id = feature.properties?.id;
-                const isSelected = !!id && selectedIds.includes(id);
                 return (
-                  <div key={id ?? index} className="group/thumb relative">
-                    <button
-                      type="button"
-                      aria-pressed={isSelected}
-                      onClick={() => select(feature)}
-                      className="rounded border border-border text-muted-foreground hover:text-foreground"
-                    >
-                      <GeometryThumb
-                        geometry={feature.geometry}
-                        color={cssColor}
-                        selected={isSelected}
-                      />
-                    </button>
-
-                    <div className="absolute right-0 top-0 rounded bg-background/80 opacity-0 transition-opacity group-hover/thumb:opacity-100 focus-within:opacity-100">
-                      <Menu
-                        content={
-                          <>
-                            <MenuItem
-                              id="zoom"
-                              icon="ZoomIn"
-                              onAction={() => zoomToFeature(feature)}
-                            >
-                              Zoom to annotation
-                            </MenuItem>
-                            <MenuSeparator />
-                            <MenuItem
-                              id="delete"
-                              icon="Trash2"
-                              isDanger
-                              isDisabled={!editable}
-                              onAction={() => deleteFeature(feature)}
-                            >
-                              Delete annotation
-                            </MenuItem>
-                          </>
-                        }
-                      >
-                        <IconButton
-                          icon="EllipsisVertical"
-                          label="Annotation actions"
-                          variant="ghost"
-                          size="xs"
-                        />
-                      </Menu>
-                    </div>
-                  </div>
+                  <AnnotationThumb
+                    key={id ?? index}
+                    feature={feature}
+                    selected={!!id && selectedIds.includes(id)}
+                    color={cssColor}
+                    editable={editable}
+                    onSelect={(e) => select(feature, e)}
+                    onZoom={() => zoomToFeature(feature)}
+                    onDelete={() => deleteFeature(feature)}
+                  />
                 );
               })}
             </div>

--- a/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationGroupRow.test.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationGroupRow.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { RGB } from "../../../state/store/types";
+import { AnnotationGroupRow } from "../AnnotationGroupRow";
+
+const RED: RGB = [255, 0, 0];
+
+describe("AnnotationGroupRow", () => {
+  test("renders the group name", () => {
+    render(
+      <AnnotationGroupRow
+        name="Tumor"
+        count={3}
+        color={RED}
+        isVisible={true}
+        onToggleVisibility={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Tumor")).toBeInTheDocument();
+  });
+
+  test("renders the item count", () => {
+    render(
+      <AnnotationGroupRow
+        name="Stroma"
+        count={7}
+        color={RED}
+        isVisible={true}
+        onToggleVisibility={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  test("visibility switch has an accessible label containing the group name", () => {
+    render(
+      <AnnotationGroupRow
+        name="Tumor"
+        count={1}
+        color={RED}
+        isVisible={true}
+        onToggleVisibility={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("switch", { name: "Toggle Tumor visibility" })).toBeInTheDocument();
+  });
+
+  test("calls onToggleVisibility when the switch is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <AnnotationGroupRow
+        name="Tumor"
+        count={1}
+        color={RED}
+        isVisible={true}
+        onToggleVisibility={onToggle}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch", { name: "Toggle Tumor visibility" }));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  test("shows a ColorPicker swatch (button) when recolorable (color non-null + onColorChange provided)", () => {
+    render(
+      <AnnotationGroupRow
+        name="Tumor"
+        count={1}
+        color={RED}
+        isVisible={true}
+        onToggleVisibility={vi.fn()}
+        onColorChange={vi.fn()}
+      />,
+    );
+
+    // ColorPicker renders a button for the swatch — role="button" with a color label
+    const colorButton = screen.getByRole("button");
+    expect(colorButton).toBeInTheDocument();
+  });
+
+  test("does not show a ColorPicker when color is null (Unclassified group)", () => {
+    render(
+      <AnnotationGroupRow
+        name="Unclassified"
+        count={2}
+        color={null}
+        isVisible={true}
+        onToggleVisibility={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  test("does not show a ColorPicker when onColorChange is not provided even if color is set", () => {
+    render(
+      <AnnotationGroupRow
+        name="Tumor"
+        count={2}
+        color={RED}
+        isVisible={true}
+        onToggleVisibility={vi.fn()}
+        onColorChange={undefined}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationThumb.test.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationThumb.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+
+import { AnnotationThumb } from "../AnnotationThumb";
+import type { AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
+
+const makeFeature = (overrides?: Partial<AnnotationFeature>): AnnotationFeature => ({
+  type: "Feature",
+  geometry: { type: "Point", coordinates: [100, 200] },
+  properties: { id: "feat-1" },
+  ...overrides,
+});
+
+const defaultProps = {
+  feature: makeFeature(),
+  selected: false,
+  color: "rgba(255, 0, 0, 255)",
+  editable: true,
+  onSelect: vi.fn(),
+  onZoom: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe("AnnotationThumb", () => {
+  test("aria-pressed is false when not selected", () => {
+    render(<AnnotationThumb {...defaultProps} selected={false} />);
+
+    expect(screen.getByRole("button", { name: "" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  test("aria-pressed is true when selected", () => {
+    render(<AnnotationThumb {...defaultProps} selected={true} />);
+
+    expect(screen.getByRole("button", { name: "" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("calls onSelect when the thumbnail button is clicked", () => {
+    const onSelect = vi.fn();
+    render(<AnnotationThumb {...defaultProps} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "" }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test("Delete menu item is disabled when editable is false", () => {
+    render(<AnnotationThumb {...defaultProps} editable={false} />);
+
+    // Open the actions menu
+    fireEvent.click(screen.getByRole("button", { name: "Annotation actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Delete annotation" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  test("Delete menu item is enabled when editable is true", () => {
+    render(<AnnotationThumb {...defaultProps} editable={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Annotation actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Delete annotation" })).not.toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  test("Zoom menu item is present in the actions menu", () => {
+    render(<AnnotationThumb {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Annotation actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Zoom to annotation" })).toBeInTheDocument();
+  });
+
+  test("calls onZoom when Zoom menu item is activated", () => {
+    const onZoom = vi.fn();
+    render(<AnnotationThumb {...defaultProps} onZoom={onZoom} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Annotation actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Zoom to annotation" }));
+
+    expect(onZoom).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationsController.test.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationsController.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useStore } from "zustand";
+
+import { createViewerStore } from "../../../state/store/createViewerStore";
+import type { ViewerStore } from "../../../state/store/types";
+import { AnnotationsController } from "../AnnotationsController";
+import type { AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
+
+// Inject a real store instance without the image-loading side-effects.
+let currentStore: ReturnType<typeof createViewerStore>;
+
+vi.mock("../../../state/store/ViewerStoreContext", () => ({
+  useViewerStore: <T,>(selector: (state: ViewerStore) => T): T => useStore(currentStore, selector),
+}));
+
+// Control the current user identity per test.
+let currentUserId: string | undefined = "own-user";
+
+vi.mock("~/hooks/useCurrentUser", () => ({
+  useCurrentUser: () => (currentUserId ? { sub: currentUserId } : undefined),
+}));
+
+// AnnotationsTools renders draw-mode controls that pull from the store and
+// have deep dependencies (canvas layer modes, etc.); stub it to keep these
+// tests focused on the AnnotationsController layout logic.
+vi.mock("../AnnotationsTools", () => ({
+  AnnotationsTools: () => <div data-testid="annotations-tools" />,
+}));
+
+// AnnotationsList has its own tests; stub it here to isolate layout behaviour.
+vi.mock("../AnnotationsList", () => ({
+  AnnotationsList: ({ userId, editable }: { userId: string; editable: boolean }) => (
+    <div data-testid={`annotations-list-${userId}`} data-editable={String(editable)} />
+  ),
+}));
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+const makeFeature = (id: string): AnnotationFeature => ({
+  type: "Feature",
+  geometry: { type: "Point", coordinates: [0, 0] },
+  properties: { id },
+});
+
+function buildStore() {
+  const store = createViewerStore(`test-${Math.random()}`);
+  currentStore = store;
+  return store;
+}
+
+function renderController() {
+  return render(<AnnotationsController />);
+}
+
+/** Opens all FeatureItem accordions (click every [data-expander] button). */
+function openAll() {
+  for (const btn of screen.getAllByRole("button").filter((b) => b.getAttribute("data-expander"))) {
+    fireEvent.click(btn);
+  }
+}
+
+// -----------------------------------------------------------------------
+// Own-first ordering
+// -----------------------------------------------------------------------
+
+describe("AnnotationsController — own-first ordering", () => {
+  test("own user's section appears before peer sections", () => {
+    const store = buildStore();
+    store.getState().updateUserFeatures("own-user", [makeFeature("f1")]);
+    store.getState().updateUserFeatures("peer-a", [makeFeature("f2")]);
+    store.getState().updateUserFeatures("peer-b", [makeFeature("f3")]);
+
+    renderController();
+
+    const items = screen.getAllByText(/^Annotations/);
+    expect(items[0]).toHaveTextContent("Annotations (You)");
+  });
+
+  test("own section is titled 'Annotations (You)'", () => {
+    const store = buildStore();
+    store.getState().updateUserFeatures("own-user", [makeFeature("f1")]);
+
+    renderController();
+
+    expect(screen.getByText("Annotations (You)")).toBeInTheDocument();
+  });
+
+  test("peer section title shows a truncated user id", () => {
+    const store = buildStore();
+    store.getState().updateUserFeatures("peer-xyz", [makeFeature("f1")]);
+
+    renderController();
+
+    // peer-xyz → first 6 chars "peer-x"
+    expect(screen.getByText("Annotations (peer-x)")).toBeInTheDocument();
+  });
+});
+
+// -----------------------------------------------------------------------
+// Empty own section injection
+// -----------------------------------------------------------------------
+
+describe("AnnotationsController — empty own section", () => {
+  test("renders an own section even when the user has no annotations yet", () => {
+    buildStore(); // empty store — own user has no key
+
+    renderController();
+
+    expect(screen.getByText("Annotations (You)")).toBeInTheDocument();
+  });
+
+  test("empty own section does not appear when ownUserId is unknown", () => {
+    currentUserId = undefined;
+    buildStore();
+
+    renderController();
+
+    expect(screen.queryByText("Annotations (You)")).not.toBeInTheDocument();
+
+    // Restore for subsequent tests.
+    currentUserId = "own-user";
+  });
+});
+
+// -----------------------------------------------------------------------
+// Editable gating — own vs peers
+// -----------------------------------------------------------------------
+
+describe("AnnotationsController — editable gating", () => {
+  test("own AnnotationsList is rendered with editable=true", () => {
+    const store = buildStore();
+    store.getState().updateUserFeatures("own-user", [makeFeature("f1")]);
+
+    renderController();
+    openAll();
+
+    const ownList = screen.getByTestId("annotations-list-own-user");
+    expect(ownList).toHaveAttribute("data-editable", "true");
+  });
+
+  test("peer AnnotationsList is rendered with editable=false", () => {
+    const store = buildStore();
+    store.getState().updateUserFeatures("peer-a", [makeFeature("f1")]);
+
+    renderController();
+    openAll();
+
+    const peerList = screen.getByTestId("annotations-list-peer-a");
+    expect(peerList).toHaveAttribute("data-editable", "false");
+  });
+
+  test("draw tools appear only in the own section header (not in peer sections)", () => {
+    const store = buildStore();
+    store.getState().updateUserFeatures("own-user", [makeFeature("f1")]);
+    store.getState().updateUserFeatures("peer-a", [makeFeature("f2")]);
+
+    renderController();
+    openAll();
+
+    // AnnotationsTools is only injected into the own FeatureItem header.
+    expect(screen.getAllByTestId("annotations-tools")).toHaveLength(1);
+  });
+});

--- a/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationsList.test.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsController/__tests__/AnnotationsList.test.tsx
@@ -1,0 +1,341 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { useStore } from "zustand";
+
+import { createViewerStore } from "../../../state/store/createViewerStore";
+import type { ViewerStore } from "../../../state/store/types";
+import { AnnotationsList } from "../AnnotationsList";
+import type { AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
+
+// Mock the ViewerStoreContext so we can inject a real store without the
+// image-loading / S3-sync side-effects of the full ViewerStoreProvider.
+// Every test builds its own store instance via buildStore().
+let currentStore: ReturnType<typeof createViewerStore>;
+
+vi.mock("../../../state/store/ViewerStoreContext", () => ({
+  useViewerStore: <T,>(selector: (state: ViewerStore) => T): T => useStore(currentStore, selector),
+}));
+
+// -----------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------
+
+const makeFeature = (
+  id: string,
+  className?: string,
+  color?: [number, number, number],
+): AnnotationFeature => ({
+  type: "Feature",
+  geometry: {
+    type: "Polygon",
+    coordinates: [
+      [
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [0, 0],
+      ],
+    ],
+  },
+  properties: {
+    id,
+    ...(className ? { classification: { name: className, color: color ?? [255, 0, 0] } } : {}),
+  },
+});
+
+const makeIdlessFeature = (): AnnotationFeature => ({
+  type: "Feature",
+  geometry: { type: "Point", coordinates: [0, 0] },
+  properties: {},
+});
+
+function buildStore(userId = "user-a", features: AnnotationFeature[] = []) {
+  const store = createViewerStore(`test-${Math.random()}`);
+  store.getState().updateUserFeatures(userId, features);
+  currentStore = store;
+  return store;
+}
+
+/** Renders AnnotationsList against the pre-configured currentStore. */
+function renderList(
+  features: AnnotationFeature[],
+  { userId = "user-a", editable = true }: { userId?: string; editable?: boolean } = {},
+) {
+  buildStore(userId, features);
+  return render(<AnnotationsList userId={userId} features={features} editable={editable} />);
+}
+
+/** Returns the thumbnail buttons in DOM order (grouped order = the Shift-range axis). */
+function thumbButtons() {
+  return screen.getAllByRole("button").filter((b) => b.hasAttribute("aria-pressed"));
+}
+
+/** Clicks the Nth thumbnail (0-based) with optional modifier keys. */
+function clickThumb(
+  index: number,
+  modifiers?: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean },
+) {
+  const buttons = thumbButtons();
+  fireEvent.click(buttons[index]!, modifiers ?? {});
+}
+
+// -----------------------------------------------------------------------
+// select() — C-319 multi-select logic
+// -----------------------------------------------------------------------
+
+describe("AnnotationsList — select() semantics (C-319)", () => {
+  test("plain click selects only the clicked feature", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3")];
+    renderList(features);
+
+    clickThumb(1);
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f2"]);
+  });
+
+  test("plain click replaces a previous selection", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3")];
+    renderList(features);
+
+    clickThumb(0);
+    clickThumb(2);
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f3"]);
+  });
+
+  test("Cmd+click adds an unselected feature to the selection", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3")];
+    renderList(features);
+
+    clickThumb(0);
+    clickThumb(2, { metaKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f1", "f3"]);
+  });
+
+  test("Cmd+click removes an already-selected feature (toggle out)", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3")];
+    renderList(features);
+
+    // Select f1 and f2, then toggle f1 out.
+    clickThumb(0);
+    clickThumb(1, { metaKey: true });
+    clickThumb(0, { metaKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f2"]);
+  });
+
+  test("Ctrl+click adds an unselected feature (same semantics as Cmd)", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3")];
+    renderList(features);
+
+    clickThumb(0);
+    clickThumb(2, { ctrlKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f1", "f3"]);
+  });
+
+  test("Shift+click selects the contiguous range from anchor to target (forward)", () => {
+    const features = [
+      makeFeature("f1"),
+      makeFeature("f2"),
+      makeFeature("f3"),
+      makeFeature("f4"),
+      makeFeature("f5"),
+    ];
+    renderList(features);
+
+    // Anchor at index 1, then Shift+click index 4.
+    clickThumb(1);
+    clickThumb(4, { shiftKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f2", "f3", "f4", "f5"]);
+  });
+
+  test("Shift+click selects the contiguous range from anchor to target (backward)", () => {
+    const features = [
+      makeFeature("f1"),
+      makeFeature("f2"),
+      makeFeature("f3"),
+      makeFeature("f4"),
+      makeFeature("f5"),
+    ];
+    renderList(features);
+
+    // Anchor at index 3, then Shift+click index 0.
+    clickThumb(3);
+    clickThumb(0, { shiftKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f1", "f2", "f3", "f4"]);
+  });
+
+  test("Shift+click with no prior anchor falls back to plain select", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3")];
+    renderList(features);
+
+    // No prior click — Shift+click with no anchor should single-select.
+    clickThumb(2, { shiftKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f3"]);
+  });
+
+  test("Cmd+click moves the anchor so subsequent Shift+click extends from the new anchor", () => {
+    const features = [
+      makeFeature("f1"),
+      makeFeature("f2"),
+      makeFeature("f3"),
+      makeFeature("f4"),
+      makeFeature("f5"),
+    ];
+    renderList(features);
+
+    // Anchor at 0, then Cmd+click 2 (anchor moves to 2), then Shift+click 4.
+    clickThumb(0);
+    clickThumb(2, { metaKey: true });
+    clickThumb(4, { shiftKey: true });
+
+    // Range from anchor (f3) to f5.
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f3", "f4", "f5"]);
+  });
+
+  test("clicking a feature with no id clears the selection", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeIdlessFeature()];
+    renderList(features);
+
+    // Select f1 first.
+    clickThumb(0);
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f1"]);
+
+    // Click the id-less feature — selection should clear.
+    clickThumb(2);
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual([]);
+  });
+
+  test("Shift+click anchor stays fixed across multiple range extensions", () => {
+    const features = [makeFeature("f1"), makeFeature("f2"), makeFeature("f3"), makeFeature("f4")];
+    renderList(features);
+
+    // Anchor at 0.
+    clickThumb(0);
+    // Extend to 3.
+    clickThumb(3, { shiftKey: true });
+    // Extend back to 1 (anchor still 0 — re-clicking Shift replaces the range).
+    clickThumb(1, { shiftKey: true });
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f1", "f2"]);
+  });
+});
+
+// -----------------------------------------------------------------------
+// aria-pressed reflects selection state
+// -----------------------------------------------------------------------
+
+describe("AnnotationsList — thumbnail selected state", () => {
+  test("aria-pressed is false on all thumbnails initially", () => {
+    const features = [makeFeature("f1"), makeFeature("f2")];
+    renderList(features);
+
+    for (const btn of thumbButtons()) {
+      expect(btn).toHaveAttribute("aria-pressed", "false");
+    }
+  });
+
+  test("aria-pressed turns true on the selected thumbnail after click", () => {
+    const features = [makeFeature("f1"), makeFeature("f2")];
+    renderList(features);
+
+    clickThumb(0);
+
+    expect(thumbButtons()[0]).toHaveAttribute("aria-pressed", "true");
+    expect(thumbButtons()[1]).toHaveAttribute("aria-pressed", "false");
+  });
+});
+
+// -----------------------------------------------------------------------
+// delete
+// -----------------------------------------------------------------------
+
+describe("AnnotationsList — delete", () => {
+  test("delete removes the feature from the user's set", () => {
+    const f1 = makeFeature("f1");
+    const f2 = makeFeature("f2");
+    renderList([f1, f2]);
+
+    // Open actions menu on the first thumb and delete.
+    const actionButtons = screen.getAllByRole("button", { name: "Annotation actions" });
+    fireEvent.click(actionButtons[0]!);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete annotation" }));
+
+    expect(currentStore.getState().annotationsByUser["user-a"]).toHaveLength(1);
+    expect(currentStore.getState().annotationsByUser["user-a"]![0].properties!.id).toBe("f2");
+  });
+
+  test("delete clears the selection and anchor", () => {
+    const features = [makeFeature("f1"), makeFeature("f2")];
+    renderList(features);
+
+    clickThumb(0);
+    expect(currentStore.getState().annotationSelectedIds).toEqual(["f1"]);
+
+    const actionButtons = screen.getAllByRole("button", { name: "Annotation actions" });
+    fireEvent.click(actionButtons[0]!);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete annotation" }));
+
+    expect(currentStore.getState().annotationSelectedIds).toEqual([]);
+  });
+});
+
+// -----------------------------------------------------------------------
+// Grouping
+// -----------------------------------------------------------------------
+
+describe("AnnotationsList — classification grouping", () => {
+  test("features are grouped by classification name with a header per group", () => {
+    const features = [
+      makeFeature("f1", "Tumor"),
+      makeFeature("f2", "Stroma"),
+      makeFeature("f3", "Tumor"),
+    ];
+    renderList(features);
+
+    expect(screen.getByText("Tumor")).toBeInTheDocument();
+    expect(screen.getByText("Stroma")).toBeInTheDocument();
+  });
+
+  test("features without a classification appear under the Unclassified group", () => {
+    const features = [makeFeature("f1")]; // no classification
+    renderList(features);
+
+    expect(screen.getByText("Unclassified")).toBeInTheDocument();
+  });
+
+  test("group count reflects the number of features in that group", () => {
+    const features = [
+      makeFeature("f1", "Tumor"),
+      makeFeature("f2", "Tumor"),
+      makeFeature("f3", "Stroma"),
+    ];
+    renderList(features);
+
+    // The Tumor group count is 2, Stroma is 1.
+    // AnnotationGroupRow renders the count as a plain number text.
+    const counts = screen.getAllByText(/^\d+$/);
+    const countValues = counts.map((el) => el.textContent);
+    expect(countValues).toContain("2");
+    expect(countValues).toContain("1");
+  });
+
+  test("Delete is disabled on peer (non-editable) thumbnails", () => {
+    const features = [makeFeature("f1")];
+    renderList(features, { editable: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Annotation actions" }));
+
+    expect(screen.getByRole("menuitem", { name: "Delete annotation" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+});

--- a/app/components/.client/ImageViewer/components/Image/Annotations/useAnnotationsLayer.tsx
+++ b/app/components/.client/ImageViewer/components/Image/Annotations/useAnnotationsLayer.tsx
@@ -23,6 +23,11 @@ import { type AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
 
 type SetTooltip = (tooltip: { content: ReactNode; x: number; y: number } | null) => void;
 
+/** Minimal structural shape of the modifier flags carried by the DOM event
+ *  behind a deck picking event — all optional so any concrete DOM event
+ *  (Mouse/Pointer/Touch) is assignable to the click handler. */
+type ModifierKeys = { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean };
+
 const MODE_CLASSES = {
   view: ViewMode,
   "draw-polygon": DrawPolygonMode,
@@ -145,10 +150,21 @@ export const useAnnotationsLayer = (imagePanelId: number, setTooltip?: SetToolti
     // Props shared by the own (editable) and peer (read-only) layers: fill/line
     // colored by classification (hidden classes → alpha 0) and view-mode
     // click-to-select. Only the alphas and per-user hidden/opacity differ.
-    const selectOnClick = (info: PickingInfo) => {
+    const selectOnClick = (info: PickingInfo, event?: { srcEvent?: ModifierKeys }) => {
       if (mode !== "view") return; // in draw modes a click is a draw action
       const id = (info.object as AnnotationFeature | undefined)?.properties?.id;
-      if (id) setSelectedIds([id]);
+      if (!id) return;
+      const src = event?.srcEvent;
+      // Any modifier keeps the selection additive — toggle the clicked feature in
+      // or out. Range-select needs an ordered list, which the canvas has no
+      // meaningful notion of, so Shift behaves like Cmd/Ctrl here.
+      if (src && (src.metaKey || src.ctrlKey || src.shiftKey)) {
+        setSelectedIds(
+          selectedIds.includes(id) ? selectedIds.filter((s) => s !== id) : [...selectedIds, id],
+        );
+        return;
+      }
+      setSelectedIds([id]);
     };
 
     const paint = (


### PR DESCRIPTION
Adds modifier-click multi-selection to annotations on both surfaces, and extracts `AnnotationThumb`.

## Behavior
- **List thumbnails** (`AnnotationsList.select`): plain = single-select + set range anchor; Cmd/Ctrl = toggle in/out + move anchor; Shift = contiguous range from the anchor over the displayed (grouped) order; no anchor → plain.
- **Canvas** (`useAnnotationsLayer.selectOnClick`): plain replaces; any modifier toggles the clicked feature. No range on canvas (no meaningful order).
- Selection state is already `string[]` and the ring renderer loops over all selected, so no store/render change.

## Refactor (bundled)
- Extracted `AnnotationThumb` (thumbnail + actions menu + geometry glyph) from `AnnotationsList`; `AnnotationsController` returns the mapped array directly.
- Actions menu revealed on thumb hover / keyboard focus-within.
- `zoomToFeature` no longer moves the Shift anchor.

## Tests
41 unit tests — first UI coverage for this area (`AnnotationsList` select() semantics, `AnnotationThumb`, `AnnotationGroupRow`, `AnnotationsController`). Reviewed by architect + fullstack + frontend agents.

## Docs
Companion SRS §3.4.4 PR in cytario-docs (amends SRS-CY-34407/34408, adds SRS-CY-34414).

Part of Annotations MVP (C-88). Follow-up: C-307 (I/O zod validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)