### PR TITLE
[C-342] Unify dev-server ports: .env.template :5173/:5174→:3000/:3001

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,8 @@
 # Services
-WEB_HOST=http://localhost:5173
+WEB_HOST=http://localhost:3000
 # Optional: customer portal base URL, surfaced to client plugin slots.
 # Leave unset on deployments without a portal (e.g. OSS).
-# PORTAL_HOST=http://localhost:5174
+# PORTAL_HOST=http://localhost:3001
 
 # Identity Provider (example: Keycloak; BASE_URL should be set to your IdP's base URL)
 BASE_URL=http://localhost:8080/realms/master


### PR DESCRIPTION
Collapses stale Vite dev-server ports in .env.template to the canonical :3000 (cytario-web) and :3001 (admin-portal) used by CI E2E.

- WEB_HOST: :5173 → :3000
- PORTAL_HOST: :5174 → :3001