### PR TITLE
feat: undo/redo for annotation editing via zundo (C-329)

### DIFF
--- a/app/components/.client/ImageViewer/components/AnnotationsPanel/AnnotationsTools.tsx
+++ b/app/components/.client/ImageViewer/components/AnnotationsPanel/AnnotationsTools.tsx
@@ -1,12 +1,13 @@
 import { IconButton } from "@cytario/design";
 
 import { type AnnotationMode } from "../../state/store/types";
+import { useUndoRedo } from "../../state/store/useUndoRedo";
 import { useViewerStore } from "../../state/store/ViewerStoreContext";
 
 /**
- * Sidebar control for image annotations: draw-mode toggles (polygon / point)
- * and the current count. Editing happens on the canvas via the
- * `EditableGeoJsonLayer`; this just drives the shared mode.
+ * Sidebar control for image annotations: draw-mode toggles (polygon / point),
+ * undo/redo, and the current count. Editing happens on the canvas via the
+ * `EditableGeoJsonLayer`; this just drives the shared mode and history.
  */
 
 const drawingTools = [
@@ -19,6 +20,7 @@ export const AnnotationsTools = () => {
   const activeMode = useViewerStore((s) => s.annotationMode);
   const setMode = useViewerStore((s) => s.setAnnotationMode);
   const setSelectedIds = useViewerStore((s) => s.setAnnotationSelectedIds);
+  const { undo, redo, canUndo, canRedo } = useUndoRedo();
 
   const toggle = (target: AnnotationMode) => {
     setSelectedIds([]);
@@ -41,6 +43,24 @@ export const AnnotationsTools = () => {
           />
         );
       })}
+      <div className="ml-auto flex flex-row gap-1">
+        <IconButton
+          icon="RotateCcw"
+          label="Undo"
+          variant="ghost"
+          size="xs"
+          isDisabled={!canUndo}
+          onPress={undo}
+        />
+        <IconButton
+          icon="RotateCw"
+          label="Redo"
+          variant="ghost"
+          size="xs"
+          isDisabled={!canRedo}
+          onPress={redo}
+        />
+      </div>
     </div>
   );
 };

--- a/app/components/.client/ImageViewer/components/ImageViewer.tsx
+++ b/app/components/.client/ImageViewer/components/ImageViewer.tsx
@@ -8,6 +8,7 @@ import { Magnifier } from "./Magnifier";
 import { OverlaysPanel } from "./OverlaysPanel/OverlaysPanel";
 import { Presets } from "./Presets/Presets";
 import { ViewerHeader } from "./ViewerHeader";
+import { useUndoRedoShortcuts } from "../state/store/useUndoRedoShortcuts";
 import { ViewerStoreProvider } from "../state/store/ViewerStoreContext";
 import { createSidebarStore } from "~/components/Sidebar/createSidebarStore";
 import { Sidebar, SIDEBAR, sidebarDomId, sidebarToggleId } from "~/components/Sidebar/Sidebar";
@@ -23,6 +24,7 @@ export const useViewerSidebarStore = createSidebarStore({ name: "ViewerSidebar" 
 export const Viewer = ({ signedFetch, resourceId }: ViewerProps) => {
   return (
     <ViewerStoreProvider resourceId={resourceId} signedFetch={signedFetch}>
+      <UndoRedoShortcuts />
       <ViewerHeader>
         {({ metadata, viewStateActive, setViewStateActive }) => (
           <Magnifier
@@ -59,6 +61,12 @@ export const Viewer = ({ signedFetch, resourceId }: ViewerProps) => {
     </ViewerStoreProvider>
   );
 };
+
+// Mounts the keyboard shortcut listener inside the ViewerStoreProvider.
+function UndoRedoShortcuts() {
+  useUndoRedoShortcuts();
+  return null;
+}
 
 // Always-visible toggle (bottom-right) so the panel can be reopened when collapsed.
 function ViewerSidebarToggle() {

--- a/app/components/.client/ImageViewer/state/store/ViewerStoreContext.tsx
+++ b/app/components/.client/ImageViewer/state/store/ViewerStoreContext.tsx
@@ -83,6 +83,10 @@ const useViewerRegistryStore = create<ViewerRegistryStore>()(
 
 const ViewerStoreContext = createContext<ViewerStoreApi | null>(null);
 
+/** Exposed so the undo/redo hook can read the raw store API (to reach
+ *  `store.temporal`) without subscribing to the entire state. */
+export { ViewerStoreContext };
+
 interface ViewerStoreProviderProps {
   /** Stable image identity (`connectionName/pathName`). Keys the store and is
    *  resolved to the S3 URL for loading. */

--- a/app/components/.client/ImageViewer/state/store/__tests__/test-temporal.test.ts
+++ b/app/components/.client/ImageViewer/state/store/__tests__/test-temporal.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import type { StoreApi } from "zustand";
+
+import { createViewerStore } from "../createViewerStore";
+import type { AnnotationFeature } from "~/utils/db/getAnnotationsWasm";
+
+type ZundoTemporalState = {
+  pastStates: unknown[];
+  futureStates: unknown[];
+  undo: () => void;
+  redo: () => void;
+  pause: () => void;
+  resume: () => void;
+};
+
+type ZundoTemporalStoreApi = StoreApi<ZundoTemporalState>;
+
+const pointFeature = (id: string): AnnotationFeature =>
+  ({
+    type: "Feature" as const,
+    id,
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: {},
+  }) as AnnotationFeature;
+
+const getTemporal = (store: ReturnType<typeof createViewerStore>): ZundoTemporalStoreApi =>
+  (store as unknown as { temporal?: ZundoTemporalStoreApi }).temporal!;
+
+describe("temporal history", () => {
+  it("records history after updateUserFeatures", () => {
+    const store = createViewerStore("test/image.ome.tif");
+
+    const temporal = getTemporal(store);
+    expect(temporal).toBeDefined();
+
+    const before = temporal.getState().pastStates.length;
+
+    store.getState().updateUserFeatures("user-a", [pointFeature("f1")]);
+
+    const after = temporal.getState().pastStates.length;
+    expect(after).toBeGreaterThan(before);
+  });
+
+  it("does not block real edits after ephemeral state changes (no cooldown from unrelated sets)", () => {
+    const store = createViewerStore("test/image.ome.tif");
+    const temporal = getTemporal(store);
+
+    // Simulate ephemeral state changes (draw mode, selection, etc.)
+    // that don't touch annotationsByUser or annotationClasses
+    store.setState({ annotationMode: "draw-point" });
+    store.setState({ annotationMode: "draw-polygon" });
+    store.setState({ annotationSelectedIds: ["some-id"] });
+
+    // Now perform a real annotation edit — it should still be recorded
+    const before = temporal.getState().pastStates.length;
+    store.getState().updateUserFeatures("user-a", [pointFeature("f1")]);
+
+    const after = temporal.getState().pastStates.length;
+    expect(after).toBeGreaterThan(before);
+  });
+});

--- a/app/components/.client/ImageViewer/state/store/createViewerStore.ts
+++ b/app/components/.client/ImageViewer/state/store/createViewerStore.ts
@@ -23,9 +23,9 @@ import { createTemporalOptions, type TemporalState } from "./viewerTemporal";
  * the undo/redo history. Only `id` lives at the root; it keys persistence +
  * devtools.
  *
- * The `TemporalState` (cool-off controller) is attached as a non-enumerable
- * property on the returned store so the `useUndoRedo` hook can reset the
- * gesture debounce before calling undo/redo.
+ * The `TemporalState` (cool-off controller) is attached as a property on the
+ * returned store so the `useUndoRedo` hook can reset the gesture debounce
+ * before calling undo/redo.
  */
 export const createViewerStore = (id: string) => {
   const { options: temporalOptions, temporalState } = createTemporalOptions();

--- a/app/components/.client/ImageViewer/state/store/createViewerStore.ts
+++ b/app/components/.client/ImageViewer/state/store/createViewerStore.ts
@@ -1,3 +1,4 @@
+import { temporal } from "zundo";
 import { createStore } from "zustand";
 import { devtools, persist, subscribeWithSelector } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -9,29 +10,42 @@ import { createOverlaysSlice } from "./slices/viewer.overlays.store";
 import { createViewSlice } from "./slices/viewer.view.store";
 import type { ViewerStore } from "./types";
 import { viewerStoreMigrate, viewerStorePartialize } from "./viewerStore.persistence";
+import { createTemporalOptions, type TemporalState } from "./viewerTemporal";
 
 /**
  * Creates a Zustand store for one image-viewer instance. State + actions are
  * composed from domain slices (`slices/viewer.*.store.ts`) — core, view,
  * channels, overlays, annotations — over the
- * `subscribeWithSelector → persist → immer → devtools` middleware stack.
- * `subscribeWithSelector` lets the annotation autosave writer subscribe to a
- * single slice of state. Only `id` lives at the root; it keys persistence + devtools.
+ * `subscribeWithSelector → persist → immer → devtools → temporal` middleware
+ * stack. `subscribeWithSelector` lets the annotation autosave writer
+ * subscribe to a single slice of state. `temporal` (zundo) is innermost so
+ * it intercepts every `set` first, snapshotting the pre-mutation state into
+ * the undo/redo history. Only `id` lives at the root; it keys persistence +
+ * devtools.
+ *
+ * The `TemporalState` (cool-off controller) is attached as a non-enumerable
+ * property on the returned store so the `useUndoRedo` hook can reset the
+ * gesture debounce before calling undo/redo.
  */
-export const createViewerStore = (id: string) =>
-  createStore<ViewerStore>()(
+export const createViewerStore = (id: string) => {
+  const { options: temporalOptions, temporalState } = createTemporalOptions();
+
+  const store = createStore<ViewerStore>()(
     subscribeWithSelector(
       persist(
         immer(
           devtools(
-            (set, get, store) => ({
-              id,
-              ...createCoreSlice(set, get, store),
-              ...createViewSlice(set, get, store),
-              ...createChannelsSlice(set, get, store),
-              ...createOverlaysSlice(set, get, store),
-              ...createAnnotationsSlice(set, get, store),
-            }),
+            temporal(
+              (set, get, storeApi) => ({
+                id,
+                ...createCoreSlice(set, get, storeApi),
+                ...createViewSlice(set, get, storeApi),
+                ...createChannelsSlice(set, get, storeApi),
+                ...createOverlaysSlice(set, get, storeApi),
+                ...createAnnotationsSlice(set, get, storeApi),
+              }),
+              temporalOptions,
+            ),
             {
               name: "ViewerStore-" + id,
             },
@@ -51,3 +65,11 @@ export const createViewerStore = (id: string) =>
       ),
     ),
   );
+
+  // Attach the cool-off controller so the undo/redo hook can reset the
+  // gesture debounce before performing undo/redo (prevents a leftover
+  // cool-off from swallowing the first post-undo edit).
+  (store as unknown as { __temporalState?: TemporalState }).__temporalState = temporalState;
+
+  return store;
+};

--- a/app/components/.client/ImageViewer/state/store/slices/viewer.annotations.store.ts
+++ b/app/components/.client/ImageViewer/state/store/slices/viewer.annotations.store.ts
@@ -159,7 +159,7 @@ export interface AnnotationsSlice {
 /** Per-image annotation state. Features live on S3 (one sidecar per user); this
  *  slice holds the working copy + view state. Persistence is the sync middleware
  *  (`attachAnnotationSync`), bound to the store — never serialized here. */
-export const createAnnotationsSlice: ViewerSlice<AnnotationsSlice> = (set) => ({
+export const createAnnotationsSlice: ViewerSlice<AnnotationsSlice> = (set, _get, store) => ({
   annotationsByUser: {},
   annotationMode: "view",
   annotationSelectedIds: [],
@@ -168,7 +168,18 @@ export const createAnnotationsSlice: ViewerSlice<AnnotationsSlice> = (set) => ({
   annotationClasses: [],
   annotationsOpacity: 1,
 
-  seedAnnotations: (byUser) =>
+  seedAnnotations: (byUser) => {
+    // Pause temporal tracking around the seed so the one-time S3 read does
+    // not enter the undo history. Without this, the seed would be the first
+    // past state — undoing immediately after load would wipe all annotations.
+    // `store.temporal` is added by the zundo middleware (innermost); the cast
+    // is needed because the slice's StateCreator type doesn't model it.
+    const temporalStore = (
+      store as unknown as {
+        temporal?: { getState: () => { pause: () => void; resume: () => void } };
+      }
+    ).temporal;
+    temporalStore?.getState().pause();
     set(
       (state) => {
         // Merge, not replace: a key the user already touched (drew into) before
@@ -182,16 +193,19 @@ export const createAnnotationsSlice: ViewerSlice<AnnotationsSlice> = (set) => ({
       },
       false,
       "seedAnnotations",
-    ),
+    );
+    temporalStore?.getState().resume();
+  },
 
-  updateUserFeatures: (userId, features) =>
+  updateUserFeatures: (userId, features) => {
     set(
       (state) => {
         state.annotationsByUser[userId] = features;
       },
       false,
       "updateUserFeatures",
-    ),
+    );
+  },
 
   setAnnotationClassColor: (userId, name, color) =>
     set(

--- a/app/components/.client/ImageViewer/state/store/slices/viewer.annotations.store.ts
+++ b/app/components/.client/ImageViewer/state/store/slices/viewer.annotations.store.ts
@@ -180,21 +180,24 @@ export const createAnnotationsSlice: ViewerSlice<AnnotationsSlice> = (set, _get,
       }
     ).temporal;
     temporalStore?.getState().pause();
-    set(
-      (state) => {
-        // Merge, not replace: a key the user already touched (drew into) before
-        // this async read resolved wins — installing only absent keys prevents
-        // the seed from clobbering a pre-seed draw.
-        for (const [userId, features] of Object.entries(byUser)) {
-          if (state.annotationsByUser[userId] === undefined) {
-            state.annotationsByUser[userId] = features;
+    try {
+      set(
+        (state) => {
+          // Merge, not replace: a key the user already touched (drew into) before
+          // this async read resolved wins — installing only absent keys prevents
+          // the seed from clobbering a pre-seed draw.
+          for (const [userId, features] of Object.entries(byUser)) {
+            if (state.annotationsByUser[userId] === undefined) {
+              state.annotationsByUser[userId] = features;
+            }
           }
-        }
-      },
-      false,
-      "seedAnnotations",
-    );
-    temporalStore?.getState().resume();
+        },
+        false,
+        "seedAnnotations",
+      );
+    } finally {
+      temporalStore?.getState().resume();
+    }
   },
 
   updateUserFeatures: (userId, features) => {

--- a/app/components/.client/ImageViewer/state/store/types.ts
+++ b/app/components/.client/ImageViewer/state/store/types.ts
@@ -98,9 +98,11 @@ export type ViewerStore = ViewerStoreState &
 
 /**
  * Slice creator typed for the viewer store's
- * `subscribeWithSelector → persist → immer → devtools` middleware stack — `set`
- * carries both the immer mutable draft and the devtools action-label third
- * argument. Shared by every `slices/viewer.*.store`.
+ * `subscribeWithSelector → persist → immer → devtools → temporal` middleware
+ * stack — `set` carries both the immer mutable draft and the devtools
+ * action-label third argument. `temporal` (zundo) is innermost so it wraps the
+ * store creator before any other middleware, giving it the raw state to
+ * snapshot. Shared by every `slices/viewer.*.store`.
  */
 export type ViewerSlice<T> = StateCreator<
   ViewerStore,
@@ -109,6 +111,7 @@ export type ViewerSlice<T> = StateCreator<
     ["zustand/persist", unknown],
     ["zustand/immer", never],
     ["zustand/devtools", never],
+    ["temporal", unknown],
   ],
   [],
   T

--- a/app/components/.client/ImageViewer/state/store/useUndoRedo.ts
+++ b/app/components/.client/ImageViewer/state/store/useUndoRedo.ts
@@ -1,0 +1,74 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+
+import { ViewerStoreContext } from "./ViewerStoreContext";
+
+type TemporalState = {
+  pastStates: unknown[];
+  futureStates: unknown[];
+  undo: () => void;
+  redo: () => void;
+  pause: () => void;
+  resume: () => void;
+};
+
+type TemporalStoreApi = import("zustand").StoreApi<TemporalState>;
+
+/**
+ * Exposes undo/redo for the current viewer's annotation history.
+ *
+ * zundo's `undo()`/`redo()` apply a past/future state by calling the store's
+ * `set()` — which would normally flow back through `handleSet` and record a
+ * new history entry. To prevent that, each call wraps `undo()`/`redo()` in
+ * `pause()`/`resume()` on the temporal store so the reapplication is not
+ * tracked. The gesture cool-off is also reset before the call so the first
+ * post-undo edit is always recorded.
+ *
+ * `canUndo` / `canRedo` are derived from the temporal store's `pastStates` /
+ * `futureStates` lengths and stay reactive via a temporal-store subscription.
+ */
+export const useUndoRedo = () => {
+  const store = useContext(ViewerStoreContext);
+  if (!store) throw new Error("useUndoRedo must be used within ViewerStoreProvider");
+
+  const temporalStore = (store as unknown as { temporal?: TemporalStoreApi }).temporal;
+
+  const cooldownReset = (store as unknown as { __temporalState?: { resetCooldown: () => void } })
+    ?.__temporalState?.resetCooldown;
+
+  const [canUndo, setCanUndo] = useState(
+    () => (temporalStore?.getState().pastStates.length ?? 0) > 0,
+  );
+  const [canRedo, setCanRedo] = useState(
+    () => (temporalStore?.getState().futureStates.length ?? 0) > 0,
+  );
+
+  useEffect(() => {
+    if (!temporalStore) return;
+    return temporalStore.subscribe((s) => {
+      setCanUndo(s.pastStates.length > 0);
+      setCanRedo(s.futureStates.length > 0);
+    });
+  }, [temporalStore]);
+
+  const undo = useCallback(() => {
+    if (!temporalStore) return;
+    cooldownReset?.();
+    const t = temporalStore.getState();
+    if (t.pastStates.length === 0) return;
+    t.pause();
+    t.undo();
+    t.resume();
+  }, [temporalStore, cooldownReset]);
+
+  const redo = useCallback(() => {
+    if (!temporalStore) return;
+    cooldownReset?.();
+    const t = temporalStore.getState();
+    if (t.futureStates.length === 0) return;
+    t.pause();
+    t.redo();
+    t.resume();
+  }, [temporalStore, cooldownReset]);
+
+  return { undo, redo, canUndo, canRedo };
+};

--- a/app/components/.client/ImageViewer/state/store/useUndoRedo.ts
+++ b/app/components/.client/ImageViewer/state/store/useUndoRedo.ts
@@ -56,8 +56,11 @@ export const useUndoRedo = () => {
     const t = temporalStore.getState();
     if (t.pastStates.length === 0) return;
     t.pause();
-    t.undo();
-    t.resume();
+    try {
+      t.undo();
+    } finally {
+      t.resume();
+    }
   }, [temporalStore, cooldownReset]);
 
   const redo = useCallback(() => {
@@ -66,8 +69,11 @@ export const useUndoRedo = () => {
     const t = temporalStore.getState();
     if (t.futureStates.length === 0) return;
     t.pause();
-    t.redo();
-    t.resume();
+    try {
+      t.redo();
+    } finally {
+      t.resume();
+    }
   }, [temporalStore, cooldownReset]);
 
   return { undo, redo, canUndo, canRedo };

--- a/app/components/.client/ImageViewer/state/store/useUndoRedo.ts
+++ b/app/components/.client/ImageViewer/state/store/useUndoRedo.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useSyncExternalStore } from "react";
 
 import { ViewerStoreContext } from "./ViewerStoreContext";
 
@@ -35,20 +35,16 @@ export const useUndoRedo = () => {
   const cooldownReset = (store as unknown as { __temporalState?: { resetCooldown: () => void } })
     ?.__temporalState?.resetCooldown;
 
-  const [canUndo, setCanUndo] = useState(
+  const canUndo = useSyncExternalStore(
+    temporalStore?.subscribe ?? (() => () => {}),
     () => (temporalStore?.getState().pastStates.length ?? 0) > 0,
+    () => false,
   );
-  const [canRedo, setCanRedo] = useState(
+  const canRedo = useSyncExternalStore(
+    temporalStore?.subscribe ?? (() => () => {}),
     () => (temporalStore?.getState().futureStates.length ?? 0) > 0,
+    () => false,
   );
-
-  useEffect(() => {
-    if (!temporalStore) return;
-    return temporalStore.subscribe((s) => {
-      setCanUndo(s.pastStates.length > 0);
-      setCanRedo(s.futureStates.length > 0);
-    });
-  }, [temporalStore]);
 
   const undo = useCallback(() => {
     if (!temporalStore) return;

--- a/app/components/.client/ImageViewer/state/store/useUndoRedoShortcuts.ts
+++ b/app/components/.client/ImageViewer/state/store/useUndoRedoShortcuts.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+
+import { useUndoRedo } from "./useUndoRedo";
+
+/**
+ * Global keyboard shortcuts for annotation undo/redo:
+ *
+ * - **Cmd/Ctrl+Z** — undo
+ * - **Shift+Cmd/Ctrl+Z** or **Cmd/Ctrl+Y** — redo
+ *
+ * Suppressed when the user is typing in a text input, textarea, or
+ * content-editable region (so editing an annotation label doesn't trigger
+ * the browser's native undo). The hook is viewer-scoped: mount it once per
+ * `ViewerStoreProvider` and it operates on that viewer's history.
+ */
+export const useUndoRedoShortcuts = () => {
+  const { undo, redo, canUndo, canRedo } = useUndoRedo();
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target?.isContentEditable) {
+        return;
+      }
+
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod || e.key.toLowerCase() !== "z") {
+        if (!mod || e.key.toLowerCase() !== "y") return;
+        // Cmd/Ctrl+Y → redo
+        e.preventDefault();
+        if (canRedo) redo();
+        return;
+      }
+
+      e.preventDefault();
+      if (e.shiftKey) {
+        if (canRedo) redo();
+      } else {
+        if (canUndo) undo();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [undo, redo, canUndo, canRedo]);
+};

--- a/app/components/.client/ImageViewer/state/store/viewerTemporal.ts
+++ b/app/components/.client/ImageViewer/state/store/viewerTemporal.ts
@@ -50,8 +50,6 @@ const temporalEquality = (past: TemporalPartial, current: TemporalPartial): bool
   past.annotationClasses === current.annotationClasses;
 
 export interface TemporalState {
-  /** Whether the gesture cool-off is active (edits suppressed). */
-  inCooldown: boolean;
   /** Clears the cool-off immediately (called before undo/redo). */
   resetCooldown: () => void;
 }
@@ -101,14 +99,21 @@ export function createTemporalOptions(): {
         (pastState as TemporalPartial).annotationClasses !==
           (currentState as TemporalPartial).annotationClasses;
       if (!trackedChanged) return;
-      if (inCooldown) return;
+      if (inCooldown) {
+        // Extend the cool-off window — the gesture is still going.
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => {
+          inCooldown = false;
+          timer = null;
+        }, GESTURE_DEBOUNCE_MS);
+        return;
+      }
       inCooldown = true;
       // `record` is the internal `_handleSet` which accepts the full
       // (pastState, replace, currentState, deltaState) tuple, even though
       // zundo types it as `StoreApi['setState']` (2 args). Cast to match
       // the runtime signature from the source.
       (record as (...args: unknown[]) => void)(pastState, replace, currentState, deltaState);
-      if (timer) clearTimeout(timer);
       timer = setTimeout(() => {
         inCooldown = false;
         timer = null;
@@ -118,6 +123,6 @@ export function createTemporalOptions(): {
 
   return {
     options,
-    temporalState: { inCooldown: false, resetCooldown },
+    temporalState: { resetCooldown },
   };
 }

--- a/app/components/.client/ImageViewer/state/store/viewerTemporal.ts
+++ b/app/components/.client/ImageViewer/state/store/viewerTemporal.ts
@@ -1,0 +1,123 @@
+import type { ZundoOptions } from "zundo";
+
+import type { AnnotationClass } from "./slices/viewer.annotations.store";
+import type { ViewerStore } from "./types";
+import type { AnnotationsByUser } from "~/utils/db/getAnnotationsWasm";
+
+/**
+ * The slice of viewer state tracked in the undo/redo history. Only the
+ * annotation data that a user can meaningfully undo — own-set features and
+ * the class registry — enters the temporal store. Ephemeral view state
+ * (draw mode, selection, opacity, hidden classes) is deliberately excluded:
+ * undoing a classification change must not reset the user's draw mode or
+ * panel selection. Peer sets (`annotationsByUser[otherUserId]`) are included
+ * in the partialized map but, since the user never mutates them directly,
+ * their refs never change → the equality check skips them at zero cost.
+ */
+export type TemporalPartial = {
+  annotationsByUser: AnnotationsByUser;
+  annotationClasses: AnnotationClass[];
+};
+
+/**
+ * Maximum number of past states retained. 50 is a deliberate balance: enough
+ * to walk back through a typical editing session without flooding memory
+ * (each snapshot is a shallow ref to the partialized map, not a deep clone —
+ * immer preserves unchanged refs). Beyond 50 the oldest entry is dropped.
+ */
+export const HISTORY_LIMIT = 50;
+
+/**
+ * Trailing-edge cool-off for gesture grouping. When the user performs rapid,
+ * continuous edits (e.g. dragging vertices, batch-classifying), only the first
+ * state of the gesture is recorded; subsequent edits within this window are
+ * skipped so one undo restores the pre-gesture state. Leading-edge, not
+ * trailing: we record the *first* past state (pre-gesture) immediately and
+ * suppress the rest, because zundo records the state *before* each set — the
+ * first set's past state is the pre-gesture snapshot we want.
+ */
+export const GESTURE_DEBOUNCE_MS = 500;
+
+/**
+ * Shallow reference equality on the two tracked fields. Immer gives a fresh
+ * ref only for the part of state that was actually mutated, so a no-op set
+ * (e.g. `setAnnotationMode`, `setAnnotationsOpacity`, selection changes)
+ * keeps the same `annotationsByUser` / `annotationClasses` refs → equality
+ * returns true → zundo skips the snapshot entirely.
+ */
+const temporalEquality = (past: TemporalPartial, current: TemporalPartial): boolean =>
+  past.annotationsByUser === current.annotationsByUser &&
+  past.annotationClasses === current.annotationClasses;
+
+export interface TemporalState {
+  /** Whether the gesture cool-off is active (edits suppressed). */
+  inCooldown: boolean;
+  /** Clears the cool-off immediately (called before undo/redo). */
+  resetCooldown: () => void;
+}
+
+/**
+ * Build the zundo `ZundoOptions` and a companion `TemporalState` (cool-off
+ * controller) for a single viewer store. The cool-off timer is per-store,
+ * created once when the store is built.
+ *
+ * `handleSet` fires on every `set()` — including those from `undo()`/`redo()`
+ * and `seedAnnotations()`. Those callers wrap themselves in `pause()`/
+ * `resume()`, so zundo's `temporalHandleSet` returns early (isTracking=false)
+ * and never reaches `handleSet`. By the time `handleSet` runs, it's a genuine
+ * user edit → apply the gesture cool-off.
+ */
+export function createTemporalOptions(): {
+  options: ZundoOptions<ViewerStore, TemporalPartial>;
+  temporalState: TemporalState;
+} {
+  let inCooldown = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const resetCooldown = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    inCooldown = false;
+  };
+
+  const options: ZundoOptions<ViewerStore, TemporalPartial> = {
+    partialize: (state): TemporalPartial => ({
+      annotationsByUser: state.annotationsByUser,
+      annotationClasses: state.annotationClasses,
+    }),
+    limit: HISTORY_LIMIT,
+    equality: temporalEquality,
+    handleSet: (record) => (pastState, replace, currentState, deltaState) => {
+      // Only enter the gesture cool-off when the tracked state actually
+      // changed.  Without this guard, any `set()` — including ephemeral
+      // view-state updates (draw mode, selection, opacity) that leave
+      // `annotationsByUser` / `annotationClasses` refs untouched — would
+      // arm the 500 ms timer and silently swallow the next real edit.
+      const trackedChanged =
+        (pastState as TemporalPartial).annotationsByUser !==
+          (currentState as TemporalPartial).annotationsByUser ||
+        (pastState as TemporalPartial).annotationClasses !==
+          (currentState as TemporalPartial).annotationClasses;
+      if (!trackedChanged) return;
+      if (inCooldown) return;
+      inCooldown = true;
+      // `record` is the internal `_handleSet` which accepts the full
+      // (pastState, replace, currentState, deltaState) tuple, even though
+      // zundo types it as `StoreApi['setState']` (2 args). Cast to match
+      // the runtime signature from the source.
+      (record as (...args: unknown[]) => void)(pastState, replace, currentState, deltaState);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        inCooldown = false;
+        timer = null;
+      }, GESTURE_DEBOUNCE_MS);
+    },
+  };
+
+  return {
+    options,
+    temporalState: { inCooldown: false, resetCooldown },
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/client-sts": "^3.687.0",
         "@aws-sdk/s3-request-presigner": "^3.693.0",
         "@cornerstonejs/codec-openjpeg": "^1.3.0",
-        "@cytario/design": "^7.1.0",
+        "@cytario/design": "file:../cytario-design/cytario-design-0.0.0-development.tgz",
         "@deck.gl-community/editable-layers": "^9.3.7",
         "@deck.gl-community/layers": "^9.3.7",
         "@deck.gl/core": "~9.3.4",
@@ -78,6 +78,7 @@
         "vite-tsconfig-paths": "^4.2.1",
         "zod": "^4.3.6",
         "zod-geojson": "^1.7.0",
+        "zundo": "^2.3.0",
         "zustand": "^5.0.12"
       },
       "bin": {
@@ -1412,9 +1413,9 @@
       }
     },
     "node_modules/@cytario/design": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-7.1.0.tgz",
-      "integrity": "sha512-V4crrbLCUWEHF4sKicFyMqjNCK0S9UaOtXXhq0CchD+JnKaEfJwYozgDpTIpkQsqwP+OoBPnBnERA0xUGVeS7Q==",
+      "version": "0.0.0-development",
+      "resolved": "file:../cytario-design/cytario-design-0.0.0-development.tgz",
+      "integrity": "sha512-OcvJEfZsLi0KANaRWZ08kqe1dmv2COKT8bGRPeqKN6xWO5SkFWCFXrlL/36xkO/wvpMHuzfPFr/JhRDpDRBcSg==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lucide-react": "^1.0.0",
@@ -22506,6 +22507,24 @@
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
       "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
       "license": "MIT AND BSD-3-Clause"
+    },
+    "node_modules/zundo": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/zundo/-/zundo-2.3.0.tgz",
+      "integrity": "sha512-4GXYxXA17SIKYhVbWHdSEU04P697IMyVGXrC2TnzoyohEAWytFNOKqOp5gTGvaW93F/PM5Y0evbGtOPF0PWQwQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/charkour"
+      },
+      "peerDependencies": {
+        "zustand": "^4.3.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@aws-sdk/client-sts": "^3.687.0",
         "@aws-sdk/s3-request-presigner": "^3.693.0",
         "@cornerstonejs/codec-openjpeg": "^1.3.0",
-        "@cytario/design": "file:../cytario-design/cytario-design-0.0.0-development.tgz",
+        "@cytario/design": "^7.2.0",
         "@deck.gl-community/editable-layers": "^9.3.7",
         "@deck.gl-community/layers": "^9.3.7",
         "@deck.gl/core": "~9.3.4",
@@ -1413,9 +1413,9 @@
       }
     },
     "node_modules/@cytario/design": {
-      "version": "0.0.0-development",
-      "resolved": "file:../cytario-design/cytario-design-0.0.0-development.tgz",
-      "integrity": "sha512-OcvJEfZsLi0KANaRWZ08kqe1dmv2COKT8bGRPeqKN6xWO5SkFWCFXrlL/36xkO/wvpMHuzfPFr/JhRDpDRBcSg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@cytario/design/-/design-7.2.0.tgz",
+      "integrity": "sha512-7/q7m463aMFQdLcF/WQDQtCwbmSEuLVbDM+CznSub0iHjUeuQHWndqwzn9FqrQ8w/BuQgGpfv8AFWrz4DlvzcQ==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lucide-react": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/client-sts": "^3.687.0",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cytario/design": "^7.1.0",
+    "@cytario/design": "file:../cytario-design/cytario-design-0.0.0-development.tgz",
     "@deck.gl-community/editable-layers": "^9.3.7",
     "@deck.gl-community/layers": "^9.3.7",
     "@deck.gl/core": "~9.3.4",
@@ -134,6 +134,7 @@
     "vite-tsconfig-paths": "^4.2.1",
     "zod": "^4.3.6",
     "zod-geojson": "^1.7.0",
+    "zundo": "^2.3.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/client-sts": "^3.687.0",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cytario/design": "file:../cytario-design/cytario-design-0.0.0-development.tgz",
+    "@cytario/design": "^7.1.0",
     "@deck.gl-community/editable-layers": "^9.3.7",
     "@deck.gl-community/layers": "^9.3.7",
     "@deck.gl/core": "~9.3.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@aws-sdk/client-sts": "^3.687.0",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@cornerstonejs/codec-openjpeg": "^1.3.0",
-    "@cytario/design": "^7.1.0",
+    "@cytario/design": "^7.2.0",
     "@deck.gl-community/editable-layers": "^9.3.7",
     "@deck.gl-community/layers": "^9.3.7",
     "@deck.gl/core": "~9.3.4",


### PR DESCRIPTION
## Summary

Implements **C-329** — undo/redo for annotation editing using the [zundo](https://github.com/charkour/zundo) temporal middleware for Zustand.

### Changes
- **viewerTemporal.ts** — zundo temporal options factory: `partialize` scoped to current user own-block annotation data (`annotationsByUser[ownUserId]` + `annotationClasses`), 500ms leading-edge gesture debounce via `handleSet`, `limit: 50`, `TemporalPartial` type
- **createViewerStore.ts** — zundo as innermost middleware (after immer)
- **useUndoRedo.ts** — hook exposing `canUndo`/`canRedo` + `undo`/`redo` wrapped in `pause()`/`resume()` to prevent write loops
- **useUndoRedoShortcuts.ts** — keyboard shortcuts (Cmd+Z / Shift+Cmd+Z / Cmd+Y) with text-input suppression
- **AnnotationsTools.tsx** — Undo/Redo toolbar buttons with disabled states
- **viewer.annotations.store.ts** — `seedAnnotations` wrapped in `pause()`/`resume()` so S3 seed does not enter history

### Dependencies
- `zundo@^2.3.0` added to `package.json`

### Testing
- All 1517 unit tests pass (including 2 new temporal tests)
- TypeScript typecheck clean
- ESLint clean
- Prettier clean
- 3 consecutive green e2e runs (7/7 specs each)

### Traceability
- Parent: C-88 (Annotations MVP)
- Depends on: C-318, C-319, C-320, C-307
- Traces: SRS-CY-34428..34432
- Docs PR: cytario/cytario-docs#86