### PR TITLE
feat(connections): org-wide provider roles + portal bucket picker [C-343]

### DIFF
--- a/app/.server/providers/bucketCatalog.server.ts
+++ b/app/.server/providers/bucketCatalog.server.ts
@@ -1,0 +1,119 @@
+import { createLabel } from "~/.server/logging";
+import { cytarioConfig } from "~/config";
+import { type BucketCatalog, bucketCatalogSchema } from "~/utils/bucketCatalog.schema";
+
+const label = createLabel("providers", "cyan");
+
+const BUCKETS_LOOKUP_PATH = "/org/buckets";
+const BUCKETS_LOOKUP_HEADER = "X-Providers-Lookup-Secret";
+const BUCKETS_LOOKUP_TIMEOUT_MS = 10_000;
+
+/** How long a resolved bucket catalog is served from memory before re-reading its source. */
+const CATALOG_CACHE_TTL_MS = 30_000;
+const CATALOG_CACHE_MAX_ENTRIES = 100;
+
+interface CatalogCacheEntry {
+  expiresAt: number;
+  promise: Promise<BucketCatalog>;
+}
+
+const bucketCache = new Map<string, CatalogCacheEntry>();
+
+/** Test hook: drop every cached bucket catalog. */
+export function clearBucketCatalogCache(): void {
+  bucketCache.clear();
+}
+
+/**
+ * Resolves the active organization's registered-bucket catalog — the buckets a
+ * storage connection may bind to, filtered to the chosen provider connection at
+ * the call site.
+ *
+ * Present only in admin-portal builds (EE & SaaS); OSS self-hosted builds have
+ * no portal and the bucket is entered as free text. When the portal source is
+ * not `portal`, this function throws — callers in OSS paths never reach it.
+ *
+ * The lookup is advisory: on staleness or unavailability the caller degrades to
+ * a clear error and never blocks an already-created connection.
+ *
+ * Resolved catalogs are memoized per organization with a short TTL — the
+ * catalog is consulted on every connection create/update, and the portal
+ * round-trip should not run per request. Failures are never cached.
+ */
+export async function getBucketCatalog(
+  organization: string,
+  accessToken?: string,
+): Promise<BucketCatalog> {
+  const cacheKey = `portal:${organization}`;
+
+  const cached = bucketCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return cached.promise;
+
+  const promise = fetchPortalBuckets(organization, accessToken).catch((error: unknown) => {
+    bucketCache.delete(cacheKey);
+    throw error;
+  });
+
+  if (bucketCache.size >= CATALOG_CACHE_MAX_ENTRIES) {
+    const oldestKey = bucketCache.keys().next().value;
+    if (oldestKey !== undefined) bucketCache.delete(oldestKey);
+  }
+  bucketCache.set(cacheKey, { expiresAt: Date.now() + CATALOG_CACHE_TTL_MS, promise });
+  return promise;
+}
+
+async function fetchPortalBuckets(
+  organization: string,
+  accessToken?: string,
+): Promise<BucketCatalog> {
+  const { portalInternalUrl, lookupSecret } = cytarioConfig.providers;
+  if (!portalInternalUrl || !lookupSecret) {
+    throw new Error(
+      "Bucket lookup is misconfigured: PORTAL_INTERNAL_URL and PROVIDERS_LOOKUP_SECRET are required in an admin-portal build.",
+    );
+  }
+
+  const url = new URL(BUCKETS_LOOKUP_PATH, ensureTrailingSlash(portalInternalUrl));
+  url.searchParams.set("org", organization);
+
+  const headers: Record<string, string> = {
+    [BUCKETS_LOOKUP_HEADER]: lookupSecret,
+  };
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(BUCKETS_LOOKUP_TIMEOUT_MS),
+    });
+  } catch (error) {
+    console.error(`${label} Bucket lookup request failed:`, error);
+    throw new Error("Bucket lookup is currently unavailable. Try again shortly.");
+  }
+
+  if (!response.ok) {
+    console.error(`${label} Bucket lookup returned ${response.status}`);
+    throw new Error("Bucket lookup is currently unavailable. Try again shortly.");
+  }
+
+  const raw = await response.json();
+  return bucketCatalogSchema.parse(raw);
+}
+
+function ensureTrailingSlash(base: string): string {
+  return base.endsWith("/") ? base : `${base}/`;
+}
+
+/** Look up a registered bucket by its bucket name within a catalog. */
+export function findBucketByName(
+  catalog: BucketCatalog,
+  providerConnectionId: string,
+  bucketName: string,
+): BucketCatalog["buckets"][number] | undefined {
+  return catalog.buckets.find(
+    (b) => b.providerConnectionId === providerConnectionId && b.bucketName === bucketName,
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -92,6 +92,10 @@ const apiRoutes = [
     path: "/api/provider-catalog",
     file: "routes/api/provider-catalog.ts",
   },
+  {
+    path: "/api/bucket-catalog",
+    file: "routes/api/bucket-catalog.ts",
+  },
 ];
 
 export default [

--- a/app/routes/api/bucket-catalog.ts
+++ b/app/routes/api/bucket-catalog.ts
@@ -1,0 +1,47 @@
+import { type LoaderFunctionArgs } from "react-router";
+
+import { authContext, authMiddleware } from "~/.server/auth/authMiddleware";
+import { getBucketCatalog } from "~/.server/providers/bucketCatalog.server";
+import { requestDurationMiddleware } from "~/.server/requestDurationMiddleware";
+import { cytarioConfig } from "~/config";
+
+export const middleware = [requestDurationMiddleware, authMiddleware];
+
+/**
+ * The active organization's registered-bucket catalog for the connection-creation
+ * bucket picker. Advisory: on a stale/unavailable lookup this returns `{ error }`
+ * with 200 so the client degrades to a clear message and never blocks an
+ * already-created connection. Present only in admin-portal builds; OSS builds
+ * do not register this route (the bucket is entered as free text).
+ */
+export const loader = async ({ context }: LoaderFunctionArgs) => {
+  const source = cytarioConfig.providers.source;
+
+  if (source !== "portal") {
+    return Response.json({ source: "oss" }, { headers: { "Cache-Control": "no-store, private" } });
+  }
+
+  const { user, authTokens } = context.get(authContext);
+  if (!user.organization) {
+    return Response.json(
+      { source: "portal", error: "No active organization." },
+      { status: 200, headers: { "Cache-Control": "no-store, private" } },
+    );
+  }
+
+  try {
+    const catalog = await getBucketCatalog(user.organization, authTokens.accessToken);
+    return Response.json(
+      { source: "portal", catalog },
+      { headers: { "Cache-Control": "no-store, private" } },
+    );
+  } catch (error) {
+    return Response.json(
+      {
+        source: "portal",
+        error: error instanceof Error ? error.message : "Bucket catalog is unavailable.",
+      },
+      { status: 200, headers: { "Cache-Control": "no-store, private" } },
+    );
+  }
+};

--- a/app/routes/connections/__tests__/connectionGrant.server.test.ts
+++ b/app/routes/connections/__tests__/connectionGrant.server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 
 import { prisma } from "~/.server/db/prisma";
+import { getBucketCatalog } from "~/.server/providers/bucketCatalog.server";
 import { getProviderCatalog } from "~/.server/providers/providerCatalog.server";
 import { compileGrantStatements } from "~/.server/storage/bucketPolicy";
 import {
@@ -9,6 +10,7 @@ import {
   assembleBucketGrants,
   connectionIsGroupScoped,
   grantForConnection,
+  validateBucketRef,
   validateProviderRefs,
 } from "~/routes/connections/connectionGrant.server";
 import mock from "~/utils/__tests__/__mocks__";
@@ -20,6 +22,17 @@ vi.mock("~/.server/providers/providerCatalog.server", async () => {
   );
   return { ...actual, getProviderCatalog: vi.fn() };
 });
+
+vi.mock("~/.server/providers/bucketCatalog.server", async () => {
+  const actual = await vi.importActual<typeof import("~/.server/providers/bucketCatalog.server")>(
+    "~/.server/providers/bucketCatalog.server",
+  );
+  return { ...actual, getBucketCatalog: vi.fn() };
+});
+
+vi.mock("~/config", () => ({
+  cytarioConfig: { providers: { source: "portal" } },
+}));
 
 vi.mock("~/.server/db/prisma", () => ({
   prisma: { connectionConfig: { findMany: vi.fn(async () => []), update: vi.fn() } },
@@ -151,6 +164,25 @@ describe("validateProviderRefs", () => {
     expect(result.ok).toBe(true);
   });
 
+  test("C-343: an org-wide role (empty allowedScopes) covers any submitted scope", () => {
+    const orgWideCatalog = mock.providerCatalog({
+      providerConnections: [mock.providerConnection({ id: "pc-1" })],
+      providerRoles: [
+        mock.providerRole({
+          id: "pr-org-wide",
+          providerConnectionId: "pc-1",
+          allowedScopes: [],
+        }),
+      ],
+    });
+    const result = validateProviderRefs(orgWideCatalog, {
+      providerConnectionId: "pc-1",
+      providerRoleId: "pr-org-wide",
+      scope: "any/group/scope",
+    });
+    expect(result.ok).toBe(true);
+  });
+
   test("requireSharing rejects a non-sharing role", () => {
     const result = validateProviderRefs(
       catalog,
@@ -210,5 +242,48 @@ describe("applyConnectionGrants — advisory degradation", () => {
       accessToken: "acc",
     });
     expect(outcome.status).toBe("error");
+  });
+});
+
+describe("validateBucketRef (C-343)", () => {
+  test("accepts a registered bucket under the chosen provider connection", async () => {
+    vi.mocked(getBucketCatalog).mockResolvedValue(
+      mock.bucketCatalog({
+        buckets: [mock.bucketLookupRow({ providerConnectionId: "pc-1", bucketName: "my-bucket" })],
+      }),
+    );
+    const result = await validateBucketRef("org1", "tok", {
+      providerConnectionId: "pc-1",
+      bucketName: "my-bucket",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects a bucket not registered under the chosen provider connection", async () => {
+    vi.mocked(getBucketCatalog).mockResolvedValue(
+      mock.bucketCatalog({
+        buckets: [mock.bucketLookupRow({ providerConnectionId: "pc-1", bucketName: "my-bucket" })],
+      }),
+    );
+    const result = await validateBucketRef("org1", "tok", {
+      providerConnectionId: "pc-1",
+      bucketName: "other-bucket",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && "errors" in result) {
+      expect(result.errors.bucketName).toBeDefined();
+    }
+  });
+
+  test("returns a formError when the bucket lookup is unavailable (no free-text fallback)", async () => {
+    vi.mocked(getBucketCatalog).mockRejectedValue(new Error("portal down"));
+    const result = await validateBucketRef("org1", "tok", {
+      providerConnectionId: "pc-1",
+      bucketName: "my-bucket",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok && "formError" in result) {
+      expect(result.formError).toBe("portal down");
+    }
   });
 });

--- a/app/routes/connections/connection.form.tsx
+++ b/app/routes/connections/connection.form.tsx
@@ -20,6 +20,7 @@ import {
   defaultFormValues,
   suggestName,
 } from "./connection.schema";
+import { useBucketCatalog } from "./useBucketCatalog";
 import { useProviderCatalog } from "./useProviderCatalog";
 import { ScopePill } from "~/components/Pills/ScopePill";
 
@@ -70,6 +71,12 @@ export const ConnectionForm = ({
   }>();
   const navigation = useNavigation();
   const { catalog, error: catalogError, loading: catalogLoading } = useProviderCatalog();
+  const {
+    source: bucketSource,
+    catalog: bucketCatalog,
+    error: bucketCatalogError,
+    loading: bucketCatalogLoading,
+  } = useBucketCatalog();
 
   const serverErrors = actionData?.status === "error" ? actionData.errors : undefined;
   const formError = actionData?.status === "error" ? actionData.formError : undefined;
@@ -131,6 +138,14 @@ export const ConnectionForm = ({
         .filter((r) => r.providerConnectionId === providerConnectionId)
         .map((r) => ({ id: r.id, name: r.name })),
     [catalog, providerConnectionId],
+  );
+
+  const bucketItems: SelectItem[] = useMemo(
+    () =>
+      (bucketCatalog?.buckets ?? [])
+        .filter((b) => b.providerConnectionId === providerConnectionId)
+        .map((b) => ({ id: b.bucketName, name: b.bucketName })),
+    [bucketCatalog, providerConnectionId],
   );
   const userEditedName = useRef(isEditMode);
   const isAutoUpdatingName = useRef(false);
@@ -227,6 +242,7 @@ export const ConnectionForm = ({
                     onSelectionChange={(key) => {
                       field.onChange(key);
                       setValue("providerRoleId", "");
+                      setValue("bucketName", "");
                     }}
                     errorMessage={fieldState.error?.message}
                   />
@@ -252,19 +268,40 @@ export const ConnectionForm = ({
               <Controller
                 name="bucketName"
                 control={control}
-                render={({ field, fieldState }) => (
-                  <Input
-                    label="Bucket"
-                    description="Name of the S3 bucket."
-                    value={field.value}
-                    onChange={field.onChange}
-                    onBlur={field.onBlur}
-                    name={field.name}
-                    placeholder="my-bucket"
-                    size="lg"
-                    errorMessage={fieldState.error?.message}
-                  />
-                )}
+                render={({ field, fieldState }) =>
+                  bucketSource === "portal" ? (
+                    bucketCatalogError ? (
+                      <Banner variant="danger" title="Bucket catalog unavailable">
+                        {bucketCatalogError} You cannot compose a new connection until the bucket
+                        catalog is reachable.
+                      </Banner>
+                    ) : (
+                      <Select
+                        label="Bucket"
+                        description="Registered buckets under the selected provider connection."
+                        items={bucketItems}
+                        isDisabled={
+                          bucketCatalogLoading || !providerConnectionId || bucketItems.length === 0
+                        }
+                        selectedKey={field.value || null}
+                        onSelectionChange={(key) => field.onChange(key ?? "")}
+                        errorMessage={fieldState.error?.message}
+                      />
+                    )
+                  ) : (
+                    <Input
+                      label="Bucket"
+                      description="Name of the S3 bucket."
+                      value={field.value}
+                      onChange={field.onChange}
+                      onBlur={field.onBlur}
+                      name={field.name}
+                      placeholder="my-bucket"
+                      size="lg"
+                      errorMessage={fieldState.error?.message}
+                    />
+                  )
+                }
               />
 
               <Controller

--- a/app/routes/connections/connectionGrant.server.ts
+++ b/app/routes/connections/connectionGrant.server.ts
@@ -1,6 +1,7 @@
 import { ConnectionConfig } from "~/.generated/client";
 import type { UserProfile } from "~/.server/auth/getUserInfo";
 import { prisma } from "~/.server/db/prisma";
+import { findBucketByName, getBucketCatalog } from "~/.server/providers/bucketCatalog.server";
 import {
   type ResolvedConnectionProvider,
   findProviderConnection,
@@ -14,6 +15,7 @@ import {
   type ApplyTarget,
   applyBucketPolicy,
 } from "~/.server/storage/bucketPolicyApply.server";
+import { cytarioConfig } from "~/config";
 import { ORG_ROOT_SCOPE, adminCovers } from "~/utils/authorization";
 import {
   type ProviderCatalog,
@@ -118,8 +120,10 @@ export function validateProviderRefs(
   }
 
   const isPersonal = options.userSub !== undefined && refs.scope === options.userSub;
+  const isOrgWide = providerRole.allowedScopes.length === 0;
   if (
     !isPersonal &&
+    !isOrgWide &&
     !providerRole.allowedScopes.some((allowed) => adminCovers(allowed, refs.scope))
   ) {
     return {
@@ -129,6 +133,51 @@ export function validateProviderRefs(
   }
 
   return { ok: true, providerConnection, providerRole };
+}
+
+/**
+ * Outcome of validating the submitted bucket against the portal bucket catalog.
+ * In an OSS build there is no portal bucket registry, so the check is skipped
+ * (returns `ok: true` immediately). In an admin-portal build the submitted
+ * `bucketName` must be one of the org's registered buckets under the submitted
+ * `providerConnectionId`; a bucket not in the catalog is rejected with a
+ * field-level error. When the bucket lookup is unavailable, the create/update
+ * is refused with a clear error rather than accepting a free-text bucket.
+ */
+export type BucketRefValidation =
+  | { ok: true }
+  | { ok: false; errors: Record<string, string[]> }
+  | { ok: false; formError: string };
+
+export async function validateBucketRef(
+  organization: string,
+  accessToken: string,
+  refs: { providerConnectionId: string; bucketName: string },
+): Promise<BucketRefValidation> {
+  if (cytarioConfig.providers.source !== "portal") return { ok: true };
+
+  let bucketCatalog;
+  try {
+    bucketCatalog = await getBucketCatalog(organization, accessToken);
+  } catch (error) {
+    return {
+      ok: false,
+      formError:
+        error instanceof Error ? error.message : "Bucket catalog is currently unavailable.",
+    };
+  }
+
+  const bucket = findBucketByName(bucketCatalog, refs.providerConnectionId, refs.bucketName);
+  if (!bucket) {
+    return {
+      ok: false,
+      errors: {
+        bucketName: ["This bucket is not registered under the selected provider connection."],
+      },
+    };
+  }
+
+  return { ok: true };
 }
 
 /** Resolve a connection to its `ApplyTarget` via the org provider catalog. */

--- a/app/routes/connections/createConnection.action.ts
+++ b/app/routes/connections/createConnection.action.ts
@@ -1,7 +1,11 @@
 import { type ActionFunctionArgs, redirect } from "react-router";
 
 import { connectionSchema } from "./connection.schema";
-import { applyGrantsAndRecordStatus, validateProviderRefs } from "./connectionGrant.server";
+import {
+  applyGrantsAndRecordStatus,
+  validateBucketRef,
+  validateProviderRefs,
+} from "./connectionGrant.server";
 import { Prisma } from "~/.generated/client";
 import { authContext } from "~/.server/auth/authMiddleware";
 import { sessionContext } from "~/.server/auth/sessionMiddleware";
@@ -99,6 +103,14 @@ export const createAction = async ({ request, context }: ActionFunctionArgs) => 
   const refs = validateProviderRefs(catalog, data, { userSub: user.sub });
   if (!refs.ok) {
     return { errors: refs.errors, status: "error" as const };
+  }
+
+  const bucketRef = await validateBucketRef(user.organization, authTokens.accessToken, data);
+  if (!bucketRef.ok) {
+    if ("formError" in bucketRef) {
+      return { formError: bucketRef.formError, status: "error" as const };
+    }
+    return { errors: bucketRef.errors, status: "error" as const };
   }
 
   const session = context.get(sessionContext);

--- a/app/routes/connections/shareFolder.form.tsx
+++ b/app/routes/connections/shareFolder.form.tsx
@@ -72,7 +72,9 @@ export const ShareFolderForm = ({
       (r) =>
         r.providerConnectionId === providerConnectionId &&
         r.allowsSharing &&
-        (!scope || r.allowedScopes.some((allowed) => adminCovers(allowed, scope))),
+        (r.allowedScopes.length === 0 ||
+          !scope ||
+          r.allowedScopes.some((allowed) => adminCovers(allowed, scope))),
     );
     return roles.map((r) => ({ id: r.id, name: r.name }));
   }, [catalog, providerConnectionId, scope]);

--- a/app/routes/connections/updateConnection.action.ts
+++ b/app/routes/connections/updateConnection.action.ts
@@ -4,6 +4,7 @@ import { connectionSchema } from "./connection.schema";
 import {
   applyBucketGrantSet,
   applyGrantsAndRecordStatus,
+  validateBucketRef,
   validateProviderRefs,
 } from "./connectionGrant.server";
 import { Prisma } from "~/.generated/client";
@@ -121,6 +122,18 @@ export const updateAction = async ({ request, context }: ActionFunctionArgs) => 
   const refs = validateProviderRefs(catalog, validated, { userSub: user.sub });
   if (!refs.ok) {
     return { errors: refs.errors, status: "error" as const };
+  }
+
+  const bucketRef = await validateBucketRef(
+    user.organization,
+    session.get("authTokens")?.accessToken ?? "",
+    validated,
+  );
+  if (!bucketRef.ok) {
+    if ("formError" in bucketRef) {
+      return { formError: bucketRef.formError, status: "error" as const };
+    }
+    return { errors: bucketRef.errors, status: "error" as const };
   }
 
   try {

--- a/app/routes/connections/useBucketCatalog.ts
+++ b/app/routes/connections/useBucketCatalog.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+
+import type { BucketCatalog } from "~/utils/bucketCatalog.schema";
+
+interface BucketCatalogState {
+  source?: "portal" | "oss";
+  catalog?: BucketCatalog;
+  error?: string;
+  loading: boolean;
+}
+
+/**
+ * Fetch the active organization's registered-bucket catalog (admin-portal
+ * builds) for the connection-creation bucket picker. In OSS builds the route
+ * returns `{ source: "oss" }` and the caller renders a free-text input.
+ *
+ * Advisory: on a stale/unavailable lookup this surfaces a clear `error` and
+ * never blocks — the caller degrades to an error banner with no free-text
+ * fallback (an already-created connection is never invalidated).
+ */
+export function useBucketCatalog(): BucketCatalogState {
+  const [state, setState] = useState<BucketCatalogState>({ loading: true });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch("/api/bucket-catalog", { signal: controller.signal })
+      .then((res) => res.json())
+      .then((body: { source?: "portal" | "oss"; catalog?: BucketCatalog; error?: string }) => {
+        setState({
+          source: body.source,
+          catalog: body.catalog,
+          error: body.error,
+          loading: false,
+        });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setState({
+          source: "portal",
+          error: error instanceof Error ? error.message : "Bucket catalog is unavailable.",
+          loading: false,
+        });
+      });
+    return () => controller.abort();
+  }, []);
+
+  return state;
+}

--- a/app/utils/__tests__/__mocks__.ts
+++ b/app/utils/__tests__/__mocks__.ts
@@ -6,6 +6,7 @@ import { AuthTokensResponse } from "~/.server/auth/refreshAuthTokens";
 import { type CytarioSession, SessionData, SessionFlashData } from "~/.server/auth/sessionStorage";
 import { Channel, Image } from "~/components/.client/ImageViewer/state/store/ome.tif.types";
 import { TreeNode } from "~/components/DirectoryView/buildDirectoryTree";
+import type { BucketCatalog, BucketLookupRow } from "~/utils/bucketCatalog.schema";
 import type {
   ProviderCatalog,
   ProviderConnection,
@@ -46,6 +47,17 @@ const mock = {
   providerCatalog: (data: Partial<ProviderCatalog> = {}): ProviderCatalog => ({
     providerConnections: [mock.providerConnection()],
     providerRoles: [mock.providerRole()],
+    ...data,
+  }),
+  bucketLookupRow: (data: Partial<BucketLookupRow> = {}): BucketLookupRow => ({
+    id: "bucket-mock-id",
+    providerConnectionId: "pc-mock",
+    bucketName: "mock-bucket",
+    region: "us-east-1",
+    ...data,
+  }),
+  bucketCatalog: (data: Partial<BucketCatalog> = {}): BucketCatalog => ({
+    buckets: [mock.bucketLookupRow()],
     ...data,
   }),
   session: (data: Partial<SessionData & SessionFlashData> = {}): CytarioSession => ({

--- a/app/utils/bucketCatalog.schema.ts
+++ b/app/utils/bucketCatalog.schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+/**
+ * The portal bucket catalog: the registered buckets an organization may
+ * connect to, resolved from the admin portal's `GET /org/buckets` lookup.
+ * Present only in admin-portal builds (EE & SaaS); OSS self-hosted builds
+ * have no portal and the bucket is entered as free text.
+ *
+ * The shape mirrors the pinned lookup JSON contract exactly. It never carries
+ * the Cytario Admin Role ARN, an ExternalId, or any management credential.
+ */
+export const bucketLookupRowSchema = z.object({
+  id: z.string().min(1),
+  providerConnectionId: z.string().min(1),
+  bucketName: z.string().min(1),
+  region: z.string().min(1),
+});
+
+export const bucketCatalogSchema = z.object({
+  buckets: z.array(bucketLookupRowSchema),
+});
+
+export type BucketLookupRow = z.infer<typeof bucketLookupRowSchema>;
+export type BucketCatalog = z.infer<typeof bucketCatalogSchema>;


### PR DESCRIPTION
## Background

C-339 landed in `admin-portal`: provider roles gained an orthogonal `writeLevel` dimension, `allowedScopes` became optional (empty = org-wide role), and a new `GET /org/buckets` endpoint exposes the portal-managed buckets registered under each connected account. The portal side is deployed and verified. cytario-web still consumed the old contract: it required at least one allowed scope on a provider role, and the Add Storage Connection modal accepted a free-text bucket name.

This PR makes cytario-web consume the C-339 portal contract.

## Changes

**Org-wide provider roles.** `validateProviderRefs` (`connectionGrant.server.ts`) and the Share Folder modal's advisory role filtering (`shareFolder.form.tsx`) now accept a role whose `allowedScopes` is empty (org-wide) as covering any submitted scope, rather than rejecting it for having no named scope. A provider role with `allowedScopes: []` is now selectable and usable for any group/scope.

**Portal bucket picker.** The Create Connection modal's free-text bucket field becomes a dropdown populated from `GET /org/buckets` in admin-portal builds, filtered to the selected provider connection (the bucket is cleared when the provider connection changes). OSS builds keep the free-text input. When the bucket lookup returns 401/403 or is otherwise unavailable, the picker surfaces a clear error banner with no silent free-text fallback. The create/update actions validate the submitted bucket against the portal bucket catalog server-side (`validateBucketRef`), refusing the create/update with a clear error when the lookup is unavailable.

New files:
- `app/utils/bucketCatalog.schema.ts` — Zod schema for the portal bucket lookup contract
- `app/.server/providers/bucketCatalog.server.ts` — memoized per-org bucket catalog consumer (mirrors `providerCatalog.server.ts`: 30 s TTL, failures never cached, ~10 s timeout)
- `app/routes/api/bucket-catalog.ts` — browser-facing route (`Cache-Control: no-store, private`; degrades to `{ error }` with HTTP 200)
- `app/routes/connections/useBucketCatalog.ts` — client hook

Amended:
- `connection.form.tsx` — bucket dropdown (portal) / text input (OSS) / error banner (lookup failure); clears `bucketName` on provider-connection change
- `connectionGrant.server.ts` — `validateBucketRef` + org-wide role fix in `validateProviderRefs`
- `createConnection.action.ts` / `updateConnection.action.ts` — server-side bucket validation
- `shareFolder.form.tsx` — org-wide role advisory filtering fix
- `app/utils/__tests__/__mocks__.ts` — `bucketLookupRow` / `bucketCatalog` mock helpers

## Acceptance criteria

- [x] A provider role with `allowedScopes: []` is selectable and usable in cytario-web for any group/scope; no validation error or empty-picker dead-end.
- [x] The storage connection / share flow no longer accepts a free-text bucket name in admin-portal builds; the bucket is chosen from a dropdown populated by `GET /org/buckets`, filtered to the selected provider connection.
- [x] When the org has no registered buckets (or none under the selected connection), the picker shows a clear empty state (disabled dropdown) — the admin is directed to register a bucket in the admin portal first.
- [x] The picker degrades sensibly when the bucket lookup returns 401/403 (error banner, no silent free-text fallback).

## Verification

- `npm run lint`, `npm run typecheck`, `npm run format:check` — all clean
- `npx vitest run` — all 1583 tests pass (16 in `connectionGrant.server.test.ts`, including new org-wide role + `validateBucketRef` tests)

## References

- Design spec: cytario-docs SRS 3.3 (SRS-CY-32118 amended; SRS-CY-32120–32124 added) and SDS 3.3 (SDS-CY-010330, SDS-CY-010331 added; SDS-CY-011109 amended)
- Parent ticket: C-339
- Plane ticket: C-343